### PR TITLE
Add support to get molecule name from _Name prop

### DIFF
--- a/openfe/setup/molecule.py
+++ b/openfe/setup/molecule.py
@@ -54,6 +54,14 @@ class Molecule:
     to edit the molecule do this in an appropriate toolkit **before** creating
     this class.
 
+    A molecule can have a name associated with it. The name can be
+    explicitly set by the ``name`` attribute, or implicitly set based on the
+    tags in the input molecular representation (if supported, as with
+    RDKit). If not explicitly set on creation, the molecule will first look
+    for an OpenFE-specific tag ``ofe-name``, and if that doesn't exist, for
+    a commonly-used naming tag (e.g., the ``_Name`` property for RDKit
+    molecules). If no name is found, the empty string is used.
+
     Parameters
     ----------
     rdkit : rdkit.Mol

--- a/openfe/setup/molecule.py
+++ b/openfe/setup/molecule.py
@@ -24,9 +24,14 @@ def _ensure_ofe_name(mol: RDKitMol, name: str) -> str:
     name; ensure that is set in the rdkit representation.
     """
     try:
-        rdkit_name = mol.GetProp("ofe-name")
+        rdkit_name = mol.GetProp("_Name")
     except KeyError:
         rdkit_name = ""
+
+    try:
+        rdkit_name = mol.GetProp("ofe-name")
+    except KeyError:
+        pass
 
     if name and rdkit_name and rdkit_name != name:
         warnings.warn(f"Molecule being renamed from {rdkit_name} to {name}.")


### PR DESCRIPTION
@IAlibay asked if I could make it so that we defaulted to getting the name from the `_Name` property in an rdkit molecule, if that is set. This PR makes that happen. Now names for molecules are set with the following precedence:

1. If you specify the `name` argument when creating a molecule, that name is used. This is the way we explicitly set the name. If the name has been implicitly set by any of methods below and the explicitly-set name differs, you get a warning about renaming the molecule.
2. Otherwise, the RDKit molecule's `ofe-name` property is used (if set).
3. Otherwise, the RDKit molecule's `_Name` property is used (if set).
4. Otherwise, the name is the empty string.