### PR TITLE
Make unit close reporter at end of simulation

### DIFF
--- a/openfe/setup/methods/openmm/equil_rbfe_methods.py
+++ b/openfe/setup/methods/openmm/equil_rbfe_methods.py
@@ -1124,6 +1124,9 @@ class RelativeLigandTransformUnit(gufe.ProtocolUnit):
                 logger.info("running production phase")
 
             sampler.extend(int(prod_steps.m / mc_steps))  # type: ignore
+            
+            # close reporter when you're done
+            sampler._reporter.close()
 
             nc = basepath / settings.simulation_settings.output_filename
             chk = basepath / settings.simulation_settings.checkpoint_storage


### PR DESCRIPTION
Alternatively we could just del() the sampler, which does this: https://github.com/choderalab/openmmtools/blob/2e64980d86cf087f69e282927eebf2b41b73a3ea/openmmtools/multistate/multistatesampler.py#L827-L830

Maybe that's a better option?