### PR TITLE
omit _version.py from coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,7 @@
+[run]
+omit =
+    */_version.py
+
 [report]
 exclude_lines =
     pragma: no cover


### PR DESCRIPTION
iirc you only need to omit in [run] and it should carry though - let's see what codecov thinks