### PR TITLE
Fix `results_cls` attribute name

### DIFF
--- a/openfe/setup/methods/openmm/equil_rbfe_methods.py
+++ b/openfe/setup/methods/openmm/equil_rbfe_methods.py
@@ -541,7 +541,7 @@ class RelativeLigandTransformResult(gufe.ProtocolResult):
 
 
 class RelativeLigandTransform(gufe.Protocol):
-    _results_cls = RelativeLigandTransformResult
+    results_cls = RelativeLigandTransformResult
 
     def __init__(self, settings: RelativeLigandTransformSettings):
         super().__init__(settings)


### PR DESCRIPTION
As per: https://github.com/OpenFreeEnergy/gufe/blob/f58fd82108c2954e9b6604cd1585bf66829f6078/gufe/protocols/protocol.py#L255

It should be `results_cls` not `_results_cls`?