### PR TITLE
Silence `openmmtools.multistate` API warnings

### DIFF
--- a/openfe/utils/logging_filter.py
+++ b/openfe/utils/logging_filter.py
@@ -1,0 +1,8 @@
+import logging
+
+class MsgIncludesStringFilter:
+    def __init__(self, string):
+        self.string = string
+
+    def filter(self, record):
+        return not self.string in record.msg

--- a/openfe/utils/logging_filter.py
+++ b/openfe/utils/logging_filter.py
@@ -1,6 +1,16 @@
 import logging
 
 class MsgIncludesStringFilter:
+    """Logging filter to silence specfic log messages.
+
+    See https://docs.python.org/3/library/logging.html#filter-objects
+
+    Parameters
+    ----------
+    string : str
+        if an exact for this is included in the log message, the log record
+        is suppressed
+    """
     def __init__(self, string):
         self.string = string
 

--- a/openfecli/commands/quickrun.py
+++ b/openfecli/commands/quickrun.py
@@ -53,6 +53,24 @@ def quickrun(transformation, work_dir, output):
     import os
     from gufe.protocols.protocoldag import execute_DAG
     from gufe.tokenization import JSON_HANDLER
+    from openfe.utils.logging_filter import MsgIncludesStringFilter
+    import logging
+
+    # silence the openmmtools.multistate API warning
+    stfu = MsgIncludesStringFilter(
+        "The openmmtools.multistate API is experimental and may change in "
+        "future releases"
+    )
+    omm_multistate = "openmmtools.multistate"
+    modules = ["multistatereporter", "multistateanalyzer",
+               "multistatesampler"]
+    for module in modules:
+        ms_log = logging.getLogger(omm_multistate + "." + module)
+        ms_log.addFilter(stfu)
+
+    # turn warnings into log message (don't show stack trace)
+    logging.captureWarnings(True)
+
 
     if work_dir is None:
         work_dir = pathlib.Path(os.getcwd())


### PR DESCRIPTION
As some of you may be aware, "The openmmtools.multistate API is experimental and may change in future releases."

I suppose it's a good thing for us to know. That said, we probably don't need to announce this to our CLI users 3 times during `quickrun`.

Also, this PR makes it so that our "you don't have a GPU" warning looks a little better.