### PR TITLE
Proposed API change on AtomMapper

### DIFF
--- a/openfe/setup/atommapper.py
+++ b/openfe/setup/atommapper.py
@@ -38,7 +38,7 @@ class AtomMapper:
         ))
 
     def suggest_mappings(
-        self, mol1: RDKitMol, mol2: RDKitMol
+        self, mol1: Molecule, mol2: Molecule
     ) -> Iterable[AtomMapping]:
         """
         Suggest :class:`.AtomMapping` options for the input molecules.

--- a/openfe/setup/atommapper.py
+++ b/openfe/setup/atommapper.py
@@ -1,10 +1,10 @@
 # This code is part of OpenFE and is licensed under the MIT license.
 # For details, see https://github.com/OpenFreeEnergy/openfe
 
-from typing import TypeVar, Iterable
+from typing import TypeVar, Iterable, Dict
 
 
-from . import AtomMapping
+from . import AtomMapping, Molecule
 from ..utils.errors import ABSTRACT_ERROR_STRING
 
 RDKitMol = TypeVar("RDKitMol")
@@ -18,7 +18,7 @@ class AtomMapper:
     """
     def _mappings_generator(
         self, mol1: RDKitMol, mol2: RDKitMol
-    ) -> Iterable[AtomMapping]:
+    ) -> Iterable[Dict[int, int]]:
         """
         Suggest :class:`.AtomMapping` options for the input molecules.
 
@@ -29,8 +29,8 @@ class AtomMapper:
 
         Returns
         -------
-        Iterable[AtomMapping] :
-            an iterable over proposed mappings
+        Iterable[Dict[int, int]] :
+            an iterable over proposed mappings from mol1 to mol2
         """
         raise NotImplementedError(ABSTRACT_ERROR_STRING.format(
             cls=self.__class__.__name__,
@@ -44,8 +44,8 @@ class AtomMapper:
         Suggest :class:`.AtomMapping` options for the input molecules.
 
         Parameters
-        ----------
-        mol1, mol2 : rdkit.Mol
+        ---------
+        mol1, mol2 : :class:`.Molecule`
             the two molecules to create a mapping for
 
         Returns
@@ -58,4 +58,5 @@ class AtomMapper:
         # subclasses of this can customize suggest_mappings while always
         # maintaining the consistency that concrete implementations must
         # implement _mappings_generator.
-        yield from self._mappings_generator(mol1, mol2)
+        for map_dct in self._mappings_generator(mol1.rdkit, mol2.rdkit):
+            yield AtomMapping(mol1, mol2, map_dct)

--- a/openfe/setup/lomap_mapper.py
+++ b/openfe/setup/lomap_mapper.py
@@ -53,5 +53,5 @@ class LomapAtomMapper(AtomMapper):
         mapping_dict = dict((map(int, v.split(':'))
                              for v in mapping_string.split(',')))
 
-        yield AtomMapping(mol1=mol1, mol2=mol2, mol1_to_mol2=mapping_dict)
+        yield mapping_dict
         return

--- a/openfe/tests/setup/conftest.py
+++ b/openfe/tests/setup/conftest.py
@@ -57,6 +57,7 @@ def lomap_basic_test_files():
         'toluene']:
         with resources.path('openfe.tests.data.lomap_basic',
                             f + '.mol2') as fn:
-            files[f] = Chem.MolFromMol2File(str(fn))
+            mol = Chem.MolFromMol2File(str(fn))
+            files[f] = Molecule(mol, name=f)
 
     return files

--- a/openfe/tests/setup/test_atommapper.py
+++ b/openfe/tests/setup/test_atommapper.py
@@ -26,7 +26,7 @@ class TestAtomMapper:
 
             def _mappings_generator(self, mol1, mol2):
                 for mapping in self.mappings:
-                    yield mapping
+                    yield mapping.mol1_to_mol2
 
         mapper = ConcreteAtomMapper([simple_mapping, other_mapping])
         results = list(mapper.suggest_mappings(mol1, mol2))

--- a/openfe/tests/setup/test_lomap_atommapper.py
+++ b/openfe/tests/setup/test_lomap_atommapper.py
@@ -1,16 +1,17 @@
+# This code is part of OpenFE and is licensed under the MIT license.
+# For details, see https://github.com/OpenFreeEnergy/openfe
 import pytest
 from rdkit import Chem
 
 
 import openfe
-from openfe.setup import Molecule
-from openfe.setup.lomap_mapper import LomapAtomMapper
+from openfe.setup import LomapAtomMapper, Molecule
 
 
 def test_simple(lomap_basic_test_files):
     # basic sanity check on the AtomMapper
-    mol1 = Molecule(lomap_basic_test_files['methylcyclohexane'])
-    mol2 = Molecule(lomap_basic_test_files['toluene'])
+    mol1 = lomap_basic_test_files['methylcyclohexane']
+    mol2 = lomap_basic_test_files['toluene']
 
     mapper = LomapAtomMapper()
 
@@ -26,8 +27,8 @@ def test_simple(lomap_basic_test_files):
 def test_generator_length(lomap_basic_test_files):
     # check that we get one mapping back from Lomap AtomMapper then the
     # generator stops correctly
-    mol1 = Molecule(lomap_basic_test_files['methylcyclohexane'])
-    mol2 = Molecule(lomap_basic_test_files['toluene'])
+    mol1 = lomap_basic_test_files['methylcyclohexane']
+    mol2 = lomap_basic_test_files['toluene']
 
     mapper = LomapAtomMapper()
 
@@ -39,8 +40,8 @@ def test_generator_length(lomap_basic_test_files):
 
 
 def test_bad_mapping(lomap_basic_test_files):
-    toluene = Molecule(lomap_basic_test_files['toluene'])
-    NigelTheNitrogen = Molecule(Chem.MolFromSmiles('N'))
+    toluene = lomap_basic_test_files['toluene']
+    NigelTheNitrogen = Molecule(Chem.MolFromSmiles('N'), name='Nigel')
 
     mapper = LomapAtomMapper()
 

--- a/openfe/tests/setup/test_lomap_atommapper.py
+++ b/openfe/tests/setup/test_lomap_atommapper.py
@@ -3,13 +3,14 @@ from rdkit import Chem
 
 
 import openfe
+from openfe.setup import Molecule
 from openfe.setup.lomap_mapper import LomapAtomMapper
 
 
 def test_simple(lomap_basic_test_files):
     # basic sanity check on the AtomMapper
-    mol1 = lomap_basic_test_files['methylcyclohexane']
-    mol2 = lomap_basic_test_files['toluene']
+    mol1 = Molecule(lomap_basic_test_files['methylcyclohexane'])
+    mol2 = Molecule(lomap_basic_test_files['toluene'])
 
     mapper = LomapAtomMapper()
 
@@ -25,8 +26,8 @@ def test_simple(lomap_basic_test_files):
 def test_generator_length(lomap_basic_test_files):
     # check that we get one mapping back from Lomap AtomMapper then the
     # generator stops correctly
-    mol1 = lomap_basic_test_files['methylcyclohexane']
-    mol2 = lomap_basic_test_files['toluene']
+    mol1 = Molecule(lomap_basic_test_files['methylcyclohexane'])
+    mol2 = Molecule(lomap_basic_test_files['toluene'])
 
     mapper = LomapAtomMapper()
 
@@ -38,8 +39,8 @@ def test_generator_length(lomap_basic_test_files):
 
 
 def test_bad_mapping(lomap_basic_test_files):
-    toluene = lomap_basic_test_files['toluene']
-    NigelTheNitrogen = Chem.MolFromSmiles('N')
+    toluene = Molecule(lomap_basic_test_files['toluene'])
+    NigelTheNitrogen = Molecule(Chem.MolFromSmiles('N'))
 
     mapper = LomapAtomMapper()
 


### PR DESCRIPTION
This proposes a change to the API for `AtomMapper` so that the input to `AtomMapper.suggest_mappings` is an `openfe.setup.Molecule` instead of an `rdkit.Mol`, and so that the output of the internal `_mapping_generator` is a `dict`, instead of the `AtomMapping`. A few reasons for this:

1. From a user perspective (while writing CLI code) it felt strange that the input to this was rdkit. Example: consider that we might want to visualize an AtomMapping. This could either be an atommapping we generate on the fly using `AtomMapper`, or one that we load from an existing Network (selecting the edge we're interested in). In these two different use cases, we would need to use different molecule classes -- rdkit for the first, openfe for the second. That was confusing, and supporting both use cases would complicate code for the CLI. Making this change simplifies.
2. From the perspective of an implementer, the choice to only return a `dict` means that the `AtomMapper` implementer doesn't have to think about our objects at all. They take rdkit and return the dict; we take care of wrapping it into an `AtomMapping`.

Tossed this together quickly, so I'll need to double-check that docstrings were all updated.