### PR TITLE
Regroup CLI Sections

### DIFF
--- a/openfecli/cli.py
+++ b/openfecli/cli.py
@@ -15,7 +15,9 @@ from openfecli.plugins import OFECommandPlugin
 
 
 class OpenFECLI(CLI):
-    COMMAND_SECTIONS = ["Setup", "Simulation", "Orchestration", "Analysis"]
+    # COMMAND_SECTIONS = ["Setup", "Simulation", "Orchestration", "Analysis"]
+    COMMAND_SECTIONS = ["Network Planning", "Quickrun Executor",
+                        "Miscellaneous"]
 
     def get_loaders(self):
         commands = str(pathlib.Path(__file__).parent.resolve() / "commands")

--- a/openfecli/commands/atommapping.py
+++ b/openfecli/commands/atommapping.py
@@ -97,6 +97,6 @@ def atommapping_visualize_main(mapper, molA, molB, file, ext):
 
 PLUGIN = OFECommandPlugin(
     command=atommapping,
-    section="Setup",
+    section="hidden",
     requires_ofe=(0, 0, 1),
 )

--- a/openfecli/commands/fetch.py
+++ b/openfecli/commands/fetch.py
@@ -57,7 +57,7 @@ def fetch():
 
 PLUGIN = OFECommandPlugin(
     command=fetch,
-    section="Setup",
+    section="Miscellaneous",
     requires_ofe=(0, 7),
 )
 

