### PR TITLE
[WIP] quickrun result error inspection

### DIFF
--- a/openfecli/commands/inspect_result.py
+++ b/openfecli/commands/inspect_result.py
@@ -1,26 +1,40 @@
+import json
+import warnings
 
-def print_failure_unit_error(failure_unit):
-    tb_text = failure_unit.traceback
-    # TODO: add a try/except around importing pygments; if it is there,
-    # let's make the output pretty
-    print(tb_text)
+def unit_summary(unit_label, unit):
+    qualname = unit['__qualname__']
+    if qualname == "ProtocolUnitResult":
+        yield f"Unit {unit_label} ran successfully."
+    elif qualname == "ProtocolUnitFailure":
+        yield f"Unit {unit_label} failed with an error:"
+        yield f"{unit['exception'][0]}: {unit['exception'][1][0]}"
+        yield f"{unit['traceback']}"
+    else:
+        warnings.warn(f"Unexpected result type '{aqualname}' from unit "
+                      f"{unit_label}")
 
-def unit_summary(unit_result):
-    ...
-
-def result_summary(result_dict, output):
+def result_summary(result_dict):
     import math
-    # we were success or failure
-    success = "FAILURE" if math.isnan(result_dict['estimate']) else "SUCCESS"
+    # we were success or failurea
+    estimate = result_dict['estimate']['magnitude']
+    success = "FAILURE" if math.isnan(estimate) else "SUCCESS"
     yield f"This edge was a {success}."
     units = result_dict['unit_results']
     yield f"This edge consists of {len(units)} units."
-    for unit in units:
-        yield f"For unit ??unit label??"
-        unit_summ = unit_summary(unit)
-        ...
-
+    yield ""
+    for unit_label, unit in units.items():
+        yield from unit_summary(unit_label, unit)
+        yield ""
 
 
 def inspect_result(json_filename):
-    ...
+    with open(json_filename, mode='r') as f:
+        result_dict = json.loads(f.read())
+
+    for line in result_summary(result_dict):
+        print(line)
+
+
+if __name__ == "__main__":
+    import sys
+    inspect_result(sys.argv[1])

--- a/openfecli/commands/inspect_result.py
+++ b/openfecli/commands/inspect_result.py
@@ -5,15 +5,21 @@ def print_failure_unit_error(failure_unit):
     # let's make the output pretty
     print(tb_text)
 
+def unit_summary(unit_result):
+    ...
+
 def result_summary(result_dict, output):
     import math
-    summ_lines = []
     # we were success or failure
     success = "FAILURE" if math.isnan(result_dict['estimate']) else "SUCCESS"
-    summ_lines.append(f"This edge was a {success}")
+    yield f"This edge was a {success}."
     units = result_dict['unit_results']
-    summ_lines.append(f"This edge consists of {len(units)}")
-    for unit in ...
+    yield f"This edge consists of {len(units)} units."
+    for unit in units:
+        yield f"For unit ??unit label??"
+        unit_summ = unit_summary(unit)
+        ...
+
 
 
 def inspect_result(json_filename):

--- a/openfecli/commands/inspect_result.py
+++ b/openfecli/commands/inspect_result.py
@@ -1,3 +1,6 @@
+import click
+from openfecli import OFECommandPlugin
+
 import json
 import warnings
 
@@ -27,14 +30,23 @@ def result_summary(result_dict):
         yield ""
 
 
-def inspect_result(json_filename):
-    with open(json_filename, mode='r') as f:
+@click.command(
+    'inspect-result',
+    short_help="Inspect result to show errors.",
+)
+@click.argument('result_json', type=click.Path(exists=True, readable=True))
+def inspect_result(result_json):
+    with open(result_json, mode='r') as f:
         result_dict = json.loads(f.read())
 
     for line in result_summary(result_dict):
         print(line)
 
+PLUGIN = OFECommandPlugin(
+    command=inspect_result,
+    section="Quickrun Executor",
+    requires_ofe=(0, 10)
+)
 
 if __name__ == "__main__":
-    import sys
-    inspect_result(sys.argv[1])
+    inspect_result()

