### PR TITLE
Update links to docs

### DIFF
--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -11,11 +11,11 @@ For new users, we recommend the following two:
 Relative Free Energies CLI tutorial
 -----------------------------------
 
-The `Relative Free Energies with the OpenFE CLI <https://github.com/OpenFreeEnergy/ExampleNotebooks/blob/main/easy_campaign/cli-tutorial.md>`_
+The `Relative Free Energies with the OpenFE CLI <https://github.com/OpenFreeEnergy/ExampleNotebooks/blob/main/rbfe_tutorial/cli_tutorial.md>`_
 tutorial walks users through how to use the OpenFE command line to calculate
 relative hydration free energies from a small set of benzene modifications.
 
-Associated with it is also a `notebook <https://github.com/OpenFreeEnergy/ExampleNotebooks/blob/main/easy_campaign/rhfe-python-tutorial.ipynb>`_
+Associated with it is also a `notebook <https://github.com/OpenFreeEnergy/ExampleNotebooks/blob/main/rbfe_tutorial/python_tutorial.ipynb>`_
 for how to achieve the same outcomes using the Python API.
 
 Python API Showcase


### PR DESCRIPTION
Correct for move to a new `rbfe_tutorial` directory.

Thanks to @RiesBen for catching it.