### PR TITLE
Remove universal bdist_wheel in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,9 +42,6 @@ test =
 console_scripts = 
     openfe = openfecli.cli:main
 
-[bdist_wheel]
-universal = 1
-
 [versioneer]
 VCS = git
 style = pep440-post


### PR DESCRIPTION
As per [wheels docs](https://wheel.readthedocs.io/en/stable/user_guide.html#building-wheels)

"If your project contains no C extensions and is expected to work on both Python 2 and 3, you will want to tell wheel to produce universal wheels by adding this to your setup.cfg file:" (referring to adding `universal = 1` under `[bdist_wheel]`).

It's surprisingly caused a ton of chaos for some MDA python-only components, so we should probably eagerly remove it.

