### PR TITLE
Fix serialization of protocol

### DIFF
--- a/openfe/tests/setup/test_openmm_equil_protocols.py
+++ b/openfe/tests/setup/test_openmm_equil_protocols.py
@@ -1,6 +1,7 @@
 # This code is part of OpenFE and is licensed under the MIT license.
 # For details, see https://github.com/OpenFreeEnergy/openfe
 import gufe
+from gufe.tests.test_tokenization import GufeTokenizableTestsMixin
 import pytest
 from unittest import mock
 from openff.units import unit
@@ -751,3 +752,14 @@ class TestTyk2XmlRegression:
             assert a.get('p1') == b.get('p1')
             assert a.get('p2') == b.get('p2')
             assert float(a.get('d')) == pytest.approx(float(b.get('d')))
+
+
+class TestRelativeLigandTransform(GufeTokenizableTestsMixin):
+    cls = openmm_rbfe.RelativeLigandTransform
+    key = "RelativeLigandTransform-30b2198af7ecb6f6a0eda9affa5feea9"
+
+    @pytest.fixture
+    def instance(self):
+        settings = openmm_rbfe.RelativeLigandTransform.default_settings()
+        return openmm_rbfe.RelativeLigandTransform(settings)
+

--- a/openfe/tests/setup/test_openmm_equil_protocols.py
+++ b/openfe/tests/setup/test_openmm_equil_protocols.py
@@ -755,11 +755,12 @@ class TestTyk2XmlRegression:
 
 
 class TestRelativeLigandTransform(GufeTokenizableTestsMixin):
-    cls = openmm_rbfe.RelativeLigandTransform
-    key = "RelativeLigandTransform-30b2198af7ecb6f6a0eda9affa5feea9"
+    cls = openmm_rbfe.RelativeLigandProtocol
+    key = "RelativeLigandProtocol-56a107ace12ff91f21bc207a5d260504"
+    repr = "<RelativeLigandProtocol-56a107ace12ff91f21bc207a5d260504>"
 
     @pytest.fixture
     def instance(self):
-        settings = openmm_rbfe.RelativeLigandTransform.default_settings()
-        return openmm_rbfe.RelativeLigandTransform(settings)
+        settings = openmm_rbfe.RelativeLigandProtocol.default_settings()
+        return openmm_rbfe.RelativeLigandProtocol(settings)
 


### PR DESCRIPTION
So far, adding the tests that should have been there in the first place. They will fail. It looks like the gufe key is not constant for this object. Probably a problem in the serialization of settings.