### PR TITLE
Fix analyzer cleaning up scope issues

### DIFF
--- a/openfe/protocols/openmm_rfe/equil_rfe_methods.py
+++ b/openfe/protocols/openmm_rfe/equil_rfe_methods.py
@@ -564,7 +564,7 @@ class RelativeHybridTopologyProtocolUnit(gufe.ProtocolUnit):
                 sim_settings.output_indices
         )
 
-        #  a. Create the multistate reporter & associated analyzer
+        #  a. Create the multistate reporter
         reporter = multistate.MultiStateReporter(
             storage=shared_basepath / sim_settings.output_filename,
             analysis_particle_indices=selection_indices,
@@ -668,9 +668,7 @@ class RelativeHybridTopologyProtocolUnit(gufe.ProtocolUnit):
                 est, _ = ana.get_free_energy()
                 est = (est[0, -1] * ana.kT).in_units_of(omm_unit.kilocalories_per_mole)
                 est = ensure_quantity(est, 'openff')
-                ana.clear()
-                del ana
-                
+                ana.clear()  # clean up cached values
 
                 nc = shared_basepath / sim_settings.output_filename
                 chk = shared_basepath / sim_settings.checkpoint_storage
@@ -681,7 +679,7 @@ class RelativeHybridTopologyProtocolUnit(gufe.ProtocolUnit):
                 for fn in fns:
                     os.remove(fn)
         finally:
-            # close reporter & analyzer when you're done, prevent file handle clashes
+            # close reporter when you're done, prevent file handle clashes
             reporter.close()
             del reporter
 


### PR DESCRIPTION
Fixes #360 

Changes:
- Analyzer clearing is now done immediately after use. We don't move it up higher because the analyzer on init will attempt to read from the reporter, so if we create it too early we're essentially caching an incorrect state (essentially _equilibration_data won't be populated correctly as far as I can tell).
- We aren't del-ing the analyzer because otherwise it'll attempt to del the reporter before we get to it. By calling clear and then del-ing the reporter directly we're essentially doing everything that `def __del__` does anyways. Let's just let the garbage collector do the rest of the work.