### PR TITLE
Add --version to CLI

### DIFF
--- a/openfecli/cli.py
+++ b/openfecli/cli.py
@@ -27,6 +27,7 @@ the OpenFE Python library.
 
 @click.command(cls=OpenFECLI, name="openfe", help=_MAIN_HELP,
                context_settings=CONTEXT_SETTINGS)
+@click.version_option(package_name='openfe')
 def main():
     # currently empty: we can add options at the openfe level (as opposed to
     # subcommands) by adding click options here. Subcommand runs after this


### PR DESCRIPTION
Yeah, @richardjgowers, this wasn't too complicated.

Note that we need to give the `openfe` package name because versioning is actually on the distribution, not the package itself. That said, we might want to change this to use the versioneer version at some point. For future reference, [docs on `click.version_option`](https://click.palletsprojects.com/en/8.0.x/api/#click.version_option).