### PR TITLE
Add platform warning for non CUDA selection

### DIFF
--- a/openfe/protocols/openmm_rbfe/_rbfe_utils/compute.py
+++ b/openfe/protocols/openmm_rbfe/_rbfe_utils/compute.py
@@ -1,4 +1,12 @@
-# A copy of Perses' perses.app.setup_relative_calculation.get_openmm_platform
+# This code is part of OpenFE and is licensed under the MIT license.
+# For details, see https://github.com/OpenFreeEnergy/openfe
+# Adapted Perses' perses.app.setup_relative_calculation.get_openmm_platform
+import warnings
+import logging
+
+
+logger = logging.getLogger(__name__)
+
 
 def get_openmm_platform(platform_name=None):
     """
@@ -29,8 +37,14 @@ def get_openmm_platform(platform_name=None):
     if name in ['CUDA', 'OpenCL']:
         platform.setPropertyDefaultValue(
                 'Precision', 'mixed')
-    if name in ['CUDA']:
+    if name == 'CUDA':
         platform.setPropertyDefaultValue(
                 'DeterministicForces', 'true')
+
+    if name != 'CUDA':
+        wmsg = (f"Non-GPU platform selected: {name}, this may significantly "
+                "impact simulation performance")
+        warnings.warn(wmsg)
+        logging.warning(wmsg)
 
     return platform

--- a/openfe/tests/protocols/test_openmm_equil_rfe_protocols.py
+++ b/openfe/tests/protocols/test_openmm_equil_rfe_protocols.py
@@ -21,6 +21,11 @@ from openmmforcefields.generators import SMIRNOFFTemplateGenerator
 from openff.units.openmm import ensure_quantity
 
 
+def test_compute_platform_warn():
+    with pytest.warns(UserWarning, match="Non-GPU platform selected: CPU"):
+        openmm_rbfe._rbfe_utils.compute.get_openmm_platform('CPU')
+
+
 def test_append_topology(benzene_complex_system, toluene_complex_system):
     mod = app.Modeller(
         benzene_complex_system['protein'].to_openmm_topology(),


### PR DESCRIPTION
Fixes #283 

We won't make the compute engine CUDA by default, but we'll raise a warning.