### PR TITLE
Speed up first output from plan-*-network

### DIFF
--- a/openfecli/commands/plan_rbfe_network.py
+++ b/openfecli/commands/plan_rbfe_network.py
@@ -92,6 +92,12 @@ def plan_rbfe_network(
 
     The generated Network will be stored in a folder containing for each transformation a JSON file, that can be run with quickrun (or other future tools).
     """
+    write("RBFE-NETWORK PLANNER")
+    write("______________________")
+    write("")
+
+    write("Parsing in Files: ")
+
     from gufe import SolventComponent
     from openfe.setup.atom_mapping.lomap_scorers import (
         default_lomap_score,
@@ -102,11 +108,6 @@ def plan_rbfe_network(
     )
 
     # INPUT
-    write("RBFE-NETWORK PLANNER")
-    write("______________________")
-    write("")
-
-    write("Parsing in Files: ")
     write("\tGot input: ")
 
     small_molecules = MOL_DIR.get(molecules)

--- a/openfecli/commands/plan_rhfe_network.py
+++ b/openfecli/commands/plan_rhfe_network.py
@@ -96,6 +96,12 @@ def plan_rhfe_network(molecules: List[str], output_dir: str):
     transformation a JSON file, that can be run with quickrun (or other
     future tools).
     """
+    write("RHFE-NETWORK PLANNER")
+    write("______________________")
+    write("")
+
+    write("Parsing in Files: ")
+
     from gufe import SolventComponent
     from openfe.setup.atom_mapping.lomap_scorers import (
         default_lomap_score,
@@ -105,12 +111,7 @@ def plan_rhfe_network(molecules: List[str], output_dir: str):
         generate_minimal_spanning_network,
     )
 
-    write("RHFE-NETWORK PLANNER")
-    write("______________________")
-    write("")
-
     # INPUT
-    write("Parsing in Files: ")
     write("\tGot input: ")
 
     small_molecules = MOL_DIR.get(molecules)


### PR DESCRIPTION
By moving the first outputs of the network planners before the imports, we show responsiveness to the user more quickly. This makes the CLI feel (psychologically) a little faster (should have no effect on real wall time).