--- a/openfecli/commands/inspect_result.py
+++ b/openfecli/commands/inspect_result.py
@@ -1,0 +1,20 @@
+
+def print_failure_unit_error(failure_unit):
+    tb_text = failure_unit.traceback
+    # TODO: add a try/except around importing pygments; if it is there,
+    # let's make the output pretty
+    print(tb_text)
+
+def result_summary(result_dict, output):
+    import math
+    summ_lines = []
+    # we were success or failure
+    success = "FAILURE" if math.isnan(result_dict['estimate']) else "SUCCESS"
+    summ_lines.append(f"This edge was a {success}")
+    units = result_dict['unit_results']
+    summ_lines.append(f"This edge consists of {len(units)}")
+    for unit in ...
+
+
+def inspect_result(json_filename):
+    ...

--- a/openfecli/commands/plan_rbfe_network.py
+++ b/openfecli/commands/plan_rbfe_network.py
@@ -7,6 +7,7 @@ from openfecli.utils import write, print_duration
 from openfecli import OFECommandPlugin
 from openfecli.parameters import (
     MOL_DIR, PROTEIN, MAPPER, OUTPUT_DIR, COFACTORS,
+    NEW_STORAGE_OUTPUT,  # separate line for easy delete later
 )
 from openfecli.plan_alchemical_networks_utils import plan_alchemical_network_output
 
@@ -82,9 +83,11 @@ def plan_rbfe_network_main(
     help=OUTPUT_DIR.kwargs["help"] + " Defaults to `./alchemicalNetwork`.",
     default="alchemicalNetwork",
 )
