### PR TITLE
adding 3D structure Mapping Vis to LigandMapping

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -22,6 +22,7 @@ dependencies:
   - openmmtools
   - openmmforcefields>=0.11.2
   - perses
+  - py3dmol
   # docs
   - myst-parser
   - sphinx-click

--- a/openfe/tests/utils/test_visualization_3D.py
+++ b/openfe/tests/utils/test_visualization_3D.py
@@ -2,21 +2,23 @@ import pytest
 from openfe.setup import LigandAtomMapping
 from openfe.utils.visualization_3D import draw_mapping_on_3Dstructure
 
-@pytest.fixture(scope='module')
+
+@pytest.fixture(scope="module")
 def maps():
     MAPS = {
-        'phenol': {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6,
-                   7: 7, 8: 8, 9: 9, 10: 12, 11: 11},
-        'anisole': {0: 5, 1: 6, 2: 7, 3: 8, 4: 9, 5: 10,
-                    6: 11, 7: 12, 8: 13, 9: 14, 10: 2, 11: 15}}
+        "phenol": {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8, 9: 9, 10: 12, 11: 11},
+        "anisole": {0: 5, 1: 6, 2: 7, 3: 8, 4: 9, 5: 10, 6: 11, 7: 12, 8: 13, 9: 14, 10: 2, 11: 15},
+    }
     return MAPS
 
-@pytest.fixture(scope='module')
+
+@pytest.fixture(scope="module")
 def benzene_phenol_mapping(benzene_transforms, maps):
-    mol1 = benzene_transforms['benzene']
-    mol2 = benzene_transforms['phenol']
-    mapping = maps['phenol']
-    return LigandAtomMapping(mol1, mol2,mapping)
+    mol1 = benzene_transforms["benzene"]
+    mol2 = benzene_transforms["phenol"]
+    mapping = maps["phenol"]
+    return LigandAtomMapping(mol1, mol2, mapping)
+
 
 def test_draw_mapping_on_3Dstructure(benzene_phenol_mapping):
     """

--- a/openfe/tests/utils/test_visualization_3D.py
+++ b/openfe/tests/utils/test_visualization_3D.py
@@ -1,0 +1,25 @@
+import pytest
+from openfe.setup import LigandAtomMapping
+from openfe.utils.visualization_3D import draw_mapping_on_3Dstructure
+
+@pytest.fixture(scope='module')
+def maps():
+    MAPS = {
+        'phenol': {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6,
+                   7: 7, 8: 8, 9: 9, 10: 12, 11: 11},
+        'anisole': {0: 5, 1: 6, 2: 7, 3: 8, 4: 9, 5: 10,
+                    6: 11, 7: 12, 8: 13, 9: 14, 10: 2, 11: 15}}
+    return MAPS
+
+@pytest.fixture(scope='module')
+def benzene_phenol_mapping(benzene_transforms, maps):
+    mol1 = benzene_transforms['benzene']
+    mol2 = benzene_transforms['phenol']
+    mapping = maps['phenol']
+    return LigandAtomMapping(mol1, mol2,mapping)
+
+def test_draw_mapping_on_3Dstructure(benzene_phenol_mapping):
+    """
+    smoke test just checking if nothing goes horribly wrong
+    """
+    draw_mapping_on_3Dstructure(edge=benzene_phenol_mapping)

--- a/openfe/tests/utils/test_visualization_3D.py
+++ b/openfe/tests/utils/test_visualization_3D.py
@@ -1,6 +1,6 @@
 import pytest
 from openfe.setup import LigandAtomMapping
-from openfe.utils.visualization_3D import draw_mapping_on_3Dstructure
+from openfe.utils.visualization_3D import show_3D_mapping
 
 
 @pytest.fixture(scope="module")
@@ -20,8 +20,8 @@ def benzene_phenol_mapping(benzene_transforms, maps):
     return LigandAtomMapping(mol1, mol2, mapping)
 
 
-def test_draw_mapping_on_3Dstructure(benzene_phenol_mapping):
+def test_show_3D_mapping(benzene_phenol_mapping):
     """
     smoke test just checking if nothing goes horribly wrong
     """
-    draw_mapping_on_3Dstructure(edge=benzene_phenol_mapping)
+    show_3D_mapping(mapping=benzene_phenol_mapping)

--- a/openfe/utils/visualization_3D.py
+++ b/openfe/utils/visualization_3D.py
@@ -10,7 +10,7 @@ from matplotlib.colors import rgb2hex
 
 from gufe.mapping import AtomMapping
 
-
+ 
 def draw_mapping_on_3Dstructure(
     edge: AtomMapping,
     spheres: bool = True,
@@ -18,6 +18,7 @@ def draw_mapping_on_3Dstructure(
     style: str = "stick",
     shift: Tuple[float, float, float] = (10, 0, 0),
 ) -> py3Dmol.view:
+
     """
     Render relative transformation edge in 3D using py3Dmol.
 

