### PR TITLE
pin dependencies for release

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,8 +13,8 @@ dependencies:
   - pytest-cov
   - pydantic
   - coverage
-  - openff-toolkit
-  - openff-units>=0.1.6
+  - openff-toolkit==0.11
+  - openff-units==0.1.8
   - pint<0.20.0
   - click
   - openeye-toolkits

--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,7 @@ dependencies:
   - coverage
   - openff-toolkit
   - openff-units>=0.1.6
-  - pint==0.19.2
+  - pint<0.2.0
   - click
   - openeye-toolkits
   - typing-extensions

--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,7 @@ dependencies:
   - coverage
   - openff-toolkit
   - openff-units>=0.1.6
-  - pint<0.2.0
+  - pint<0.20.0
   - click
   - openeye-toolkits
   - typing-extensions

--- a/environment.yml
+++ b/environment.yml
@@ -15,6 +15,7 @@ dependencies:
   - coverage
   - openff-toolkit
   - openff-units>=0.1.6
+  - pint==0.19.2
   - click
   - openeye-toolkits
   - typing-extensions


### PR DESCRIPTION
in preparation of next release:

pins pint to fix a current issue
pins openff-units to specific version as it seems very mobile right now
pins openff-toolkit to current 0.11.z release to allow patches but hopefully no breaks

the idea going forwards is to manually move these pins as needed