+@NEW_STORAGE_OUTPUT.parameter()
 @print_duration
 def plan_rbfe_network(
-    molecules: List[str], protein: str, cofactors: tuple[str], output_dir: str
+    molecules: List[str], protein: str, cofactors: tuple[str],
+    output_dir: str, new_storage: bool,
 ):
     """
     Plan a relative binding free energy network, saved as JSON files for
@@ -175,12 +178,16 @@ def plan_rbfe_network(
 
     # OUTPUT
     write("Output:")
-    write("\tSaving to: " + str(output_dir))
-    plan_alchemical_network_output(
-        alchemical_network=alchemical_network,
-        ligand_network=ligand_network,
-        folder_path=OUTPUT_DIR.get(output_dir),
-    )
+    if new_storage:
+        write("Got new storage!")
+        ...
+    else:
+        write("\tSaving to: " + str(output_dir))
+        plan_alchemical_network_output(
+            alchemical_network=alchemical_network,
+            ligand_network=ligand_network,
+            folder_path=OUTPUT_DIR.get(output_dir),
+        )
 
 
 PLUGIN = OFECommandPlugin(

--- a/openfecli/parameters/__init__.py
+++ b/openfecli/parameters/__init__.py
@@ -4,6 +4,6 @@
 from .mol import MOL
 from .mapper import MAPPER
 from .output import OUTPUT_FILE_AND_EXT
-from .output_dir import OUTPUT_DIR
+from .output_dir import OUTPUT_DIR, NEW_STORAGE_OUTPUT
 from .protein import PROTEIN
 from .molecules import MOL_DIR, COFACTORS

--- a/openfecli/parameters/output_dir.py
+++ b/openfecli/parameters/output_dir.py
@@ -16,3 +16,10 @@ OUTPUT_DIR = Option(
     getter=get_dir,
     type=click.Path(file_okay=False, resolve_path=True),
 )
+
+NEW_STORAGE_OUTPUT = Option(
+    "--new-storage",
+    help="use the new storage",
+    is_flag=True,
+    hidden=True,
+)


### PR DESCRIPTION
This adds an `inspect-result` command to the CLI, which takes a result JSON file and outputs some basic information on each unit.

The information included here can definitely be expanded later (timings, possibly more details on simulation parameters, etc). But I thought it was most urgent to get error messages out.



<details><summary>Here's an example output from an edge that had a NaN failure:</summary>

```
$ openfe inspect-result easy_rbfe_lig_ejm_46_solvent_lig_jmc_28_solvent.json
This edge was a SUCCESS.
This edge consists of 4 units.

Unit ProtocolUnitResult-e8e4c380537f4bfd89639cf52b8a8b95 ran successfully.

Unit ProtocolUnitFailure-4c981804da4c40b198d7fc310401c755 failed with an error:
SimulationNaNError: Propagating replica 1 at state 1 resulted in a NaN!
The state of the system and integrator before the error were saved in results/easy_rbfe_lig_ejm_46_solvent_lig_jmc_28_solvent/shared_RelativeHybridTopologyProtocolUnit-60df96a488094f63978880d19487d299_attempt_0/nan-error-logs
Traceback (most recent call last):
  File "/lila/home/henrym3/micromamba/envs/openfe-0.10.1/lib/python3.10/site-packages/openmmtools/multistate/multistatesampler.py", line 1326, in _propagate_replica
    mcmc_move.apply(thermodynamic_state, sampler_state, context_cache=self.sampler_context_cache)
  File "/lila/home/henrym3/micromamba/envs/openfe-0.10.1/lib/python3.10/site-packages/openmmtools/mcmc.py", line 1151, in apply
    super(LangevinDynamicsMove, self).apply(thermodynamic_state, sampler_state,
  File "/lila/home/henrym3/micromamba/envs/openfe-0.10.1/lib/python3.10/site-packages/openmmtools/mcmc.py", line 755, in apply
    raise IntegratorMoveError(err_msg, self, context)
openmmtools.mcmc.IntegratorMoveError: Potential energy is NaN after 20 attempts of integration with move LangevinDynamicsMove

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/lila/home/henrym3/micromamba/envs/openfe-0.10.1/lib/python3.10/site-packages/gufe/protocols/protocolunit.py", line 308, in execute
    outputs = self._execute(context, **inputs)
  File "/lila/home/henrym3/micromamba/envs/openfe-0.10.1/lib/python3.10/site-packages/openfe/protocols/openmm_rfe/equil_rfe_methods.py", line 674, in _execute
    outputs = self.run(scratch_basepath=ctx.scratch, shared_basepath=ctx.shared)
  File "/lila/home/henrym3/micromamba/envs/openfe-0.10.1/lib/python3.10/site-packages/openfe/protocols/openmm_rfe/equil_rfe_methods.py", line 617, in run
    sampler.equilibrate(int(equil_steps / mc_steps))  # type: ignore
  File "/lila/home/henrym3/micromamba/envs/openfe-0.10.1/lib/python3.10/site-packages/openmmtools/multistate/multistatesampler.py", line 696, in equilibrate
    self._propagate_replicas()
  File "/lila/home/henrym3/micromamba/envs/openfe-0.10.1/lib/python3.10/site-packages/openmmtools/utils/utils.py", line 95, in _wrapper
    return func(*args, **kwargs)
  File "/lila/home/henrym3/micromamba/envs/openfe-0.10.1/lib/python3.10/site-packages/openmmtools/multistate/multistatesampler.py", line 1299, in _propagate_replicas
    propagated_states, replica_ids = mpiplus.distribute(self._propagate_replica, range(self.n_replicas),
  File "/lila/home/henrym3/micromamba/envs/openfe-0.10.1/lib/python3.10/site-packages/mpiplus/mpiplus.py", line 523, in distribute
    all_results = [task(job_args, *other_args, **kwargs) for job_args in distributed_args]
  File "/lila/home/henrym3/micromamba/envs/openfe-0.10.1/lib/python3.10/site-packages/mpiplus/mpiplus.py", line 523, in <listcomp>
    all_results = [task(job_args, *other_args, **kwargs) for job_args in distributed_args]
  File "/lila/home/henrym3/micromamba/envs/openfe-0.10.1/lib/python3.10/site-packages/openmmtools/multistate/multistatesampler.py", line 1337, in _propagate_replica
    raise SimulationNaNError(message)
openmmtools.multistate.utils.SimulationNaNError: Propagating replica 1 at state 1 resulted in a NaN!
The state of the system and integrator before the error were saved in results/easy_rbfe_lig_ejm_46_solvent_lig_jmc_28_solvent/shared_RelativeHybridTopologyProtocolUnit-60df96a488094f63978880d19487d299_attempt_0/nan-error-logs


Unit ProtocolUnitResult-3be6df093b0e4f61ad443dc966595621 ran successfully.

Unit ProtocolUnitResult-5ea0dbdc7ee94e86a547f66e421adb95 ran successfully.
```

</details>


Still needs tests, so that'll come after review comments on output.