--- a/openfe/utils/visualization_3D.py
+++ b/openfe/utils/visualization_3D.py
@@ -1,16 +1,21 @@
-import py3Dmol
 import numpy as np
 from numpy.typing import NDArray
 from typing import Tuple, Union, Optional
-
 
 from rdkit import Chem
 from rdkit.Geometry.rdGeometry import Point3D
 from matplotlib import pyplot as plt
 from matplotlib.colors import rgb2hex
 
+try:
+    import py3Dmol
+except ImportError:
+    pass    # Don't throw  error, will happen later
+
+
 from gufe.mapping import AtomMapping
 
+from openfe.utils import requires_package
 
 def _get_max_dist_in_x(atom_mapping: AtomMapping) -> float:
     """helper function
@@ -36,7 +41,7 @@ def _get_max_dist_in_x(atom_mapping: AtomMapping) -> float:
     estm = float(np.round(max(max_d), 1))
     return estm if (estm > 5) else 5
 
-
+@requires_package("py3Dmol")
 def draw_mapping_on_3Dstructure(
     edge: AtomMapping,
     spheres: Optional[bool] = True,

--- a/openfe/utils/visualization_3D.py
+++ b/openfe/utils/visualization_3D.py
@@ -16,7 +16,7 @@ def draw_mapping_on_3Dstructure(
     spheres: bool = True,
     show_atomIDs: bool = False,
     style: str = "stick",
-    shift: Tuple[float, float, float] = np.array([10, 0, 0]),
+    shift: Tuple[float, float, float] = (10, 0, 0),
 ) -> py3Dmol.view:
     """
     Render relative transformation edge in 3D using py3Dmol.
