### PR TITLE
Cleanup contexts upon calculation completion, failure

### DIFF
--- a/openfe/protocols/openmm_rfe/_rfe_utils/multistate.py
+++ b/openfe/protocols/openmm_rfe/_rfe_utils/multistate.py
@@ -287,10 +287,13 @@ def minimize(thermodynamic_state: states.ThermodynamicState, sampler_state: stat
     context, integrator = cache.global_context_cache.get_context(
         thermodynamic_state, integrator
     )
-    sampler_state.apply_to_context(
-        context, ignore_velocities=True
-    )
-    openmm.LocalEnergyMinimizer.minimize(
-        context, maxIterations=max_iterations
-    )
-    sampler_state.update_from_context(context)
+    try:
+        sampler_state.apply_to_context(
+            context, ignore_velocities=True
+        )
+        openmm.LocalEnergyMinimizer.minimize(
+            context, maxIterations=max_iterations
+        )
+        sampler_state.update_from_context(context)
+    finally:
+        del context, integrator

--- a/openfe/protocols/openmm_rfe/equil_rfe_methods.py
+++ b/openfe/protocols/openmm_rfe/equil_rfe_methods.py
@@ -693,7 +693,7 @@ class RelativeHybridTopologyProtocolUnit(gufe.ProtocolUnit):
             # cautiously clear out the global context cache too
             for context in list(
                     openmmtools.cache.global_context_cache._lru._data.keys()):
-                del cache.global_context_cache._lru._data[context]
+                del openmmtools.cache.global_context_cache._lru._data[context]
 
             del sampler_context_cache, energy_context_cache
             if not dry:

--- a/openfe/protocols/openmm_rfe/equil_rfe_methods.py
+++ b/openfe/protocols/openmm_rfe/equil_rfe_methods.py
@@ -628,6 +628,7 @@ class RelativeHybridTopologyProtocolUnit(gufe.ProtocolUnit):
             lambda_protocol=lambdas,
             temperature=to_openmm(protocol_settings.thermo_settings.temperature),
             endstates=alchem_settings.unsampled_endstates,
+            minimization_platform=platform.getName(),
         )
 
         try:

--- a/openfe/protocols/openmm_rfe/equil_rfe_methods.py
+++ b/openfe/protocols/openmm_rfe/equil_rfe_methods.py
@@ -632,7 +632,6 @@ class RelativeHybridTopologyProtocolUnit(gufe.ProtocolUnit):
 
         try:
             # Create context caches (energy + sampler)
-            #     Note: these needs to exist on the compute node
             energy_context_cache = openmmtools.cache.ContextCache(
                 capacity=None, time_to_live=None, platform=platform,
             )
@@ -680,11 +679,15 @@ class RelativeHybridTopologyProtocolUnit(gufe.ProtocolUnit):
         finally:
             # close reporter when you're done, prevent file handle clashes
             reporter.close()
+            del reporter
+
+            # clean up the analyzer
+            if not dry:
+                ana.clear()
+                del ana
 
             # clear GPU contexts
-            #energy_context_cache.empty()
-            #sampler_context_cache.empty()
-            # TODO: remove once upstream solution in place: https://github.com/choderalab/openmmtools/pull/690
+            # TODO: use cache.empty() calls when openmmtools #690 is resolved
             # replace with above
             for context in list(energy_context_cache._lru._data.keys()):
                 del energy_context_cache._lru._data[context]

--- a/openfe/protocols/openmm_rfe/equil_rfe_methods.py
+++ b/openfe/protocols/openmm_rfe/equil_rfe_methods.py
@@ -688,9 +688,9 @@ class RelativeHybridTopologyProtocolUnit(gufe.ProtocolUnit):
             # TODO: remove once upstream solution in place: https://github.com/choderalab/openmmtools/pull/690
             # replace with above
             for context in list(energy_context_cache._data.keys()):
-                del self._data[context]
+                del self._lru._data[context]
             for context in list(sampler_context_cache._data.keys()):
-                del self._data[context]
+                del self._lru._data[context]
 
             del sampler_context_cache, energy_context_cache
             del integrator, sampler

--- a/openfe/protocols/openmm_rfe/equil_rfe_methods.py
+++ b/openfe/protocols/openmm_rfe/equil_rfe_methods.py
@@ -688,9 +688,9 @@ class RelativeHybridTopologyProtocolUnit(gufe.ProtocolUnit):
             # TODO: remove once upstream solution in place: https://github.com/choderalab/openmmtools/pull/690
             # replace with above
             for context in list(energy_context_cache._lru._data.keys()):
-                del self._lru._data[context]
+                del energy_context_cache._lru._data[context]
             for context in list(sampler_context_cache._lru._data.keys()):
-                del self._lru._data[context]
+                del sampler_context_cache._lru._data[context]
 
             del sampler_context_cache, energy_context_cache
             del integrator, sampler

--- a/openfe/protocols/openmm_rfe/equil_rfe_methods.py
+++ b/openfe/protocols/openmm_rfe/equil_rfe_methods.py
@@ -687,9 +687,9 @@ class RelativeHybridTopologyProtocolUnit(gufe.ProtocolUnit):
             #sampler_context_cache.empty()
             # TODO: remove once upstream solution in place: https://github.com/choderalab/openmmtools/pull/690
             # replace with above
-            for context in list(energy_context_cache._data.keys()):
+            for context in list(energy_context_cache._lru._data.keys()):
                 del self._lru._data[context]
-            for context in list(sampler_context_cache._data.keys()):
+            for context in list(sampler_context_cache._lru._data.keys()):
                 del self._lru._data[context]
 
             del sampler_context_cache, energy_context_cache

--- a/openfe/protocols/openmm_rfe/equil_rfe_methods.py
+++ b/openfe/protocols/openmm_rfe/equil_rfe_methods.py
@@ -81,13 +81,7 @@ class RelativeHybridTopologyProtocolResult(gufe.ProtocolResult):
           a Quantity defined with units.
         """
         # TODO: Check this holds up completely for SAMS.
-        # this v
-        dGs = []
-        for pus in self.data.values():
-            dGs.extend([pu.outputs['unit_estimate'] for pu in pus])
-
-        # not this v
-        #dGs = [pus[0].outputs['unit_estimate'] for pus in self.data.values()]
+        dGs = [pus[0].outputs['unit_estimate'] for pus in self.data.values()]
         u = dGs[0].u
         # convert all values to units of the first value, then take average of magnitude
         # this would avoid a screwy case where each value was in different units
@@ -97,13 +91,7 @@ class RelativeHybridTopologyProtocolResult(gufe.ProtocolResult):
 
     def get_uncertainty(self):
         """The uncertainty/error in the dG value: The std of the estimates of each independent repeat"""
-        # this v
-        dGs = []
-        for pus in self.data.values():
-            dGs.extend([pu.outputs['unit_estimate'] for pu in pus])
-
-        # not this v
-        #dGs = [pus[0].outputs['unit_estimate'] for pus in self.data.values()]
+        dGs = [pus[0].outputs['unit_estimate'] for pus in self.data.values()]
         u = dGs[0].u
         # convert all values to units of the first value, then take average of magnitude
         # this would avoid a screwy case where each value was in different units


### PR DESCRIPTION
This adds calls to `ContextCache.empty` at the end of repex execution, or in the case of execution failure, to avoid leaving behind stale contexts. This can be important for long-running processes executing multiple `ProtocolDAG`s in sequence.
