### PR TITLE
Prevent CodeCov from running on forks, cron jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,3 +68,5 @@ jobs:
           file: coverage.xml
           fail_ci_if_error: True
           verbose: True
+        if: ${{ github.repository == 'OpenFreeEnergy/openfe'
+                && github.event != 'schedule' }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,10 +63,10 @@ jobs:
           pytest -n 2 -v --cov=openfe --cov-report=xml openfe/tests/
 
       - name: codecov
+        if: ${{ github.repository == 'OpenFreeEnergy/openfe'
+                && github.event != 'schedule' }}
         uses: codecov/codecov-action@v2
         with:
           file: coverage.xml
           fail_ci_if_error: True
           verbose: True
-        if: ${{ github.repository == 'OpenFreeEnergy/openfe'
-                && github.event != 'schedule' }}


### PR DESCRIPTION
Small update to the CI.

* By default, GitHub actions run on forks as well (e.g., when I synchronize `main` with `upstream`, or in scheduled builds). This is a strange choice for a default, which wastes a lot of CPU cycles, but it's how GH did things. For our forkers, if their fork isn't set up to run on CodeCov, the CI fails, which annoys the user with emails about failing CI. This PR prevents CodeCov from running on forks.
* This PR also prevents CodeCov from running on scheduled builds. This may be overkill (there were reasons I did this in other repos; they may not be relevant now), however, I don't think there's any particular benefit to checking coverage when the code isn't changing. But let me know if you have a reason to do that -- I could be overlooking something.