### PR TITLE
CLI `fetch` command

### DIFF
--- a/openfecli/commands/fetch.py
+++ b/openfecli/commands/fetch.py
@@ -8,7 +8,7 @@ from plugcli.cli import CLI, CONTEXT_SETTINGS
 from openfecli.fetching import FetchablePlugin
 from openfecli import OFECommandPlugin
 
-# MOVE SINGLEMODULEPLUGINLOADER UPSTREAM
+# MOVE SINGLEMODULEPLUGINLOADER UPSTREAM TO PLUGCLI
 import importlib
 from plugcli.plugin_management import CLIPluginLoader
 class SingleModulePluginLoader(CLIPluginLoader):
@@ -28,6 +28,11 @@ class SingleModulePluginLoader(CLIPluginLoader):
 
 
 class FetchCLI(CLI):
+    """Custom command class for the Fetch subcommand.
+
+    This provides the command sections used in help and defines where
+    plugins should be kept.
+    """
     COMMAND_SECTIONS = ["Built-in", "Requires Internet"]
 
     def get_loaders(self):
@@ -57,5 +62,6 @@ PLUGIN = OFECommandPlugin(
 )
 
 if __name__ == "__main__":
+    # it's useful to keep a main here for debugging where problems happen in
+    # the command tree
     fetch()
-

--- a/openfecli/commands/fetch.py
+++ b/openfecli/commands/fetch.py
@@ -1,0 +1,61 @@
+# This code is part of OpenFE and is licensed under the MIT license.
+# For details, see https://github.com/OpenFreeEnergy/openfe
+
+import click
+import urllib
+import shutil
+from plugcli.cli import CLI, CONTEXT_SETTINGS
+from openfecli.fetching import FetchablePlugin
+from openfecli import OFECommandPlugin
+
+# MOVE SINGLEMODULEPLUGINLOADER UPSTREAM
+import importlib
+from plugcli.plugin_management import CLIPluginLoader
+class SingleModulePluginLoader(CLIPluginLoader):
+    """Load plugins from a specific module
+    """
+    def __init__(self, module_name, plugin_class):
+        super().__init__(plugin_type="single_module",
+                         search_path=module_name,
+                         plugin_class=plugin_class)
+
+    def _find_candidates(self):
+        return [importlib.import_module(self.search_path)]
+
+    @staticmethod
+    def _make_nsdict(candidate):
+        return vars(candidate)
+
+
+class FetchCLI(CLI):
+    COMMAND_SECTIONS = ["Built-in", "Requires Internet"]
+
+    def get_loaders(self):
+        return [
+            SingleModulePluginLoader('openfecli.fetchables',
+                                     FetchablePlugin)
+        ]
+
+    def get_installed_plugins(self):
+        loader = self.get_loaders()[0]
+        return list(loader())
+
+@click.command(
+    cls=FetchCLI,
+    short_help="Fetch tutorial or other resource."
+)
+def fetch():
+    """
+    Fetch the given resource. Some resources require internet; others are
+    built-in.
+    """
+
+PLUGIN = OFECommandPlugin(
+    command=fetch,
+    section="Setup",
+    requires_ofe=(0, 7),
+)
+
+if __name__ == "__main__":
+    fetch()
+

--- a/openfecli/fetchables.py
+++ b/openfecli/fetchables.py
@@ -1,0 +1,16 @@
+"""Plugins for the ``fetch`` command"""
+
+from openfecli.fetching import URLFetcher
+
+_EXAMPLE_NB_BASE = ("https://raw.githubusercontent.com/"
+                    "OpenFreeEnergy/ExampleNotebooks/master/")
+
+RHFE_TUTORIAL = URLFetcher(
+    resources=[
+        (_EXAMPLE_NB_BASE + "easyCampaign/molecules/rhfe/",
+         "benzenes_RHFE.sdf")
+    ],
+    short_name="rhfe-cli-tutorial",
+    short_help="CLI tutorial on relative hydration free energies",
+    requires_ofe=(0, 7, 0),
+).plugin

