### PR TITLE
Fixes ProtocolResult aggregation for get_estimate, get_uncertainty

### DIFF
--- a/openfe/protocols/openmm_rfe/equil_rfe_methods.py
+++ b/openfe/protocols/openmm_rfe/equil_rfe_methods.py
@@ -81,7 +81,13 @@ class RelativeHybridTopologyProtocolResult(gufe.ProtocolResult):
           a Quantity defined with units.
         """
         # TODO: Check this holds up completely for SAMS.
-        dGs = [pus[0].outputs['unit_estimate'] for pus in self.data.values()]
+        # this v
+        dGs = []
+        for pus in self.data.values():
+            dGs.extend([pu.outputs['unit_estimate'] for pu in pus])
+
+        # not this v
+        #dGs = [pus[0].outputs['unit_estimate'] for pus in self.data.values()]
         u = dGs[0].u
         # convert all values to units of the first value, then take average of magnitude
         # this would avoid a screwy case where each value was in different units
@@ -91,7 +97,13 @@ class RelativeHybridTopologyProtocolResult(gufe.ProtocolResult):
 
     def get_uncertainty(self):
         """The uncertainty/error in the dG value: The std of the estimates of each independent repeat"""
-        dGs = [pus[0].outputs['unit_estimate'] for pus in self.data.values()]
+        # this v
+        dGs = []
+        for pus in self.data.values():
+            dGs.extend([pu.outputs['unit_estimate'] for pu in pus])
+
+        # not this v
+        #dGs = [pus[0].outputs['unit_estimate'] for pus in self.data.values()]
         u = dGs[0].u
         # convert all values to units of the first value, then take average of magnitude
         # this would avoid a screwy case where each value was in different units

--- a/openfe/protocols/openmm_rfe/equil_rfe_methods.py
+++ b/openfe/protocols/openmm_rfe/equil_rfe_methods.py
@@ -81,13 +81,10 @@ class RelativeHybridTopologyProtocolResult(gufe.ProtocolResult):
           a Quantity defined with units.
         """
         # TODO: Check this holds up completely for SAMS.
-        # this v
         dGs = []
         for pus in self.data.values():
             dGs.extend([pu.outputs['unit_estimate'] for pu in pus])
 
-        # not this v
-        #dGs = [pus[0].outputs['unit_estimate'] for pus in self.data.values()]
         u = dGs[0].u
         # convert all values to units of the first value, then take average of magnitude
         # this would avoid a screwy case where each value was in different units
@@ -97,13 +94,10 @@ class RelativeHybridTopologyProtocolResult(gufe.ProtocolResult):
 
     def get_uncertainty(self):
         """The uncertainty/error in the dG value: The std of the estimates of each independent repeat"""
-        # this v
         dGs = []
         for pus in self.data.values():
             dGs.extend([pu.outputs['unit_estimate'] for pu in pus])
 
-        # not this v
-        #dGs = [pus[0].outputs['unit_estimate'] for pus in self.data.values()]
         u = dGs[0].u
         # convert all values to units of the first value, then take average of magnitude
         # this would avoid a screwy case where each value was in different units


### PR DESCRIPTION
When gathering multiple independent `ProtocolDAGResult`s, we need to gather up estimates from all the `ProtocolUnitResult`s under each repeat index, not just the first one.
