### PR TITLE
CLI: Remove openfe import required for help

### DIFF
--- a/openfecli/parameters/mapper.py
+++ b/openfecli/parameters/mapper.py
@@ -3,7 +3,6 @@
 
 from plugcli.params import MultiStrategyGetter, Option
 from openfecli.parameters.utils import import_parameter
-from openfe import setup
 
 def _atommapper_from_openfe_setup(user_input, context):
     return import_parameter("openfe.setup." + user_input)
@@ -27,6 +26,5 @@ MAPPER = Option(
     "--mapper",
     getter=get_atommapper,
     help=("Atom mapper; can either be a name in the openfe.setup namespace "
-          "or a custom fully-qualified name.\n"
-          "In the openfe.setup namespace currently following options are possible: "+", ".join([m for m in vars(setup) if "Mapper" in m]))
+          "or a custom fully-qualified name.")
 )


### PR DESCRIPTION
This was a nice try to give users the list of options for atom mappers, but doing this dynamically requires importing `openfe`, which means that things like `--help` and (eventual) tab-autocomplete get massively slowed down.