### PR TITLE
Swap LangevinSplittingDynamicMove to LangevinDynamicsMove

### DIFF
--- a/openfe/protocols/openmm_rfe/equil_rfe_methods.py
+++ b/openfe/protocols/openmm_rfe/equil_rfe_methods.py
@@ -589,7 +589,6 @@ class RelativeHybridTopologyProtocolUnit(gufe.ProtocolUnit):
             reassign_velocities=integrator_settings.reassign_velocities,
             n_restart_attempts=integrator_settings.n_restart_attempts,
             constraint_tolerance=integrator_settings.constraint_tolerance,
-            splitting=integrator_settings.splitting
         )
 
         # 12. Create sampler

--- a/openfe/protocols/openmm_rfe/equil_rfe_methods.py
+++ b/openfe/protocols/openmm_rfe/equil_rfe_methods.py
@@ -582,7 +582,7 @@ class RelativeHybridTopologyProtocolUnit(gufe.ProtocolUnit):
         integrator_settings = protocol_settings.integrator_settings
 
         #  b. create langevin integrator
-        integrator = openmmtools.mcmc.LangevinSplittingDynamicsMove(
+        integrator = openmmtools.mcmc.LangevinDynamicsMove(
             timestep=to_openmm(integrator_settings.timestep),
             collision_rate=to_openmm(integrator_settings.collision_rate),
             n_steps=integrator_settings.n_steps.m,

--- a/openfe/protocols/openmm_rfe/equil_rfe_settings.py
+++ b/openfe/protocols/openmm_rfe/equil_rfe_settings.py
@@ -277,11 +277,6 @@ class IntegratorSettings(settings.SettingsBaseModel):
     If True, velocities are reassigned from the Maxwell-Boltzmann
     distribution at the beginning of move. Default False.
     """
-    splitting = "V R O R V"
-    """
-    Sequence of "R", "V", "O" substeps to be carried out at each timestep.
-    Default "V R O R V".
-    """
     n_restart_attempts = 20
     """
     Number of attempts to restart from Context if there are NaNs in the

--- a/openfe/tests/protocols/test_rfe_tokenization.py
+++ b/openfe/tests/protocols/test_rfe_tokenization.py
@@ -39,8 +39,8 @@ class TestRelativeHybridTopologyProtocolResult(GufeTokenizableTestsMixin):
 
 class TestRelativeHybridTopologyProtocol(GufeTokenizableTestsMixin):
     cls = openmm_rfe.RelativeHybridTopologyProtocol
-    key = "RelativeHybridTopologyProtocol-792d6407576c6d17d6d35800fd8eeada"
-    repr = "<RelativeHybridTopologyProtocol-792d6407576c6d17d6d35800fd8eeada>"
+    key = "RelativeHybridTopologyProtocol-beef0967b5182aea82a41ba825f1d3e2"
+    repr = "<RelativeHybridTopologyProtocol-beef0967b5182aea82a41ba825f1d3e2>"
 
     @pytest.fixture()
     def instance(self, protocol):


### PR DESCRIPTION
I believe perses did this at some point last year: https://github.com/choderalab/perses/blob/main/perses/app/setup_relative_calculation.py

Performance-wise it yields:
- ~ 5-6x speed up in vacuum calcs
- ~ 50% performance increase in solvent calcs
- ~ couple % in complex calcs 

## Validation

To check that everything runs fine, I did a comparison of the benzenes RHFE set. When comparing DDGs between v0.6 and a hypothetical v0.8 with this integrator swap, we find all values to be within error of each other.

![DDG](https://user-images.githubusercontent.com/12460125/233888235-b1b1c148-7505-4f25-92bb-a09aa74be9b1.png)


We do note however, that when comparing just the gas phase results, one of the edges has a > 1 kcal/mol deviation. This however turns out to not be linked to this integrator swap, but the change from HMR using 3.0 amu to 4.0 amu (results not shown, but effectively if I change the mass this deviation goes away). The error cancels out so it's fine here, but it's something we should be careful about (see #363) especially when we do AFEs.

![DG-vacuum](https://user-images.githubusercontent.com/12460125/233890862-723b3b7e-4ef7-47f8-9850-e6e0ac1c5bc9.png)

(scales make it hard to see, but the red data point is what you're looking at above)