### PR TITLE
Molecule class

### DIFF
--- a/openfe/setup/__init__.py
+++ b/openfe/setup/__init__.py
@@ -1,3 +1,4 @@
+from .molecule import Molecule
 from .atommapping import AtomMapping
 from .alchemical_molecule import AlchemicalMolecule
 from .network import Network

--- a/openfe/setup/molecule.py
+++ b/openfe/setup/molecule.py
@@ -1,6 +1,9 @@
 # This code is part of OpenFE and is licensed under the MIT license.
 # For details, see https://github.com/OpenFreeEnergy/openfe
 
+from typing import TypeVal
+RDKitMol = TypeVar('RDKitMol')
+
 from openfe.utils.molhashing import hashmol
 
 
@@ -12,18 +15,17 @@ class Molecule:
     rdkit : rdkit.Mol
         rdkit representation of the molecule
     """
-    def __init__(self, rdkit):
+    def __init__(self, rdkit: RDKitMol):
         self._rdkit = rdkit
-        self._hash = None
+        self._hash = hashmol(self._rdkit)
 
     # property for immutability; also may allow in-class type conversion
     @property
-    def rdkit(self):
+    def rdkit(self) -> RDKitMol:
+        """RDKit representation of this molecule"""
         return self._rdkit
 
     def __hash__(self):
-        if self._hash is None:
-            self._hash = hashmol(self.rdkit)
         return hash(self._hash)
 
     def __eq__(self, other):

--- a/openfe/setup/molecule.py
+++ b/openfe/setup/molecule.py
@@ -3,6 +3,7 @@
 
 from openfe.utils.molhashing import hashmol
 
+
 class Molecule:
     """Molecule wrapper to provide proper hashing and equality.
 

--- a/openfe/setup/molecule.py
+++ b/openfe/setup/molecule.py
@@ -1,7 +1,7 @@
 # This code is part of OpenFE and is licensed under the MIT license.
 # For details, see https://github.com/OpenFreeEnergy/openfe
 
-from typing import TypeVal
+from typing import TypeVar
 RDKitMol = TypeVar('RDKitMol')
 
 from openfe.utils.molhashing import hashmol

--- a/openfe/setup/molecule.py
+++ b/openfe/setup/molecule.py
@@ -1,0 +1,29 @@
+# This code is part of OpenFE and is licensed under the MIT license.
+# For details, see https://github.com/OpenFreeEnergy/openfe
+
+from openfe.utils.molhashing import hashmol
+
+class Molecule:
+    """Molecule wrapper to provide proper hashing and equality.
+
+    Parameters
+    ----------
+    rdkit : rdkit.Mol
+        rdkit representation of the molecule
+    """
+    def __init__(self, rdkit):
+        self._rdkit = rdkit
+        self._hash = None
+
+    # property for immutability; also may allow in-class type conversion
+    @property
+    def rdkit(self):
+        return self._rdkit
+
+    def __hash__(self):
+        if self._hash is None:
+            self._hash = hashmol(self.rdkit)
+        return hash(self._hash)
+
+    def __eq__(self, other):
+        return hash(self) == hash(other)

--- a/openfe/tests/setup/conftest.py
+++ b/openfe/tests/setup/conftest.py
@@ -4,6 +4,7 @@ from rdkit import Chem
 from openfe.setup import AtomMapping
 from openfe.setup import Molecule
 
+
 @pytest.fixture(scope='session')
 def ethane():
     return Molecule(Chem.MolFromSmiles('CC'))

--- a/openfe/tests/setup/conftest.py
+++ b/openfe/tests/setup/conftest.py
@@ -2,6 +2,11 @@ import pytest
 from rdkit import Chem
 
 from openfe.setup import AtomMapping
+from openfe.setup import Molecule
+
+@pytest.fixture(scope='session')
+def ethane():
+    return Molecule(Chem.MolFromSmiles('CC'))
 
 
 @pytest.fixture(scope='session')
@@ -12,8 +17,8 @@ def simple_mapping():
 
     C C
     """
-    molA = Chem.MolFromSmiles('CCO')
-    molB = Chem.MolFromSmiles('CC')
+    molA = Molecule(Chem.MolFromSmiles('CCO'))
+    molB = Molecule(Chem.MolFromSmiles('CC'))
 
     m = AtomMapping(molA, molB, mol1_to_mol2={0: 0, 1: 1})
 
@@ -28,8 +33,8 @@ def other_mapping():
 
     C   C
     """
