### PR TITLE
Install docs: Use Mambaforge

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,9 +13,9 @@ dependencies:
   - pytest-rerunfailures
   - pydantic
   - coverage
-  - openff-toolkit>=0.12.0
+  - openff-toolkit>=0.13.0
   - openff-units>=0.2.0
-  - openff-models>=0.0.4
+  - openff-models>=0.0.5
   - click
   - typing-extensions
   - lomap2>=2.3.0


### PR DESCRIPTION
`micromamba` is not a full replacement for `mamba`/`conda`; it is a subset of commands that misses a lot of the more rarely needed functionality. We should recommend that our users have `mamba` installed. Following the recommendations of `mamba`, I think we should suggest using the `mambaforge` version. Unfortunately, its install instructions are mixed in with a bunch of instructions from other variants (`miniforge`, `mambaforge-pypy3`, etc.) Additionally, adding a table with 5 rows to ask people to select their mambaforge install link seemed like a bit much distraction for our docs.

So I wrote an HTML/Javascript tool that lets people select their OS and hardware architecture, and generates a `curl ... | sh` command to run. I think this gives the docs UX we want.

Still needs:

- [x] a hands-on test (did I typo when I created the command?) (Manually checked that the `curl` command works for all options; ran the mamba install process as given on MacOSX-arm64)
- [ ] better CSS/layout/design, I hope
- [ ] a copy button, so the mambaforge install can be click-and-paste

Checking that the files get downloaded is a hard requirement before merge. CSS and copy would be fun, but aren't required.