### PR TITLE
Remove test skipping

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,6 +66,8 @@ jobs:
         env:
           # Set the OFE_SLOW_TESTS to True if running a Cron job
           OFE_SLOW_TESTS: ${{ fromJSON('{"false":"false","true":"true"}')[github.event_name == 'schedule'] }}
+          # Run tests that fail when called with pyargs
+          SKIP_SOME_TESTS: FALSE
         run: |
           pytest -n auto -v --cov=openfe --cov=openfecli --cov-report=xml
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,8 +66,6 @@ jobs:
         env:
           # Set the OFE_SLOW_TESTS to True if running a Cron job
           OFE_SLOW_TESTS: ${{ fromJSON('{"false":"false","true":"true"}')[github.event_name == 'schedule'] }}
-          # Run tests that fail when called with pyargs
-          SKIP_SOME_TESTS: FALSE
         run: |
           pytest -n auto -v --cov=openfe --cov=openfecli --cov-report=xml
 

--- a/.github/workflows/installer.yaml
+++ b/.github/workflows/installer.yaml
@@ -61,7 +61,7 @@ jobs:
         chmod +x ${{ steps.file-name.outputs.FILE_NAME }}
         ./${{ steps.file-name.outputs.FILE_NAME }} -b
         export PATH="$HOME/openfeforge/bin:$PATH"
-        OFE_DOCKER_BUILD=TRUE OFE_SLOW_TESTS=FALSE pytest -v --pyargs openfe pytest -v --pyargs openfe
+        OFE_SLOW_TESTS=FALSE pytest -v --pyargs openfe pytest -v --pyargs openfe
 
     - uses: actions/upload-artifact@v3
       with:

--- a/openfe/tests/storage/test_resultclient.py
+++ b/openfe/tests/storage/test_resultclient.py
@@ -199,7 +199,6 @@ class TestResultClient(_ResultContainerTest):
                                                 "store_transformation",
                                                 "load_transformation")
 
-    @pytest.mark.skipif(os.getenv("SKIP_SOME_TESTS", default="TRUE").upper() == "TRUE", reason="Test fails in docker image, see issue #342")
     @pytest.mark.parametrize("fixture", ["benzene_variants_star_map"])
     def test_store_load_network_same_process(self, request, fixture):
         network = request.getfixturevalue(fixture)
@@ -207,7 +206,6 @@ class TestResultClient(_ResultContainerTest):
                                            "store_network",
                                            "load_network")
 
-    @pytest.mark.skipif(os.getenv("SKIP_SOME_TESTS", default="TRUE").upper() == "TRUE", reason="Test fails in docker image, see issue #342")
     @pytest.mark.parametrize("fixture", ["benzene_variants_star_map"])
     def test_store_load_network_different_process(self, request, fixture):
         network = request.getfixturevalue(fixture)

--- a/openfe/tests/storage/test_resultclient.py
+++ b/openfe/tests/storage/test_resultclient.py
@@ -199,7 +199,7 @@ class TestResultClient(_ResultContainerTest):
                                                 "store_transformation",
                                                 "load_transformation")
 
-    @pytest.mark.skipif(os.getenv("OFE_DOCKER_BUILD", default="false").upper() == "TRUE", reason="Test fails in docker image, see issue #342")
+    @pytest.mark.skipif(os.getenv("SKIP_SOME_TESTS", default="TRUE").upper() == "TRUE", reason="Test fails in docker image, see issue #342")
     @pytest.mark.parametrize("fixture", ["benzene_variants_star_map"])
     def test_store_load_network_same_process(self, request, fixture):
         network = request.getfixturevalue(fixture)
@@ -207,7 +207,7 @@ class TestResultClient(_ResultContainerTest):
                                            "store_network",
                                            "load_network")
 
-    @pytest.mark.skipif(os.getenv("OFE_DOCKER_BUILD", default="false").upper() == "TRUE", reason="Test fails in docker image, see issue #342")
+    @pytest.mark.skipif(os.getenv("SKIP_SOME_TESTS", default="TRUE").upper() == "TRUE", reason="Test fails in docker image, see issue #342")
     @pytest.mark.parametrize("fixture", ["benzene_variants_star_map"])
     def test_store_load_network_different_process(self, request, fixture):
         network = request.getfixturevalue(fixture)

--- a/production/Dockerfile
+++ b/production/Dockerfile
@@ -7,8 +7,6 @@ LABEL org.opencontainers.image.licenses=MIT
 # Don't buffer stdout & stderr streams, so if there is a crash no partial buffer output is lost
 # https://docs.python.org/3/using/cmdline.html#cmdoption-u
 ENV PYTHONUNBUFFERED=1
-# We can use this to check if we are in a docker image
-ENV OFE_DOCKER_BUILD=TRUE
 
 COPY --chown=$MAMBA_USER:$MAMBA_USER production/environment.yml /tmp/env.yaml
 COPY --chown=$MAMBA_USER:$MAMBA_USER dist/*py3-none-any.whl /tmp


### PR DESCRIPTION
Liked we talked about, this should make skipping the tests that fail when called with `--pyargs` the default, but our CI "opts in" to running the tests so they are still tested, but when end-users run the tests, everything passes since the tests will be skipped. 
