### PR TITLE
Fix setup.cfg to include packages

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,10 +48,12 @@ jobs:
       - name: "Test imports"
         run: |
           # if we add more to this, consider changing to for + env vars
+          cd
           python -c "import openfe.setup"
           python -c "import openfe.orchestration"
           python -c "import openfe.simulation"
           python -c "import openfe.analysis"
+          cd -
 
       - name: "Environment Information"
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,12 +48,10 @@ jobs:
       - name: "Test imports"
         run: |
           # if we add more to this, consider changing to for + env vars
-          cd
-          python -c "import openfe.setup"
-          python -c "import openfe.orchestration"
-          python -c "import openfe.simulation"
-          python -c "import openfe.analysis"
-          cd -
+          python -Ic "import openfe.setup"
+          python -Ic "import openfe.orchestration"
+          python -Ic "import openfe.simulation"
+          python -Ic "import openfe.analysis"
 
       - name: "Environment Information"
         run: |

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,11 @@ install_requires =
     networkx
 
 include_package_data = True
+packages =
+    openfe.setup
+    openfe.orchestration
+    openfe.simulation
+    openfe.analysis
 namespace_packages = openfe
 
 [options.extras_require]


### PR DESCRIPTION
Fixes remaining issue for installing as discussed in #22.

Also moves the CI import testing so we're not in the repo directory, to ensure that we're actually testing the import of the installed package.