### PR TITLE
Fix rms tolerance check

### DIFF
--- a/openfe/setup/_rbfe_utils/topologyhelpers.py
+++ b/openfe/setup/_rbfe_utils/topologyhelpers.py
@@ -335,7 +335,7 @@ def get_system_mappings(old_to_new_atom_map,
 
 def set_and_check_new_positions(mapping, old_topology, new_topology,
                                 old_positions, insert_positions,
-                                shift_insert=None, tolerance=1e-5):
+                                shift_insert=None, tolerance=0.5):
     """
     Utility to create new positions given a mapping, the old positions and
     the positions of the molecule being inserted, defined by `insert_positions.

--- a/openfe/setup/methods/openmm/equil_rbfe_methods.py
+++ b/openfe/setup/methods/openmm/equil_rbfe_methods.py
@@ -129,6 +129,9 @@ class AlchemicalSettings(BaseModel):
       Whether to scale torsion terms involving unique atoms, such that at the
       endstate the torsion term is turned off/on depending on the state the
       unique atoms belong to.
+    atom_overlap_tolerance : float
+      Maximum allowed deviation along any dimension (x,y,z) in mapped atoms
+      between the positions of state A and B. Default 0.5.
     """
     # Lambda settings
     lambda_functions = 'default'
@@ -144,6 +147,7 @@ class AlchemicalSettings(BaseModel):
     softcore_sigma_Q = 1.0
     interpolate_old_and_new_14s = False
     flatten_torsions = False
+    atom_overlap_tolerance = 0.5
 
 
 class OpenMMEngineSettings(BaseModel):
@@ -768,6 +772,7 @@ class RelativeLigandTransform(FEMethod):
             old_positions=stateA_positions,
             insert_positions=stateB_openff_ligand.conformers[0],
             shift_insert=center_offset.value_in_unit(omm_unit.angstrom),
+            tolerance=self._settings.alchemical_settings.atom_overlap_tolerance
         )
 
         # 7. Create the hybrid topology


### PR DESCRIPTION
Add tolerance as a setting for alchemical_settings for now (since it declares whether or not things should really be mapped-ish).

We need this so we can go ahead with our benchmark runs.