### PR TITLE
Add base Scorer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# custom ignores
+.xxrun
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/openfe/setup/scorer.py
+++ b/openfe/setup/scorer.py
@@ -1,4 +1,71 @@
-class Scorer:
-    def __call__(self, atommapping):
-        return 0.0
+# This code is part of OpenFE and is licensed under the MIT license.
+# For details, see https://github.com/OpenFreeEnergy/openfe
 
+"""
+Scorers
+=======
+
+A scorer is used to determine a score (and optionally, annotations) for a
+given AtomMapping.
+"""
+
+from typing import NamedTuple, Dict, Any, Union
+
+
+class ScoreAnnotation(NamedTuple):
+    """Container for a score from a mapping and any associated annotations.
+
+    Parameters
+    ----------
+    score : float
+        The score, or ``None`` if there is no score associated
+    annotation : Dict[str, Any]
+        Mapping of annotation label to annotation value for any annotations
+    """
+    score: Union[float, None]
+    annotation: Dict[str, Any]
+
+
+class Scorer:
+    """Abstract base class for Scorers.
+
+    To implement a subclass, you must implement the ``score`` method. If
+    your ``Scorer`` only returns annotations, then return None from the
+    ``score`` method. You may optionally implement the ``annotation``
+    method. The default ``annotation`` returns an empty dictionary.
+
+    Use a ``Scorer`` by calling it as a function.
+    """
+    def score(self, atommapping) -> Union[float, None]:
+        """Calculate the score for an AtomMapping.
+
+        Parameters
+        ----------
+        atommapping : AtomMapping
+            AtomMapping to score
+
+        Returns
+        -------
+        Union[float, None] :
+            The score, or ``None`` if no score is calculated
+        """
+        raise NotImplementedError()
+
+    def annotation(self, atommapping) -> Dict[str, Any]:
+        """Create annotation dict for an AtomMapping.
+
+        Parameters
+        ----------
+        atommapping : AtomMapping
+            Atommapping to annotate
+
+        Returns
+        -------
+        Dict[str, Any] :
+            Mapping of annotation labels to annotation values
+        """
+        return {}
+
+    def __call__(self, atommapping) -> ScoreAnnotation:
+        return ScoreAnnotation(score=self.score(atommapping),
+                               annotation=self.annotation(atommapping))

--- a/openfe/setup/scorer.py
+++ b/openfe/setup/scorer.py
@@ -49,7 +49,10 @@ class Scorer:
         Union[float, None] :
             The score, or ``None`` if no score is calculated
         """
-        raise NotImplementedError()
+        raise NotImplementedError(
+            "'Scorer' is an abstract class and should not be used directly. "
+            "Please use a specific subclass of 'Scorer'."
+        )
 
     def annotation(self, atommapping) -> Dict[str, Any]:
         """Create annotation dict for an AtomMapping.

--- a/openfe/tests/setup/conftest.py
+++ b/openfe/tests/setup/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+
+
+@pytest.fixture
+def mock_atommapping():
+    """Mock to functions that take an AtomMapping as input"""
+    # TODO: add internal structure of this once we have an AtomMapping class
+    return "foo"  # current tests using this just need a placeholder

--- a/openfe/tests/setup/test_scorer.py
+++ b/openfe/tests/setup/test_scorer.py
@@ -1,3 +1,4 @@
+import pytest
 from openfe.setup.scorer import Scorer
 
 
@@ -17,6 +18,11 @@ class ConcreteAnnotator(Scorer):
 
 
 class TestScorer:
+    def test_abstract_error(self, mock_atommapping):
+        scorer = Scorer()
+        with pytest.raises(NotImplementedError, match="'Scorer'.*abstract"):
+            scorer(mock_atommapping)
+
     def test_concrete_scorer(self, mock_atommapping):
         # The ConcreteScorer class should give the implemented value for the
         # score and the default empty dict for the annotation.

--- a/openfe/tests/setup/test_scorer.py
+++ b/openfe/tests/setup/test_scorer.py
@@ -1,0 +1,34 @@
+from openfe.setup.scorer import Scorer
+
+
+class ConcreteScorer(Scorer):
+    """Test implementation of Scorer with a score"""
+    def score(self, atommapping):
+        return 3.14
+
+
+class ConcreteAnnotator(Scorer):
+    """Test implementation of Scorer with a custom annotation"""
+    def score(self, atommapping):
+        return None
+
+    def annotation(self, atommapping):
+        return {'annotation': 'data'}
+
+
+class TestScorer:
+    def test_concrete_scorer(self, mock_atommapping):
+        # The ConcreteScorer class should give the implemented value for the
+        # score and the default empty dict for the annotation.
+        scorer = ConcreteScorer()
+        result = scorer(mock_atommapping)
+        assert result.score == 3.14
+        assert result.annotation == {}
+
+    def test_concrete_annotator(self, mock_atommapping):
+        # The ConcreteAnnotator class should give the implemented (None)
+        # value for the score and the implemented value of the annotation.
+        scorer = ConcreteAnnotator()
+        result = scorer(mock_atommapping)
+        assert result.score is None
+        assert result.annotation == {'annotation': 'data'}


### PR DESCRIPTION
Resolves #2.

## Overview

This provides a base class `Scorer`. The `Scorer.__call__` returns a `NamedTuple` with attributes `score` and `annotation`. Subclass implementers **must** implement the method `score`, and **may** override the method `annotation`.

## Self-criticism

* The module-level docstring is pretty thin. I just wasn't sure what else to say at this point.
* There's perhaps a little too much detail on implementation in the `Scorer` class docstring. I'm concerned about this getting out-of-sync with code, but it will be important to document the idea. Any better approach welcome.
* This is heavier in precise use of typing than I usually care about, but for abstract classes, I think detalied typing might be worth it.
* There's an overly-trivial placeholder fixture for a `mock_atommapping`. Since we don't have a completed `AtomMapping` class, we can't create a good fixture for it yet, but I added the stub.