### PR TITLE
Add support for CLI `--mol` to load SDF

### DIFF
--- a/openfe/setup/molecule.py
+++ b/openfe/setup/molecule.py
@@ -144,6 +144,31 @@ class Molecule:
         # https://sourceforge.net/p/rdkit/mailman/message/27518272/
         supp = Chem.SDMolSupplier()
         supp.SetData(sdf_str)
+        return cls._from_sdf_supplier(supp)
+
+    @classmethod
+    def from_sdf_file(cls, filename: str):
+        """Create ``Molecule`` from SDF file.
+
+        Parameters
+        ----------
+        filename : str
+            name of SDF file
+
+        Returns
+        -------
+        :class:`.Molecule` :
+            the deserialized molecule
+        """
+        # technically, we allow file-like objects
+        supp = Chem.SDMolSupplier(str(filename))
+        return cls._from_sdf_supplier(supp)
+
+    @classmethod
+    def _from_sdf_supplier(cls, supp):
+        """
+        Internal mechanism used by both from_sdf_string and from_sdf_file.
+        """
         mol = next(supp)
 
         # ensure that there's only one molecule in the file

--- a/openfe/tests/setup/conftest.py
+++ b/openfe/tests/setup/conftest.py
@@ -1,9 +1,11 @@
 # This code is part of OpenFE and is licensed under the MIT license.
 # For details, see https://github.com/OpenFreeEnergy/openfe
+import importlib
+import string
 import pytest
 from rdkit import Chem
-from importlib import resources
 
+import openfe
 from openfe.setup import AtomMapping
 from openfe.setup import Molecule
 
@@ -58,8 +60,8 @@ def lomap_basic_test_files():
         '2-naftanol',
         'methylcyclohexane',
         'toluene']:
-        with resources.path('openfe.tests.data.lomap_basic',
-                            f + '.mol2') as fn:
+        with importlib.resources.path('openfe.tests.data.lomap_basic',
+                                      f + '.mol2') as fn:
             mol = Chem.MolFromMol2File(str(fn))
             files[f] = Molecule(mol, name=f)
 
@@ -69,9 +71,6 @@ def lomap_basic_test_files():
 @pytest.fixture
 def serialization_template():
     def inner(filename):
-        import importlib
-        import string
-        import openfe
         loc = "openfe.tests.data.serialization"
         tmpl = importlib.resources.read_text(loc, filename)
         return tmpl.format(OFE_VERSION=openfe.__version__)

--- a/openfe/tests/setup/test_molecule.py
+++ b/openfe/tests/setup/test_molecule.py
@@ -113,6 +113,14 @@ class TestMolecule:
         sdf_str = serialization_template("ethane_template.sdf")
         assert Molecule.from_sdf_string(sdf_str) == named_ethane
 
+    def test_from_sdf_file(self, named_ethane, serialization_template,
+                           tmpdir):
+        sdf_str = serialization_template("ethane_template.sdf")
+        with open(tmpdir / "temp.sdf", mode='w') as tmpf:
+            tmpf.write(sdf_str)
+
+        assert Molecule.from_sdf_file(tmpdir / "temp.sdf") == named_ethane
+
     def test_from_sdf_string_multiple_molecules(self):
         contents = importlib.resources.read_text("openfe.tests.data",
                                                  "multi_molecule.sdf")

--- a/openfecli/parameters/mol.py
+++ b/openfecli/parameters/mol.py
@@ -42,6 +42,6 @@ get_molecule = MultiStrategyGetter(
 
 MOL = Option(
     "--mol",
-    help="Molecule. Can be provided as an SDF file or as a string",
+    help="Molecule. Can be provided as an SDF file or as a SMILES string.",
     getter=get_molecule
 )

--- a/openfecli/parameters/mol.py
+++ b/openfecli/parameters/mol.py
@@ -20,8 +20,19 @@ def _load_molecule_from_smiles(user_input, context):
     return Molecule(rdkit=mol)
 
 
+def _load_molecule_from_sdf(user_input, context):
+    from openfe.setup import Molecule
+    try:
+        with open(user_input, mode="r") as sdf:
+            contents = sdf.read()
+        return Molecule.from_sdf_string(contents)
+    except:  # any exception should try other strategies
+        return NOT_PARSED
+
+
 get_molecule = MultiStrategyGetter(
     strategies=[
+        _load_molecule_from_sdf,
         # NOTE: I think loading from smiles must be last choice, because
         # failure will give meaningless user-facing errors
         _load_molecule_from_smiles,
@@ -31,6 +42,6 @@ get_molecule = MultiStrategyGetter(
 
 MOL = Option(
     "--mol",
-    help="Molecule",
+    help="Molecule. Can be provided as an SDF file or as a string",
     getter=get_molecule
 )

--- a/openfecli/parameters/mol.py
+++ b/openfecli/parameters/mol.py
@@ -23,9 +23,7 @@ def _load_molecule_from_smiles(user_input, context):
 def _load_molecule_from_sdf(user_input, context):
     from openfe.setup import Molecule
     try:
-        with open(user_input, mode="r") as sdf:
-            contents = sdf.read()
-        return Molecule.from_sdf_string(contents)
+        return Molecule.from_sdf_file(user_input)
     except:  # any exception should try other strategies
         return NOT_PARSED
 

--- a/openfecli/tests/parameters/test_mol.py
+++ b/openfecli/tests/parameters/test_mol.py
@@ -16,13 +16,14 @@ def test_get_molecule_smiles():
 
 
 def test_get_molecule_sdf():
-    contents = importlib.resources.read_text(
-        "openfe.tests.data.serialization", "ethane_template.sdf"
-    ).format(OFE_VERSION=openfe.__version__)
-
-    mol = Molecule.from_sdf_string(contents)
-    assert mol.name == "ethane"
-    assert mol.smiles == "CC"
+    with importlib.resources.path("openfe.tests.data.serialization",
+                                  "ethane_template.sdf") as filename:
+        # Note: the template doesn't include a valid version, but it loads
+        # anyway. In the future, we may need to create a temporary file with
+        # template substitutions done, but that seemed like overkill now.
+        mol = get_molecule(filename)
+        assert mol.smiles == "CC"
+        assert mol.name == "ethane"
 
 
 def test_get_molecule_error():

--- a/openfecli/tests/parameters/test_mol.py
+++ b/openfecli/tests/parameters/test_mol.py
@@ -1,14 +1,27 @@
+import importlib
+
 import pytest
 import click
 
+import openfe
 from openfecli.parameters.mol import get_molecule
 from openfe.setup import Molecule
 
 
-def test_get_molecule():
+def test_get_molecule_smiles():
     mol = get_molecule("CC")
     assert isinstance(mol, Molecule)
     assert mol.name == ""
+    assert mol.smiles == "CC"
+
+
+def test_get_molecule_sdf():
+    contents = importlib.resources.read_text(
+        "openfe.tests.data.serialization", "ethane_template.sdf"
+    ).format(OFE_VERSION=openfe.__version__)
+
+    mol = Molecule.from_sdf_string(contents)
+    assert mol.name == "ethane"
     assert mol.smiles == "CC"
 
 


### PR DESCRIPTION
Now the CLI `--mol` parameter will load an SDF if the filename is given. This is the first way it tried to interpret the user input; if that fails, it interprets it as a string.