### PR TITLE
Don't exclude py3.10 macos runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,9 +29,6 @@ jobs:
         python-version:
           - "3.9"
           - "3.10"
-        exclude:
-          - os: 'macos'
-            python-version: '3.10'
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,10 +29,7 @@ jobs:
         python-version:
           - "3.9"
           - "3.10"
-          - "3.11"
         exclude:
-          - os: 'macos'
-            python-version: "3.10"
           - os: 'macos'
             python-version: "3.9"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,12 @@ jobs:
         python-version:
           - "3.9"
           - "3.10"
+          - "3.11"
+        exclude:
+          - os: 'macos'
+            python-version: "3.10"
+          - os: 'macos'
+            python-version: "3.9"
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
With OpenMM 8 out, this should be ok to do now.