### PR TITLE
Silence root logging (on perses imports)

### DIFF
--- a/openfe/setup/atom_mapping/perses_mapper.py
+++ b/openfe/setup/atom_mapping/perses_mapper.py
@@ -9,8 +9,12 @@ The MCS class from Perses shamelessly wrapped and used here to match our API.
 from openmm import unit
 from openfe.utils import requires_package
 
+from ...utils.silence_root_logging import silence_root_logging
 try:
-    from perses.rjmc.atom_mapping import AtomMapper, InvalidMappingException
+    with silence_root_logging():
+        from perses.rjmc.atom_mapping import (
+            AtomMapper, InvalidMappingException
+        )
 except ImportError:
     pass    # Don't throw  error, will happen later
 

--- a/openfe/setup/atom_mapping/perses_scorers.py
+++ b/openfe/setup/atom_mapping/perses_scorers.py
@@ -5,8 +5,10 @@ from typing import Callable
 
 from openfe.utils import requires_package
 
+from ...utils.silence_root_logging import silence_root_logging
 try:
-    from perses.rjmc.atom_mapping import AtomMapper, AtomMapping
+    with silence_root_logging():
+        from perses.rjmc.atom_mapping import AtomMapper, AtomMapping
 except ImportError:
     pass    # Don't throw  error, will happen later
 

--- a/openfe/tests/setup/atom_mapping/test_perses_scorers.py
+++ b/openfe/tests/setup/atom_mapping/test_perses_scorers.py
@@ -10,7 +10,9 @@ from openfe.setup import perses_scorers
 
 pytest.importorskip('perses')
 pytest.importorskip('openeye')
-from perses.rjmc.atom_mapping import AtomMapper, AtomMapping
+from ....utils.silence_root_logging import silence_root_logging
+with silence_root_logging():
+    from perses.rjmc.atom_mapping import AtomMapper, AtomMapping
 
 USING_OLD_OFF = False
 

--- a/openfe/utils/silence_root_logging.py
+++ b/openfe/utils/silence_root_logging.py
@@ -1,4 +1,5 @@
 import contextlib
+import logging
 
 @contextlib.contextmanager
 def silence_root_logging():
@@ -7,8 +8,7 @@ def silence_root_logging():
     a.k.a, "Why are you using basicConfig during import -- or in library
     code at all?"
     """
-    import logging
-    root = logger.getLogger()
+    root = logging.getLogger()
     old_handlers = root.handlers
     for handler in old_handlers:
         root.removeHandler(handler)

--- a/openfe/utils/silence_root_logging.py
+++ b/openfe/utils/silence_root_logging.py
@@ -1,0 +1,24 @@
+import contextlib
+
+@contextlib.contextmanager
+def silence_root_logging():
+    """Context manager to silence logging from root logging handlers.
+
+    a.k.a, "Why are you using basicConfig during import -- or in library
+    code at all?"
+    """
+    import logging
+    root = logger.getLogger()
+    old_handlers = root.handlers
+    for handler in old_handlers:
+        root.removeHandler(handler)
+
+    null = logging.NullHandler()
+    root.addHandler(null)
+    yield
+    root.removeHandler(null)
+    for handler in old_handlers:
+        root.addHandler(handler)
+
+
+


### PR DESCRIPTION
This provides a context manager intended to wrap imports that use `logging.basicConfig`.

`logging.basicConfig` is aimed at users. Libraries shouldn't use it. This temporarily attaches a handler to the root logger (which makes `basicConfig` a no-op). It then resets the root logger handlers, in case someone in user-land had set them previously.

I haven't tested that this fixes annoyances of overly-verbose logging (specifically due to perses) while waiting for the upstream fix to be released; but this should be a solution.