--- a/openfecli/commands/fetch.py
+++ b/openfecli/commands/fetch.py
@@ -33,7 +33,7 @@ class FetchCLI(CLI):
     This provides the command sections used in help and defines where
     plugins should be kept.
     """
-    COMMAND_SECTIONS = ["Built-in", "Requires Internet"]
+    COMMAND_SECTIONS = ["Tutorials"]
 
     def get_loaders(self):
         return [

--- a/openfecli/commands/gather.py
+++ b/openfecli/commands/gather.py
@@ -140,6 +140,6 @@ def gather(rootdir, output):
 
 PLUGIN = OFECommandPlugin(
     command=gather,
-    section='Simulation',
+    section='Quickrun Executor',
     requires_ofe=(0, 6),
 )

--- a/openfecli/commands/ligand_network_viewer.py
+++ b/openfecli/commands/ligand_network_viewer.py
@@ -28,6 +28,6 @@ def ligand_network_viewer(ligand_network):
 
 PLUGIN = OFECommandPlugin(
     command=ligand_network_viewer,
-    section="Setup",
+    section="Network Planning",
     requires_ofe=(0, 7, 0),
 )

--- a/openfecli/commands/plan_rbfe_network.py
+++ b/openfecli/commands/plan_rbfe_network.py
@@ -159,5 +159,5 @@ def plan_rbfe_network(
 
 
 PLUGIN = OFECommandPlugin(
-    command=plan_rbfe_network, section="Setup", requires_ofe=(0, 3)
+    command=plan_rbfe_network, section="Network Planning", requires_ofe=(0, 3)
 )

--- a/openfecli/commands/plan_rhfe_network.py
+++ b/openfecli/commands/plan_rhfe_network.py
@@ -159,5 +159,5 @@ def plan_rhfe_network(molecules: List[str], output_dir: str):
 
 
 PLUGIN = OFECommandPlugin(
-    command=plan_rhfe_network, section="Setup", requires_ofe=(0, 3)
+    command=plan_rhfe_network, section="Network Planning", requires_ofe=(0, 3)
 )

--- a/openfecli/commands/quickrun.py
+++ b/openfecli/commands/quickrun.py
@@ -135,6 +135,6 @@ def quickrun(transformation, work_dir, output):
 
 PLUGIN = OFECommandPlugin(
     command=quickrun,
-    section="Simulation",
+    section="Quickrun Executor",
     requires_ofe=(0, 3)
 )

--- a/openfecli/commands/test.py
+++ b/openfecli/commands/test.py
@@ -37,6 +37,6 @@ def test(long):
 
 PLUGIN = OFECommandPlugin(
     test,
-    "hidden",
+    "Miscellaneous",
     requires_ofe=(0, 7,5)
 )

--- a/openfecli/fetchables.py
+++ b/openfecli/fetchables.py
@@ -14,6 +14,7 @@ RBFE_TUTORIAL = URLFetcher(
     ],
     short_name="rbfe-tutorial",
     short_help="CLI and Python tutorial on relative binding free energies",
+    section="Tutorials",
     requires_ofe=(0, 7, 0),
 ).plugin
 
@@ -23,5 +24,6 @@ RBFE_TUTORIAL_RESULTS = PkgResourceFetcher(
     ],
     short_name="rbfe-tutorial-results",
     short_help="Results package to follow-up the rbfe-tutorial",
+    section="Tutorials",
     requires_ofe=(0, 7, 5),
 ).plugin

--- a/openfecli/fetching.py
+++ b/openfecli/fetching.py
@@ -31,12 +31,14 @@ class _Fetcher:
         short_name,
         short_help,
         requires_ofe,
+        section=None,
         long_help=None
     ):
         self._resources = resources
         self.short_name = short_name
         self.short_help = short_help
         self.requires_ofe = requires_ofe
+        self.section = section
         self.long_help = long_help
 
     @property
@@ -55,9 +57,19 @@ class _Fetcher:
         # forgot to make resources a list of tuple of (base, filename)
         for _, filename in self.resources:
             docs += f"* {filename}\n"
+
+        if self.REQUIRES_INTERNET is True:
+            short_help = self.short_help + " [requires internet]"
+            section = "Requires Internet"
+        elif self.REQUIRES_INTERNET is False:
+            short_help = self.short_help
+            section = "Built-in"
+        else:  # -no-cov-
+            raise RuntimeError("Class must set boolean REQUIRES_INTERNET")
+
         @click.command(
             self.short_name,
-            short_help=self.short_help,
+            short_help=short_help,
             help=docs,
         )
         @click.option(
@@ -70,16 +82,9 @@ class _Fetcher:
             directory.mkdir(parents=True, exist_ok=True)
             self(directory)
 
-        if self.REQUIRES_INTERNET is True:
-            section = "Requires Internet"
-        elif self.REQUIRES_INTERNET is False:
-            section = "Built-in"
-        else:  # -no-cov-
-            raise RuntimeError("Class must set boolean REQUIRES_INTERNET")
-
         return FetchablePlugin(
             command,
-            section,
+            section=self.section,
             requires_ofe=self.requires_ofe,
             fetcher=self
         )

--- a/openfecli/tests/test_cli.py
+++ b/openfecli/tests/test_cli.py
@@ -52,7 +52,8 @@ class TestCLI:
         # This test does not ensure the order of the sections, and does not
         # prevent other sections from being added later. It only ensures
         # that the main 4 sections continue to exist.
-        included = ["Setup", "Simulation", "Orchestration", "Analysis"]
+        included = ["Network Planning", "Quickrun Executor",
+                    "Miscellaneous"]
         for sec in included:
             assert sec in cli.COMMAND_SECTIONS
 

--- a/openfecli/tests/test_fetching.py
+++ b/openfecli/tests/test_fetching.py
@@ -52,6 +52,8 @@ class TestURLFetcher(FetcherTester):
     def test_call(self, fetcher, tmp_path):
         super().test_call(fetcher, tmp_path)
 
+    @pytest.mark.skipif(not HAS_INTERNET,
+                        reason="Internet seems to be unavailable")
     def test_without_trailing_slash(self, tmp_path):
         fetcher = URLFetcher(
             resources=[("https://www.google.com", "index.html")],


### PR DESCRIPTION
Code I can easily write without internet access. Resolves #403

### For `openfe -h`

Before: 

```text
Setup Commands:
  fetch                  Fetch tutorial or other resource.
  plan-rhfe-network      Plan a relative hydration free energy network, with
                         each leg saved as a JSON file
  atommapping            Check the atom mapping of a given pair of ligands
  plan-rbfe-network      Plan a relative binding free energy network, saved in
                         a dir with multiple JSON files.
  ligand-network-viewer  Visualize a ligand network

Simulation Commands:
  gather    Gather result jsons for network of RFE results into a TSV file
  quickrun  Run a given transformation, saved as a JSON file
```

After:

```text
Network Planning Commands:
  plan-rhfe-network      Plan a relative hydration free energy network, with
                         each leg saved as a JSON file
  plan-rbfe-network      Plan a relative binding free energy network, saved in
                         a dir with multiple JSON files.
  ligand-network-viewer  Visualize a ligand network

Quickrun Executor Commands:
  gather    Gather result jsons for network of RFE results into a TSV file
  quickrun  Run a given transformation, saved as a JSON file

Miscellaneous Commands:
  fetch  Fetch tutorial or other resource.
  test   Run the OpenFE test suite
```

### For `openfe fetch -h`

Before:

```text
Built-in Commands:
  rbfe-tutorial-results  Results package to follow-up the rbfe-tutorial

Requires Internet Commands:
  rbfe-tutorial  CLI and Python tutorial on relative binding free energies
```


After:

```text
Tutorials Commands:
  rbfe-tutorial          CLI and Python tutorial on relative binding free
                         energies [requires internet]
  rbfe-tutorial-results  Results package to follow-up the rbfe-tutorial
```