-    molA = Chem.MolFromSmiles('CCO')
-    molB = Chem.MolFromSmiles('CC')
+    molA = Molecule(Chem.MolFromSmiles('CCO'))
+    molB = Molecule(Chem.MolFromSmiles('CC'))
 
     m = AtomMapping(molA, molB, mol1_to_mol2={0: 0, 2: 1})
 

--- a/openfe/tests/setup/test_molecule.py
+++ b/openfe/tests/setup/test_molecule.py
@@ -19,11 +19,9 @@ def named_ethane():
 class TestMolecule:
     def test_rdkit_behavior(self, ethane, alt_ethane):
         # Check that fixture setup is correct (we aren't accidentally
-        # testing tautologies) and that rdkit continues to behave in a way
-        # that require our custom equality.
+        # testing tautologies)
         assert ethane is not alt_ethane
         assert ethane.rdkit is not alt_ethane.rdkit
-        assert ethane.rdkit != alt_ethane.rdkit  # rdkit might change this
 
     def test_equality_and_hash(self, ethane, alt_ethane):
         assert hash(ethane) == hash(alt_ethane)

--- a/openfe/tests/setup/test_molecule.py
+++ b/openfe/tests/setup/test_molecule.py
@@ -1,0 +1,33 @@
+import pytest
+
+from openfe.setup import Molecule
+from rdkit import Chem
+
+@pytest.fixture
+def alt_ethane():
+    return Molecule(Chem.MolFromSmiles("CC"))
+
+@pytest.fixture
+def named_ethane():
+    mol = Chem.MolFromSmiles("CC")
+    mol.SetProp("_Name", "ethane")
+    return Molecule(mol)
+
+class TestMolecule:
+    def test_rdkit_behavior(self, ethane, alt_ethane):
+        # Check that fixture setup is correct (we aren't accidentally
+        # testing tautologies) and that rdkit continues to behave in a way
+        # that require our custom equality.
+        assert ethane is not alt_ethane
+        assert ethane.rdkit is not alt_ethane.rdkit
+        assert ethane.rdkit != alt_ethane.rdkit  # rdkit might change this
+
+    def test_equality_and_hash(self, ethane, alt_ethane):
+        assert hash(ethane) == hash(alt_ethane)
+        assert ethane == alt_ethane
+
+    def test_equality_and_hash_name_differs(self, ethane, named_ethane):
+        # names would be used to distinguish different binding modes
+        assert hash(ethane) != hash(named_ethane)
+        assert ethane != named_ethane
+

--- a/openfe/tests/setup/test_molecule.py
+++ b/openfe/tests/setup/test_molecule.py
@@ -3,15 +3,18 @@ import pytest
 from openfe.setup import Molecule
 from rdkit import Chem
 
+
 @pytest.fixture
 def alt_ethane():
     return Molecule(Chem.MolFromSmiles("CC"))
+
 
 @pytest.fixture
 def named_ethane():
     mol = Chem.MolFromSmiles("CC")
     mol.SetProp("_Name", "ethane")
     return Molecule(mol)
+
 
 class TestMolecule:
     def test_rdkit_behavior(self, ethane, alt_ethane):
@@ -30,4 +33,3 @@ class TestMolecule:
         # names would be used to distinguish different binding modes
         assert hash(ethane) != hash(named_ethane)
         assert ethane != named_ethane
-

--- a/openfe/utils/__init__.py
+++ b/openfe/utils/__init__.py
@@ -1,0 +1,5 @@
+# This code is part of OpenFE and is licensed under the MIT license.
+# For details, see https://github.com/OpenFreeEnergy/openfe
+
+from . import molhashing
+from . import errors

--- a/openfe/utils/molhashing.py
+++ b/openfe/utils/molhashing.py
@@ -1,0 +1,12 @@
+# This code is part of OpenFE and is licensed under the MIT license.
+# For details, see https://github.com/OpenFreeEnergy/openfe
+from rdkit import Chem
+
+
+def hashmol(mol):
+    # canonical by default
+    try:
+        name = mol.GetProp("_Name")
+    except KeyError:
+        name = ""
+    return (Chem.MolToSmiles(mol), name)


### PR DESCRIPTION
Adds `Molecule` class. In principle, this could be extended in the future to automate conversion between properties `rdkit`, `oechem`, `openff`, etc. to allow access to alternate molecular representations.

Includes the hashing the @richardjgowers previously wrote, with addition to support the `_Name` attribute as discussed in Slack.

One thing that might improve this: is there a way to make an rdkit molecule immutable?