@@ -40,6 +40,7 @@ def draw_mapping_on_3Dstructure(
     view : py3Dmol.view
         View of the system containing both molecules in the edge.
     """
+    shift = np.array(shift)
 
     def translate(mol, shift):
         conf = mol.GetConformer()

--- a/openfe/utils/visualization_3D.py
+++ b/openfe/utils/visualization_3D.py
@@ -108,7 +108,7 @@ def _add_spheres(view:py3Dmol.view, mol1:Chem.Mol, mol2:Chem.Mol, mapping:Dict[i
 
 
 @requires_package("py3Dmol")
-def draw_mapping_on_3Dstructure(
+def show_3D_mapping(
     mapping: AtomMapping,
     spheres: Optional[bool] = True,
     show_atomIDs: Optional[bool] = False,

--- a/openfe/utils/visualization_3D.py
+++ b/openfe/utils/visualization_3D.py
@@ -1,0 +1,112 @@
+import py3Dmol
+import numpy as np
+from typing import Tuple
+
+
+from rdkit import Chem
+from rdkit.Geometry.rdGeometry import Point3D
+from matplotlib import pyplot as plt
+from matplotlib.colors import rgb2hex
+
+from gufe.mapping import AtomMapping
+
+
+def draw_mapping_on_3Dstructure(
+    edge: AtomMapping,
+    spheres: bool = True,
+    show_atomIDs: bool = False,
+    style: str = "stick",
+    shift: Tuple[float, float, float] = np.array([10, 0, 0]),
+) -> py3Dmol.view:
+    """
+    Render relative transformation edge in 3D using py3Dmol.
+
+    By default matching atoms will be annotated using colored spheres.
+
+    Parameters
+    ----------
+    edge : LigandAtomMapping
+        The ligand transformation edge to visualize.
+    spheres : bool
+        Whether or not to show matching atoms as spheres.
+    style : str
+        Style in which to represent the molecules in py3Dmol.
+    shift : Tuple of floats
+        Amount to shift molB by in order to visualise the two ligands.
+        By default molB is shifted by 10 A in the z direction.
+
+    Returns
+    -------
+    view : py3Dmol.view
+        View of the system containing both molecules in the edge.
+    """
+
+    def translate(mol, shift):
+        conf = mol.GetConformer()
+        for i, atom in enumerate(mol.GetAtoms()):
+            x, y, z = conf.GetAtomPosition(i)
+            point = Point3D(x + shift[0], y + shift[1], z + shift[2])
+            conf.SetAtomPosition(i, point)
+        return mol
+
+    def add_spheres(view, mol1, mol2, mapping):
+        # Get colourmap of size mapping
+        cmap = plt.cm.get_cmap("hsv", len(mapping))
+        for i, pair in enumerate(mapping.items()):
+            p1 = mol1.GetConformer().GetAtomPosition(pair[0])
+            p2 = mol2.GetConformer().GetAtomPosition(pair[1])
+            color = rgb2hex(cmap(i))
+            view.addSphere(
+                {
+                    "center": {"x": p1.x, "y": p1.y, "z": p1.z},
+                    "radius": 0.6,
+                    "color": color,
+                    "alpha": 0.8,
+                }
+            )
+            view.addSphere(
+                {
+                    "center": {"x": p2.x, "y": p2.y, "z": p2.z},
+                    "radius": 0.6,
+                    "color": color,
+                    "alpha": 0.8,
+                }
+            )
+
+    molA = edge.componentA.to_rdkit()
+    molB = edge.componentB.to_rdkit()
+
+    mblock1 = Chem.MolToMolBlock(translate(molA, -1 * shift))
+    mblock2 = Chem.MolToMolBlock(translate(molB, shift))
+
+    view = py3Dmol.view(width=600, height=600)
+    view.addModel(mblock1, "molA")
+    view.addModel(mblock2, "molB")
+
+    if spheres:
+        add_spheres(view, molA, molB, edge.componentA_to_componentB)
+
+    if show_atomIDs:
+        view.addPropertyLabels(
+            "index",
+            {"not": {"resn": ["molA_overlay", "molA_overlay"]}},
+            {
+                "fontColor": "black",
+                "font": "sans-serif",
+                "fontSize": "10",
+                "showBackground": "false",
+                "alignment": "center",
+            },
+        )
+
+    # middle fig
+    overlay_mblock1 = Chem.MolToMolBlock(translate(molA, 1 * shift))
+    overlay_mblock2 = Chem.MolToMolBlock(translate(molB, -1 * shift))
+
+    view.addModel(overlay_mblock1, "molA_overlay")
+    view.addModel(overlay_mblock2, "molB_overlay")
+
+    view.setStyle({style: {}})
+
+    view.zoomTo()
+    return view


### PR DESCRIPTION
Here the visualization functions are added in order to visualize the mapping in 3D.

new dependency: py3DMol

New feature:
```
lomap_mapper = LomapAtomMapper()
lomap_mapping = next(lomap_mapper.suggest_mappings(SmallMoleculeComponent(molA) , SmallMoleculeComponent(molB)))
lomap_mapping.show_mapping3D()

```
![image](https://user-images.githubusercontent.com/12428005/215092774-c8dd26b1-77e0-4316-83df-6268fa128aed.png)


