### PR TITLE
`test` CLI command

### DIFF
--- a/openfecli/commands/test.py
+++ b/openfecli/commands/test.py
@@ -1,0 +1,40 @@
+import click
+from openfecli import OFECommandPlugin
+
+import pytest
+import os
+
+from openfecli.utils import write
+
+@click.command(
+    "test",
+    short_help="Run the OpenFE test suite"
+)
+@click.option('--long', is_flag=True, default=False,
+              help="Run additional tests (takes much longer)")
+def test(long):
+    """
+    Run the OpenFE test suite. This first checks that OpenFE is correctly
+    imported, and then runs the main test suite, which should take several
+    minutes. If given the ``--long`` flag, this will include several tests
+    that take significantly longer, but ensure that we're able to fully run
+    in your environment.
+    """
+    default = ["-v"]
+    pyargs = ["--pyargs", "openfe", "--pyargs", "openfecli"]
+    old_env = dict(os.environ)
+    os.environ["OFE_SLOW_TESTS"] = long
+
+    write("Testing can import....")
+    import openfe
+    write("Running the main package tests")
+    pytest.main(["-v", "--pyargs", "openfe", "--pyargs", "openfecli"])
+
+    os.environ.clear()
+    os.environ.update(old_env)
+
+PLUGIN = OFECommandPlugin(
+    test,
+    "hidden",
+    requires_ofe=(0, 7,5)
+)


### PR DESCRIPTION
Just a little start on this. Seems to work for me locally.

A couple of questions:

1. Which "section" of the CLI should this be listed in, if at all? Currently I have it hidden, so it doesn't show in `openfe -h` (it will show its help if you type `openfe test -h`, though). NB: we can also change up the sections we have listed, and I think that's probably a good idea anyway.

2. Do we want to add options to pass through some pytest options, like `-k`? That would make it possible to test, too. Otherwise I'm afraid we'd get into testception.