### PR TITLE
Minor updates to Scorer

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,6 +63,8 @@ jobs:
           pytest -n 2 -v --cov=openfe --cov-report=xml openfe/tests/
 
       - name: codecov
+        if: ${{ github.repository == 'OpenFreeEnergy/openfe'
+                && github.event != 'schedule' }}
         uses: codecov/codecov-action@v2
         with:
           file: coverage.xml

--- a/openfe/setup/errors.py
+++ b/openfe/setup/errors.py
@@ -1,0 +1,3 @@
+ABSTRACT_ERROR_STRING = ("'{cls}' is an abstract class and should not be "
+                         "used directly. Please use a specific subclass of "
+                         "'{cls}' that implements {func}.")

--- a/openfe/setup/scorer.py
+++ b/openfe/setup/scorer.py
@@ -11,6 +11,8 @@ given AtomMapping.
 
 from typing import NamedTuple, Dict, Any, Union
 
+from openfe.setup.errors import ABSTRACT_ERROR_STRING
+
 
 class ScoreAnnotation(NamedTuple):
     """Container for a score from a mapping and any associated annotations.
@@ -36,7 +38,7 @@ class Scorer:
 
     Use a ``Scorer`` by calling it as a function.
     """
-    def score(self, atommapping) -> Union[float, None]:
+    def _score(self, atommapping) -> Union[float, None]:
         """Calculate the score for an AtomMapping.
 
         Parameters
@@ -49,12 +51,12 @@ class Scorer:
         Union[float, None] :
             The score, or ``None`` if no score is calculated
         """
-        raise NotImplementedError(
-            "'Scorer' is an abstract class and should not be used directly. "
-            "Please use a specific subclass of 'Scorer'."
-        )
+        raise NotImplementedError(ABSTRACT_ERROR_STRING.format(
+            cls=self.__class__.__name__,
+            func='_score'
+        ))
 
-    def annotation(self, atommapping) -> Dict[str, Any]:
+    def _annotation(self, atommapping) -> Dict[str, Any]:
         """Create annotation dict for an AtomMapping.
 
         Parameters
@@ -70,5 +72,5 @@ class Scorer:
         return {}
 
     def __call__(self, atommapping) -> ScoreAnnotation:
-        return ScoreAnnotation(score=self.score(atommapping),
-                               annotation=self.annotation(atommapping))
+        return ScoreAnnotation(score=self._score(atommapping),
+                               annotation=self._annotation(atommapping))

--- a/openfe/tests/setup/conftest.py
+++ b/openfe/tests/setup/conftest.py
@@ -1,8 +1,36 @@
 import pytest
+from rdkit import Chem
+
+from openfe.setup import AtomMapping
 
 
-@pytest.fixture
-def mock_atommapping():
-    """Mock to functions that take an AtomMapping as input"""
-    # TODO: add internal structure of this once we have an AtomMapping class
-    return "foo"  # current tests using this just need a placeholder
+@pytest.fixture(scope='session')
+def simple_mapping():
+    """Disappearing oxygen on end
+
+    C C O
+
+    C C
+    """
+    molA = Chem.MolFromSmiles('CCO')
+    molB = Chem.MolFromSmiles('CC')
+
+    m = AtomMapping(molA, molB, mol1_to_mol2={0: 0, 1: 1})
+
+    return m
+
+
+@pytest.fixture(scope='session')
+def other_mapping():
+    """Disappearing middle carbon
+
+    C C O
+
+    C   C
+    """
+    molA = Chem.MolFromSmiles('CCO')
+    molB = Chem.MolFromSmiles('CC')
+
+    m = AtomMapping(molA, molB, mol1_to_mol2={0: 0, 2: 1})
+
+    return m

--- a/openfe/tests/setup/test_atommapping.py
+++ b/openfe/tests/setup/test_atommapping.py
@@ -1,39 +1,4 @@
-from rdkit import Chem
 import pytest
-
-from openfe.setup import AtomMapping
-
-
-@pytest.fixture(scope='module')
-def simple_mapping():
-    """Disappearing oxygen on end
-
-    C C O
-
-    C C
-    """
-    molA = Chem.MolFromSmiles('CCO')
-    molB = Chem.MolFromSmiles('CC')
-
-    m = AtomMapping(molA, molB, mol1_to_mol2={0: 0, 1: 1})
-
-    return m
-
-
-@pytest.fixture(scope='module')
-def other_mapping():
-    """Disappearing middle carbon
-
-    C C O
-
-    C   C
-    """
-    molA = Chem.MolFromSmiles('CCO')
-    molB = Chem.MolFromSmiles('CC')
-
-    m = AtomMapping(molA, molB, mol1_to_mol2={0: 0, 2: 1})
-
-    return m
 
 
 def test_atommapping_usage(simple_mapping):

--- a/openfe/tests/setup/test_scorer.py
+++ b/openfe/tests/setup/test_scorer.py
@@ -4,37 +4,38 @@ from openfe.setup.scorer import Scorer
 
 class ConcreteScorer(Scorer):
     """Test implementation of Scorer with a score"""
-    def score(self, atommapping):
+    def _score(self, atommapping):
         return 3.14
 
 
 class ConcreteAnnotator(Scorer):
     """Test implementation of Scorer with a custom annotation"""
-    def score(self, atommapping):
+    def _score(self, atommapping):
         return None
 
-    def annotation(self, atommapping):
+    def _annotation(self, atommapping):
         return {'annotation': 'data'}
 
 
 class TestScorer:
-    def test_abstract_error(self, mock_atommapping):
+    def test_abstract_error(self, simple_mapping):
         scorer = Scorer()
-        with pytest.raises(NotImplementedError, match="'Scorer'.*abstract"):
-            scorer(mock_atommapping)
+        match_re = "'Scorer'.*abstract.*_score"
+        with pytest.raises(NotImplementedError, match=match_re):
+            scorer(simple_mapping)
 
-    def test_concrete_scorer(self, mock_atommapping):
+    def test_concrete_scorer(self, simple_mapping):
         # The ConcreteScorer class should give the implemented value for the
         # score and the default empty dict for the annotation.
         scorer = ConcreteScorer()
-        result = scorer(mock_atommapping)
+        result = scorer(simple_mapping)
         assert result.score == 3.14
         assert result.annotation == {}
 
-    def test_concrete_annotator(self, mock_atommapping):
+    def test_concrete_annotator(self, simple_mapping):
         # The ConcreteAnnotator class should give the implemented (None)
         # value for the score and the implemented value of the annotation.
         scorer = ConcreteAnnotator()
-        result = scorer(mock_atommapping)
+        result = scorer(simple_mapping)
         assert result.score is None
         assert result.annotation == {'annotation': 'data'}


### PR DESCRIPTION
This is a small PR where I'm cherry-picking some of the changes that have come up as I've been working on AtomMappers. Main things:

* Added `setup/errors.py`, which currently just contains a string template for errors when using abstract methods.
* Make `score` and `annotation` functions in `Scorer` private. This will allow arbitrary functions to be used as scorers (useful if an AtomMapper wants to provide a scoring function as an instance method).
* Move the fixtures for atommappings into conftest.py; use one of them instead of the nonsense placeholder for the scoring tests. 