### PR TITLE
use versioneer for the version number

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 openfe/_version.py export-subst
+openfecli/_version.py export-subst

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
-openfe/_version.py export-subst
 openfecli/_version.py export-subst

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
 include versioneer.py
-include openfe/_version.py
+include openfecli/_version.py

--- a/openfe/__init__.py
+++ b/openfe/__init__.py
@@ -4,5 +4,5 @@ from . import simulation
 from . import analysis
 from . import utils
 
-from . import _version
+from openfecli import _version
 __version__ = _version.get_versions()['version']

--- a/openfecli/__init__.py
+++ b/openfecli/__init__.py
@@ -3,3 +3,6 @@
 
 from .plugins import OFECommandPlugin
 from . import commands
+
+from . import _version
+__version__ = _version.get_versions()['version']

--- a/openfecli/_version.py
+++ b/openfecli/_version.py
@@ -44,7 +44,7 @@ def get_config():
     cfg.style = "pep440-post"
     cfg.tag_prefix = ""
     cfg.parentdir_prefix = "None"
-    cfg.versionfile_source = "openfe/_version.py"
+    cfg.versionfile_source = "openfecli/_version.py"
     cfg.verbose = False
     return cfg
 

--- a/openfecli/cli.py
+++ b/openfecli/cli.py
@@ -4,9 +4,11 @@
 import pathlib
 
 import click
-
 from plugcli.cli import CLI, CONTEXT_SETTINGS
 from plugcli.plugin_management import FilePluginLoader
+
+import openfe
+
 from .plugins import OFECommandPlugin
 
 
@@ -27,7 +29,7 @@ the OpenFE Python library.
 
 @click.command(cls=OpenFECLI, name="openfe", help=_MAIN_HELP,
                context_settings=CONTEXT_SETTINGS)
-@click.version_option(package_name='openfe')
+@click.version_option(version=openfe.__version__)
 def main():
     # currently empty: we can add options at the openfe level (as opposed to
     # subcommands) by adding click options here. Subcommand runs after this

--- a/openfecli/cli.py
+++ b/openfecli/cli.py
@@ -7,7 +7,7 @@ import click
 from plugcli.cli import CLI, CONTEXT_SETTINGS
 from plugcli.plugin_management import FilePluginLoader
 
-import openfe
+import openfecli
 
 from .plugins import OFECommandPlugin
 
@@ -29,7 +29,7 @@ the OpenFE Python library.
 
 @click.command(cls=OpenFECLI, name="openfe", help=_MAIN_HELP,
                context_settings=CONTEXT_SETTINGS)
-@click.version_option(version=openfe.__version__)
+@click.version_option(version=openfecli.__version__)
 def main():
     # currently empty: we can add options at the openfe level (as opposed to
     # subcommands) by adding click options here. Subcommand runs after this

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,8 +48,8 @@ universal = 1
 [versioneer]
 VCS = git
 style = pep440-post
-versionfile_source = openfe/_version.py
-versionfile_build = openfe/_version.py
+versionfile_source = openfecli/_version.py
+versionfile_build = openfecli/_version.py
 tag_prefix = ''
 
 [mypy]


### PR DESCRIPTION
@dwhswenson thoughts on this? The one thing that is nice about using versioneer here is the output is really useful during development, but I will admit I'm not an expert on the plugin cli architecture, so not having an `import openfe` may be very intentional.

```
$ openfe --version
openfe, version v0.1.post7+gfdc895f
```

P.S. Really not trying to bike shed hear, so if this PR feels like that is what I'm doing, feel free to close it!