### PR TITLE
Add a simple coveragerc to ignore tests in reporting

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[report]
+omit =
+    */openfe/tests/*
+

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,6 @@
 [report]
 omit =
     */openfe/tests/*
-
+exclude_lines =
+    pragma: no cover
+    raise NotImplementedError

--- a/.coveragerc
+++ b/.coveragerc
@@ -3,4 +3,6 @@ omit =
     */openfe/tests/*
 exclude_lines =
     pragma: no cover
+    pragma: no-cover
+    -no-cov
     raise NotImplementedError

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,4 @@
 [report]
-omit =
-    */openfe/tests/*
 exclude_lines =
     pragma: no cover
     pragma: no-cover


### PR DESCRIPTION
As per the title - I noticed we were including tests in our coverage.

I know some folks advocate for and some against - debate if you wish.

FWIW - I'm in the against purely because I feel like including tests isn't really helping me with anything except inflate the total %.