### PR TITLE
Reconfigure stdout to be line-buffered in quickrun

### DIFF
--- a/openfecli/commands/quickrun.py
+++ b/openfecli/commands/quickrun.py
@@ -51,10 +51,14 @@ def quickrun(transformation, work_dir, output):
     """
     import gufe
     import os
+    import sys
     from gufe.protocols.protocoldag import execute_DAG
     from gufe.tokenization import JSON_HANDLER
     from openfe.utils.logging_filter import MsgIncludesStringFilter
     import logging
+
+    # avoid problems with output not showing if queueing system kills a job
+    sys.stdout.reconfigure(line_buffering=True)
 
     # silence the openmmtools.multistate API warning
     stfu = MsgIncludesStringFilter(


### PR DESCRIPTION
It looks like we're having an issue that, if a job is killed by a queueing system, some of the buffered output might not get written to the job's output file. This should force the buffer to flush on newline, which can hopefully solve some user confusion.

I considered putting this in the CLI `main`, but decided the one-liner can go in specific commands that need it. It should only be needed for commands that will be long-running (on a cluster).