### PR TITLE
Pin libnetcdf to avoid current failures

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -24,6 +24,7 @@ dependencies:
   - perses
   - py3dmol
   - plugcli
+  - libnetcdf<4.9
   # docs
   - myst-parser
   - sphinx-click


### PR DESCRIPTION
Tests are currently failing on some complaint about filters from netcdf. I'm guessing this is `libnetcdf` / `hdf5` incompatibility. In particular, the fail happens when we go:

* `hdf5` 1.12.2 => 1.14.0
* `libnetcdf` 4.8.1 => 4.9.1


<details>
<summary>Full diff between passing and failing commits in here</summary>

```diff
10c10
< ambertools                22.0            py310h206695f_3    conda-forge
---
> ambertools                22.0            py310h50827f7_4    conda-forge
43,44c43,44
< boost                     1.74.0          py310h7c3ba0c_5    conda-forge
< boost-cpp                 1.74.0               h75c5d50_8    conda-forge
---
> boost                     1.78.0          py310hc4a4660_4    conda-forge
> boost-cpp                 1.78.0               h75c5d50_1    conda-forge
64c64
< coverage                  7.2.1           py310h1fa729e_0    conda-forge
---
> coverage                  7.2.2           py310h1fa729e_0    conda-forge
111,112c111,112
< hdf4                      4.2.15               h9772cbc_5    conda-forge
< hdf5                      1.12.2          nompi_h4df4325_101    conda-forge
---
> hdf4                      4.2.15               h501b40f_6    conda-forge
> hdf5                      1.14.0          nompi_hb72d44e_103    conda-forge
129d128
< jpeg                      9e                   h0b41bf4_3    conda-forge
144c143
< lcms2                     2.15                 hfd0df8a_0    conda-forge
---
> lcms2                     2.15                 haa2dc70_1    conda-forge
177a177
> libjpeg-turbo             2.1.5.1              h0b41bf4_0    conda-forge
181c181
< libnetcdf                 4.8.1           nompi_h261ec11_106    conda-forge
---
> libnetcdf                 4.9.1           nompi_hf3f8848_103    conda-forge
197c197
< libtiff                   4.5.0                h6adf6a1_2    conda-forge
---
> libtiff                   4.5.0                hddfeb54_5    conda-forge
241,242c241,242
< netcdf-fortran            4.6.0           nompi_he1eeb6f_102    conda-forge
< netcdf4                   1.6.2           nompi_py310h55e1e36_100    conda-forge
---
> netcdf-fortran            4.6.0           nompi_h6fc414f_104    conda-forge
> netcdf4                   1.6.3           nompi_py310hfec4f3c_101    conda-forge
257c257
< openfe                    0.post1+gcebbaac           dev_0    <develop>
---
> openfe                    0.post1+g202da4a           dev_0    <develop>
294c294
< pillow                    9.4.0           py310h023d228_1    conda-forge
---
> pillow                    9.4.0           py310h065c6d2_2    conda-forge
327c327
< pytables                  3.7.0           py310hb60b9b2_3    conda-forge
---
> pytables                  3.7.0           py310hde6a235_4    conda-forge
341c341
< qt-main                   5.15.8               h5d23da1_6    conda-forge
---
> qt-main                   5.15.8               h67dfc38_7    conda-forge
345c345
< rdkit                     2022.09.1       py310h10c98a6_0    conda-forge
---
> rdkit                     2022.09.5       py310h7988725_0    conda-forge
421a422
> xorg-xf86vidmodeproto     2.3.1             h7f98852_1002    conda-forge
```

</details>