### PR TITLE
CodeCov only on PR

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,7 +77,7 @@ jobs:
 
       - name: codecov
         if: ${{ github.repository == 'OpenFreeEnergy/openfe'
-                && github.event_name != 'schedule' }}
+                && github.event_name == 'pull_request' }}
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
#460 added slow tests on pushes. CodeCov was running on pushes, meaning PRs fail the codecov/project test, since they don't run the slow tests and the last push commit did. This PR makes it so that CodeCov only runs on PRs.

I think what we really need here is a solution based on [CodeCov flags](https://docs.codecov.com/docs/flags), but this is a quick fix in the meantime.