--- a/openfecli/fetchables.py
+++ b/openfecli/fetchables.py
@@ -1,13 +1,13 @@
 """Plugins for the ``fetch`` command"""
 
-from openfecli.fetching import URLFetcher
+from openfecli.fetching import URLFetcher, PkgResourceFetcher
 
 _EXAMPLE_NB_BASE = ("https://raw.githubusercontent.com/"
                     "OpenFreeEnergy/ExampleNotebooks/master/")
 
 RHFE_TUTORIAL = URLFetcher(
     resources=[
-        (_EXAMPLE_NB_BASE + "easyCampaign/molecules/rhfe/",
+        (_EXAMPLE_NB_BASE + "easy_campaign/molecules/rhfe/",
          "benzenes_RHFE.sdf")
     ],
     short_name="rhfe-cli-tutorial",

--- a/openfecli/fetching.py
+++ b/openfecli/fetching.py
@@ -1,0 +1,138 @@
+import click
+from plugcli.plugin_management import CommandPlugin
+
+import urllib.request
+import importlib.resources
+import shutil
+
+import pathlib
+
+class _Fetcher:
+    """Base class for fetchers. Defines the API and plugin creation.
+
+    Parameters
+    ----------
+    resources: Iterable[Tuple[str, str]]
+        resources to be downloaded, as (source, filename)
+    short_name: str
+        name of the command used after openfe fetch
+    short_help: str
+        short help shown in openfe fetch --help
+    long_help: str
+        help shown in openfe fetch short_name --help
+    requires_ofe: Tuple
+        minimum version of OpenFE required
+    """
+    REQUIRES_INTERNET = None
+    def __init__(
+        self,
+        resources,
+        short_name,
+        short_help,
+        requires_ofe,
+        long_help=None
+    ):
+        self._resources = resources
+        self.short_name = short_name
+        self.short_help = short_help
+        self.requires_ofe = requires_ofe
+        self.long_help = long_help
+
+    @property
+    def resources(self):
+        yield from self._resources
+
+    def __call__(self, directory: pathlib.Path):
+        raise NotImplementedError()
+
+    @property
+    def plugin(self):
+        docs = self.long_help or ""
+        docs += "\n\nThis will fetch the following files:\n\n"
+        # if you're getting a problem with unpacking here, you probably
+        # forgot to make resources a list of tuple of (base, filename)
+        for _, filename in self.resources:
+            docs += f"* {filename}\n"
+        @click.command(
+            self.short_name,
+            short_help=self.short_help,
+            help=docs,
+        )
+        @click.option(
+            '-d', '--directory', default='.',
+            help="output directory, defaults to current directory",
+            type=click.Path(file_okay=False, dir_okay=True, writable=True),
+        )
+        def command(directory):
+            directory.mkdir(parents=True, exist_ok=True)
+            self(directory)
+
+        if self.REQUIRES_INTERNET is True:
+            section = "Requires Internet"
+        elif self.REQUIRES_INTERNET is False:
+            section = "Built-in"
+        else:
+            raise RuntimeError("Class must set boolean REQUIRES_INTERNET")
+
+        return FetchablePlugin(
+            command,
+            section,
+            requires_lib=self.requires_ofe,
+            requires_cli=self.requires_ofe
+        )
+
+class URLFetcher(_Fetcher):
+    """Fetcher for URLs.
+
+    Resources should be (base, filename), e.g., ("https://google.com/",
+    "index.html).
+    """
+    REQUIRES_INTERNET = True
+    def __call__(self, dest_dir):
+        for base, filename in self.resources:
+            # let's just prevent one footgun here
+            if not base.endswith('/'):
+                base += "/"
+
+            with urllib.request.urlopen(base + filename) as resp:
+                contents = resp.read()
+
+            with open(dest_dir / filename, mode='wb') as f:
+                f.write(contents)
+
+
+class PkgResourceFetcher(_Fetcher):
+    """Fetcher for data included with the package
+
+    Resources should be (package, filename), e.g., ("openfecli",
+    "__init__.py").
+    """
+    REQUIRES_INTERNET = False
+    def __call__(self, dest_dir):
+        for package, filename in self.resources:
+            ref = importlib.resources.files(package) / filename
+            with importlib.resources.as_file(ref) as f:
+                shutil.copyfile(ref, dest_dir / filename)
+
+
+# should work, but don't want to write tests yet or deal with typing
+# class MixedResourcesFetcher(_Fetcher):
+#     @property
+#     def REQUIRES_INTERNET(self):
+#         return any([fetcher.REQUIRES_INTERNET
+#                     for fetcher in self._resources])
+
+#     @property
+#     def resources(self):
+#         for resource in self._resources:
+#             yield from resource.resources
+
+#     def __call__(self):
+#         for fetcher in self._resources:
+#             fetcher()
+
+
+class FetchablePlugin(CommandPlugin):
+    pass  # separate class for isinstance reasons
+
+

--- a/openfecli/tests/conftest.py
+++ b/openfecli/tests/conftest.py
@@ -1,0 +1,8 @@
+import urllib.request
+
+try:
+    urllib.request.urlopen('https://www.google.com')
+except:  # -no-cov-
+    HAS_INTERNET = False
+else:
+    HAS_INTERNET = True

--- a/openfecli/tests/test_fetchables.py
+++ b/openfecli/tests/test_fetchables.py
@@ -12,7 +12,7 @@ def fetchable_test(fetchable):
     assert isinstance(fetchable, FetchablePlugin)
     expected_paths = [pathlib.Path(f) for f in fetchable.filenames]
     runner = CliRunner()
-    if fetchable.fetcher.REQUIRES_INTERNET and not HAS_INTERNET:
+    if fetchable.fetcher.REQUIRES_INTERNET and not HAS_INTERNET:  # -no-cov-
         pytest.skip("Internet seems to be unavailable")
     with runner.isolated_filesystem():
         result = runner.invoke(fetchable.command, ['-d' 'output-dir'])

--- a/openfecli/tests/test_fetchables.py
+++ b/openfecli/tests/test_fetchables.py
@@ -1,0 +1,25 @@
+import pytest
+from click.testing import CliRunner
+from .conftest import HAS_INTERNET
+import pathlib
+
+from openfecli.fetching import FetchablePlugin
+
+from openfecli.fetchables import RHFE_TUTORIAL
+
+def fetchable_test(fetchable):
+    """Unit test to ensure that a given FetchablePlugin works"""
+    assert isinstance(fetchable, FetchablePlugin)
+    expected_paths = [pathlib.Path(f) for f in fetchable.filenames]
+    runner = CliRunner()
+    if fetchable.fetcher.REQUIRES_INTERNET and not HAS_INTERNET:
+        pytest.skip("Internet seems to be unavailable")
+    with runner.isolated_filesystem():
+        result = runner.invoke(fetchable.command, ['-d' 'output-dir'])
+        assert result.exit_code == 0
+        for path in expected_paths:
+            assert (pathlib.Path("output-dir") / path).exists()
+
+
+def test_rhfe_tutorial():
+    fetchable_test(RHFE_TUTORIAL)

--- a/openfecli/tests/test_fetching.py
+++ b/openfecli/tests/test_fetching.py
@@ -1,6 +1,6 @@
 import pytest
 
-from conftest import HAS_INTERNET
+from .conftest import HAS_INTERNET
 
 from openfecli.fetching import URLFetcher, PkgResourceFetcher
 from openfecli.fetching import FetchablePlugin

--- a/openfecli/tests/test_fetching.py
+++ b/openfecli/tests/test_fetching.py
@@ -1,0 +1,66 @@
+import pytest
+
+from openfecli.fetching import URLFetcher, PkgResourceFetcher
+from openfecli.fetching import FetchablePlugin
+
+class FetcherTester:
+    @pytest.fixture
+    def fetcher(self):
+        raise NotImplementedError()
+
+    def test_resources(self):
+        raise NotImplementedError()
+
+    def test_plugin(self, fetcher):
+        # this is just a smoke test; individual plugins should test that
+        # they work
+        plugin = fetcher.plugin
+        assert isinstance(plugin, FetchablePlugin)
+
+    def test_call(self, fetcher, tmp_path):
+        # Here we just check that the machinery works. Each plugin should
+        # have a test to ensure that we're getting the right kind of file.
+        paths = [tmp_path / filename for _, filename in fetcher.resources]
+        for path in paths:
+            assert not path.exists()
+
+        fetcher(tmp_path)
+
+        for path in paths:
+            assert path.exists()
+
+
+class TestURLFetcher(FetcherTester):
+    @pytest.fixture
+    def fetcher(self):
+        return URLFetcher(
+            resources=[("https://www.google.com/", "index.html")],
+            short_name="google",
+            short_help="The Goog",
+            requires_ofe=(0, 7, 0),
+            long_help="Google, an Alphabet company"
+        )
+
+    def test_resources(self, fetcher):
+        expected = [("https://www.google.com/", "index.html")]
+        assert list(fetcher.resources) == expected
+
+    def test_call(self, fetcher, tmp_path):
+        # TODO skip if no internet
+        super().test_call(fetcher, tmp_path)
+
+class TestPkgResourceFetcher(FetcherTester):
+    @pytest.fixture
+    def fetcher(self):
+        return PkgResourceFetcher(
+            resources=[('openfecli.tests', 'test_fetching.py')],
+            short_name="me",
+            short_help="download this file",
+            requires_ofe=(0, 7, 4),
+            long_help="whoa, meta."
+        )
+
+    def test_resources(self, fetcher):
+        expected = [('openfecli.tests', 'test_fetching.py')]
+        assert list(fetcher.resources) == expected
+

--- a/openfecli/tests/test_fetching.py
+++ b/openfecli/tests/test_fetching.py
@@ -1,5 +1,7 @@
 import pytest
 
+from conftest import HAS_INTERNET
+
 from openfecli.fetching import URLFetcher, PkgResourceFetcher
 from openfecli.fetching import FetchablePlugin
 
@@ -45,9 +47,22 @@ class TestURLFetcher(FetcherTester):
         expected = [("https://www.google.com/", "index.html")]
         assert list(fetcher.resources) == expected
 
+    @pytest.mark.skipif(not HAS_INTERNET,
+                        reason="Internet seems to be unavailable")
     def test_call(self, fetcher, tmp_path):
-        # TODO skip if no internet
         super().test_call(fetcher, tmp_path)
+
+    def test_without_trailing_slash(self, tmp_path):
+        fetcher = URLFetcher(
+            resources=[("https://www.google.com", "index.html")],
+            short_name="goog2",
+            short_help="more goog",
+            requires_ofe=(0, 7, 0),
+            long_help="What if you forget the trailing slash?"
+        )
+
+        self.test_call(fetcher, tmp_path)
+
 
 class TestPkgResourceFetcher(FetcherTester):
     @pytest.fixture


### PR DESCRIPTION
This adds `openfe fetch`, with subcommands to fetch specific materials for tutorials, etc.

New materials can be added to the `fetchables.py` file and will be automatically added.

- [x] URL Fetcher
- [x] Package Resource Fetcher
- [x] Tests for fetchers
- [x] `fetch` command
- [x] tests for `fetch` command
- [x] Plugin for RHFE CLI tutorial
- [x] Tests for RHFE CLI tutorial plugin