### PR TITLE
Fix links in docs

### DIFF
--- a/docs/guide/results/index.rst
+++ b/docs/guide/results/index.rst
@@ -2,5 +2,5 @@ Working with Results
 ====================
 
 This section is still under construction. In the meantime, please
-contact us on our `issue tracker <https://github.com/OpenFreeEnergy/openfe/issues>__`
+contact us on our `issue tracker <https://github.com/OpenFreeEnergy/openfe/issues>`_
 if you have any questions about analysing your results!

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -4,24 +4,24 @@ Tutorials
 .. todo: make sure we can inline the tutorial, for now we only provide links
 
 OpenFE has several tutorial notebooks which are maintained on our
-`Example Notebooks repository <https://github.com/OpenFreeEnergy/ExampleNotebooks>__`.
+`Example Notebooks repository <https://github.com/OpenFreeEnergy/ExampleNotebooks>`_.
 For new users, we recommend the following two:
 
 
 Relative Free Energies CLI tutorial
 -----------------------------------
 
-The `Relative Free Energies with the OpenFE CLI <https://github.com/OpenFreeEnergy/ExampleNotebooks/blob/main/easy_campaign/cli-tutorial.md>__`
+The `Relative Free Energies with the OpenFE CLI <https://github.com/OpenFreeEnergy/ExampleNotebooks/blob/main/easy_campaign/cli-tutorial.md>`_
 tutorial walks users through how to use the OpenFE command line to calculate
 relative hydration free energies from a small set of benzene modifications.
 
-Associated with it is also a `notebook <https://github.com/OpenFreeEnergy/ExampleNotebooks/blob/main/easy_campaign/rhfe-python-tutorial.ipynb>__`
+Associated with it is also a `notebook <https://github.com/OpenFreeEnergy/ExampleNotebooks/blob/main/easy_campaign/rhfe-python-tutorial.ipynb>`_
 for how to achieve the same outcomes using the Python API.
 
 Python API Showcase
 -------------------
 
-Our `showcase notebook <https://github.com/OpenFreeEnergy/ExampleNotebooks/blob/main/openmm_rbfe/OpenFE_showcase_1_RBFE_of_T4lysozyme.ipynb>__`
+Our `showcase notebook <https://github.com/OpenFreeEnergy/ExampleNotebooks/blob/main/openmm_rbfe/OpenFE_showcase_1_RBFE_of_T4lysozyme.ipynb>`_
 walks users through how to use the main components of OpenFE to create a
 relative binding free energy calculation.
 


### PR DESCRIPTION
A number of our links weren't actually generating rst links. Fixes.