### PR TITLE
Fix nesting of shared directory for checkpoint

### DIFF
--- a/openfe/protocols/openmm_rfe/equil_rfe_methods.py
+++ b/openfe/protocols/openmm_rfe/equil_rfe_methods.py
@@ -577,7 +577,7 @@ class RelativeHybridTopologyProtocolUnit(gufe.ProtocolUnit):
             storage=shared_basepath / sim_settings.output_filename,
             analysis_particle_indices=selection_indices,
             checkpoint_interval=sim_settings.checkpoint_interval.m,
-            checkpoint_storage=shared_basepath / sim_settings.checkpoint_storage,
+            checkpoint_storage=sim_settings.checkpoint_storage,
         )
 
         # 10. Get platform

--- a/openfe/tests/protocols/test_openmm_equil_rfe_protocols.py
+++ b/openfe/tests/protocols/test_openmm_equil_rfe_protocols.py
@@ -811,7 +811,7 @@ def set_openmm_threads_1():
             os.environ['OPENMM_CPU_THREADS'] = previous
 
 
-# @pytest.mark.slow
+@pytest.mark.slow
 @pytest.mark.flaky(reruns=3)  # pytest-rerunfailures; we can get bad minimisation
 @pytest.mark.parametrize('platform', ['CPU', 'CUDA'])
 def test_openmm_run_engine(benzene_vacuum_system, platform, available_platforms,

--- a/openfe/tests/protocols/test_openmm_equil_rfe_protocols.py
+++ b/openfe/tests/protocols/test_openmm_equil_rfe_protocols.py
@@ -811,7 +811,7 @@ def set_openmm_threads_1():
             os.environ['OPENMM_CPU_THREADS'] = previous
 
 
-@pytest.mark.slow
+# @pytest.mark.slow
 @pytest.mark.flaky(reruns=3)  # pytest-rerunfailures; we can get bad minimisation
 @pytest.mark.parametrize('platform', ['CPU', 'CUDA'])
 def test_openmm_run_engine(benzene_vacuum_system, platform, available_platforms,

--- a/openfe/tests/protocols/test_openmm_equil_rfe_protocols.py
+++ b/openfe/tests/protocols/test_openmm_equil_rfe_protocols.py
@@ -828,6 +828,7 @@ def test_openmm_run_engine(benzene_vacuum_system, platform, available_platforms,
     s.system_settings.nonbonded_method = 'nocutoff'
     s.alchemical_sampler_settings.n_repeats = 1
     s.engine_settings.compute_platform = platform
+    s.simulation_settings.checkpoint_interval = 5 * unit.timestep
 
     p = openmm_rfe.RelativeHybridTopologyProtocol(s)
 
@@ -838,6 +839,17 @@ def test_openmm_run_engine(benzene_vacuum_system, platform, available_platforms,
                    mapping={'ligand': m})
 
     cwd = pathlib.Path(str(tmpdir))
-    r = execute_DAG(dag, shared_basedir=cwd, scratch_basedir=cwd)
+    r = execute_DAG(dag, shared_basedir=cwd, scratch_basedir=cwd,
+                    keep_shared=True)
 
     assert r.ok()
+    for pur in r.protocol_unit_results:
+        unit_shared = tmpdir / f"shared_{pur.source_key}"
+        assert unit_shared.exists()
+        assert pathlib.Path(unit_shared).is_dir()
+        checkpoint = pur.outputs['last_checkpoint']
+        assert checkpoint == unit_shared / "checkpoint.nc"
+        assert checkpoint.exists()
+        nc = pur.outputs['nc']
+        assert nc == unit_shared / "simulation.nc"
+        assert nc.exists()


### PR DESCRIPTION
Per docs on `MultistateReporter`, ["this should NOT be a full path, and instead just a filename"](https://github.com/choderalab/openmmtools/blob/abd4011f1c756722ab8671097335c0e895f5741f/openmmtools/multistate/multistatereporter.py#L93).

Going to add tests to `test_openmm_run_engine` to check this -- that is the appropriate "moist" test, right?