### PR TITLE
Skip running OE license check on PR

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,6 +46,7 @@ jobs:
             activate-environment: openfe
 
       - name: Decrypt OpenEye license
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         env:
           OE_LICENSE_TEXT: ${{ secrets.OE_LICENSE }}
         run: |


### PR DESCRIPTION
This should skip the OE license check when CI runs on a PR that came from a fork, but should run on branches from the main repo. 