### PR TITLE
Get plugcli from conda-forge

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -23,12 +23,12 @@ dependencies:
   - openmmforcefields>=0.11.2
   - perses
   - py3dmol
+  - plugcli
   # docs
   - myst-parser
   - sphinx-click
   # - gufe==0.5
   - pip:
-    - plugcli
     - git+https://github.com/OpenFreeEnergy/gufe@main
     - git+https://github.com/mikemhenry/openff-models.git@support_nested_models
     


### PR DESCRIPTION
I didn’t even know I had put plugcli on conda-forge until I did a PyPI release today to fix a problem that @RiesBen caught — got the conda forge notification to release there, too.

also, first attempt at a PR 100% done in mobile while on a train. Hope it works!