### PR TITLE
Make super slow tests integration tests

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,5 @@ recursive-include openfe/tests/data/ *.xml
 recursive-include openfe/tests/data/ *.graphml
 include openfecli/tests/data/*.json
 include openfecli/tests/data/*.tar.gz
+recursive-include openfecli/tests/ *.sdf
+recursive-include openfecli/tests/ *.pdb

--- a/openfe/tests/conftest.py
+++ b/openfe/tests/conftest.py
@@ -70,8 +70,8 @@ class SlowTests:
         if (config.getoption('--integration') or
             os.getenv("OFE_INTEGRATION_TESTS", default="false").lower() == 'true'):
             return
-        elif not (config.getoption('--runslow') or
-                  os.getenv("OFE_SLOW_TESTS", default="false").lower() == 'true'):
+        elif (config.getoption('--runslow') or
+              os.getenv("OFE_SLOW_TESTS", default="false").lower() == 'true'):
             self._modify_integration(items, config)
         else:
             self._modify_integration(items, config)

--- a/openfe/tests/conftest.py
+++ b/openfe/tests/conftest.py
@@ -12,30 +12,62 @@ import openfe
 from gufe import SmallMoleculeComponent, LigandAtomMapping
 
 
+class SlowTest:
+    """Plugin for a fixture that skips slow tests"""
+
+    def __init__(self, config):
+        self.config = config
+
+    def pytest_collection_modifyitems(self, items, config):
+        if (config.getoption('--runslow') or
+            os.getenv("OFE_SLOW_TESTS", default="false").lower() == 'true'):
+            return
+
+        msg = ("need --runslow pytest cli option or the environment variable "
+           "`OFE_SLOW_TESTS` set to `True` to run")
+        skip_slow = pytest.mark.skip(reason=msg)
+        for item in items:
+            if "slow" in item.keywords:
+                item.add_marker(skip_slow)
+
+
+class IntegrationTest:
+    """Plugin for a fixture that skips very slow integration tests"""
+
+    def __init__(self, config):
+        self.config = config
+
+    def pytest_collection_modifyitems(self, items, config):
+        if (config.getoption('--integration') or
+            os.getenv("OFE_INTEGRATION_TESTS", default="false").lower() == 'true'):
+            return
+
+        msg = ("need --integration pytest cli option or the environment "
+               "variable `OFE_INTEGRATION_TESTS` set to `True` to run")
+        skip_int = pytest.mark.skip(reason=msg)
+        for item in items:
+            if "integration" in item.keywords:
+                item.add_marker(skip_int)
+
+
 # allow for optional slow tests
 # See: https://docs.pytest.org/en/latest/example/simple.html
 def pytest_addoption(parser):
     parser.addoption(
         "--runslow", action="store_true", default=False, help="run slow tests"
     )
+    parser.addoption(
+        "--integration", action="store_true", default=False,
+        help="run long integration tests",
+    )
 
 
 def pytest_configure(config):
-    config.addinivalue_line("markers", "slow: mark test as slow to run")
-
-
-def pytest_collection_modifyitems(config, items):
-    if (config.getoption("--runslow") or
-        os.getenv("OFE_SLOW_TESTS", default="false").lower() == 'true'):
-        # --runslow given in cli or OFE_SLOW_TESTS set to True in env vars
-        # do not skip slow tests
-        return
-    msg = ("need --runslow pytest cli option or the environment variable "
-           "`OFE_SLOW_TESTS` set to `True` to run")
-    skip_slow = pytest.mark.skip(reason=msg)
-    for item in items:
-        if "slow" in item.keywords:
-            item.add_marker(skip_slow)
+    config.pluginmanager.register(SlowTest(config), "slow")
+    config.addinivalue_line("markers", "slow: mark test as slow")
+    config.pluginmanager.register(IntegrationTest(config), "integration")
+    config.addinivalue_line(
+            "markers", "integration: mark test as long integration test")
 
 
 def mol_from_smiles(smiles: str) -> Chem.Mol:

--- a/openfe/tests/conftest.py
+++ b/openfe/tests/conftest.py
@@ -15,16 +15,35 @@ from gufe import SmallMoleculeComponent, LigandAtomMapping
 class SlowTests:
     """Plugin for handling fixtures that skips slow tests
 
+    Fixtures
+    --------
+
     Currently two fixture types are handled:
-      * integration:
+      * `integration`:
         Extremely slow tests that are meant to be run to truly put the code
         through a real run.
 
-      * slow:
+      * `slow`:
         Unit tests that just take too long to be running regularly.
+
+
+    How to use the fixtures
+    -----------------------
 
     To add these fixtures simply add `@pytest.mark.integration` or
     `@pytest.mark.slow` decorator to the relevant function or class.
+
+
+    How to run tests marked by these fixtures
+    -----------------------------------------
+
+    To run the `integration` tests, either use the `--integration` flag
+    when invoking pytest, or set the environment variable
+    `OFE_INTEGRATION_TESTS` to `true`. Note: triggering `integration` will
+    automatically also trigger tests marked as `slow`.
+
+    To run the `slow` tests, either use the `--runslow` flag when invoking
+    pytest, or set the environment variable `OFE_SLOW_TESTS` to `true`
     """
     def __init__(self, config):
         self.config = config

--- a/openfe/tests/conftest.py
+++ b/openfe/tests/conftest.py
@@ -91,7 +91,7 @@ def pytest_addoption(parser):
 
 
 def pytest_configure(config):
-    config.pluginmanager.register(SlowTest(config), "slow")
+    config.pluginmanager.register(SlowTests(config), "slow")
     config.addinivalue_line("markers", "slow: mark test as slow")
     config.addinivalue_line(
             "markers", "integration: mark test as long integration test")

--- a/openfe/tests/protocols/test_openmm_rfe_slow.py
+++ b/openfe/tests/protocols/test_openmm_rfe_slow.py
@@ -86,7 +86,7 @@ def test_openmm_run_engine(benzene_vacuum_system, platform,
         assert nc.exists()
 
 
-@pytest.mark.slow  # takes ~7 minutes to run
+@pytest.mark.integration  # takes ~7 minutes to run
 @pytest.mark.flaky(reruns=3)
 def test_run_eg5_sim(eg5_protein, eg5_ligands, eg5_cofactor, tmpdir):
     # this runs a very short eg5 complex leg


### PR DESCRIPTION
Adds `--integration` or `OFE_INTEGRATION_TESTS` as triggers for the super slow tests.