### PR TITLE
[WIP] quickrun result error inspection command

### DIFF
--- a/openfecli/commands/inspect_result.py
+++ b/openfecli/commands/inspect_result.py
@@ -1,0 +1,52 @@
+import click
+from openfecli import OFECommandPlugin
+
+import json
+import warnings
+
+def unit_summary(unit_label, unit):
+    qualname = unit['__qualname__']
+    if qualname == "ProtocolUnitResult":
+        yield f"Unit {unit_label} ran successfully."
+    elif qualname == "ProtocolUnitFailure":
+        yield f"Unit {unit_label} failed with an error:"
+        yield f"{unit['exception'][0]}: {unit['exception'][1][0]}"
+        yield f"{unit['traceback']}"
+    else:
+        warnings.warn(f"Unexpected result type '{aqualname}' from unit "
+                      f"{unit_label}")
+
+def result_summary(result_dict):
+    import math
+    # we were success or failurea
+    estimate = result_dict['estimate']['magnitude']
+    success = "FAILURE" if math.isnan(estimate) else "SUCCESS"
+    yield f"This edge was a {success}."
+    units = result_dict['unit_results']
+    yield f"This edge consists of {len(units)} units."
+    yield ""
+    for unit_label, unit in units.items():
+        yield from unit_summary(unit_label, unit)
+        yield ""
+
+
+@click.command(
+    'inspect-result',
+    short_help="Inspect result to show errors.",
+)
+@click.argument('result_json', type=click.Path(exists=True, readable=True))
+def inspect_result(result_json):
+    with open(result_json, mode='r') as f:
+        result_dict = json.loads(f.read())
+
+    for line in result_summary(result_dict):
+        print(line)
+
+PLUGIN = OFECommandPlugin(
+    command=inspect_result,
+    section="Quickrun Executor",
+    requires_ofe=(0, 10)
+)
+
+if __name__ == "__main__":
+    inspect_result()


### PR DESCRIPTION
Clean version of #491. Repeating description from that:

This adds an `inspect-result` command to the CLI, which takes a result JSON file and outputs some basic information on each unit.

The information included here can definitely be expanded later (timings, possibly more details on simulation parameters, etc). But I thought it was most urgent to get error messages out.



<details><summary>Here's an example output from an edge that had a NaN failure:</summary>

```
$ openfe inspect-result easy_rbfe_lig_ejm_46_solvent_lig_jmc_28_solvent.json
This edge was a SUCCESS.
This edge consists of 4 units.

Unit ProtocolUnitResult-e8e4c380537f4bfd89639cf52b8a8b95 ran successfully.

Unit ProtocolUnitFailure-4c981804da4c40b198d7fc310401c755 failed with an error:
SimulationNaNError: Propagating replica 1 at state 1 resulted in a NaN!
The state of the system and integrator before the error were saved in results/easy_rbfe_lig_ejm_46_solvent_lig_jmc_28_solvent/shared_RelativeHybridTopologyProtocolUnit-60df96a488094f63978880d19487d299_attempt_0/nan-error-logs
Traceback (most recent call last):
  File "/lila/home/henrym3/micromamba/envs/openfe-0.10.1/lib/python3.10/site-packages/openmmtools/multistate/multistatesampler.py", line 1326, in _propagate_replica
    mcmc_move.apply(thermodynamic_state, sampler_state, context_cache=self.sampler_context_cache)
  File "/lila/home/henrym3/micromamba/envs/openfe-0.10.1/lib/python3.10/site-packages/openmmtools/mcmc.py", line 1151, in apply
    super(LangevinDynamicsMove, self).apply(thermodynamic_state, sampler_state,
  File "/lila/home/henrym3/micromamba/envs/openfe-0.10.1/lib/python3.10/site-packages/openmmtools/mcmc.py", line 755, in apply
    raise IntegratorMoveError(err_msg, self, context)
openmmtools.mcmc.IntegratorMoveError: Potential energy is NaN after 20 attempts of integration with move LangevinDynamicsMove

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/lila/home/henrym3/micromamba/envs/openfe-0.10.1/lib/python3.10/site-packages/gufe/protocols/protocolunit.py", line 308, in execute
    outputs = self._execute(context, **inputs)
  File "/lila/home/henrym3/micromamba/envs/openfe-0.10.1/lib/python3.10/site-packages/openfe/protocols/openmm_rfe/equil_rfe_methods.py", line 674, in _execute
    outputs = self.run(scratch_basepath=ctx.scratch, shared_basepath=ctx.shared)
  File "/lila/home/henrym3/micromamba/envs/openfe-0.10.1/lib/python3.10/site-packages/openfe/protocols/openmm_rfe/equil_rfe_methods.py", line 617, in run
    sampler.equilibrate(int(equil_steps / mc_steps))  # type: ignore
  File "/lila/home/henrym3/micromamba/envs/openfe-0.10.1/lib/python3.10/site-packages/openmmtools/multistate/multistatesampler.py", line 696, in equilibrate
    self._propagate_replicas()
  File "/lila/home/henrym3/micromamba/envs/openfe-0.10.1/lib/python3.10/site-packages/openmmtools/utils/utils.py", line 95, in _wrapper
    return func(*args, **kwargs)
  File "/lila/home/henrym3/micromamba/envs/openfe-0.10.1/lib/python3.10/site-packages/openmmtools/multistate/multistatesampler.py", line 1299, in _propagate_replicas
    propagated_states, replica_ids = mpiplus.distribute(self._propagate_replica, range(self.n_replicas),
  File "/lila/home/henrym3/micromamba/envs/openfe-0.10.1/lib/python3.10/site-packages/mpiplus/mpiplus.py", line 523, in distribute
    all_results = [task(job_args, *other_args, **kwargs) for job_args in distributed_args]
  File "/lila/home/henrym3/micromamba/envs/openfe-0.10.1/lib/python3.10/site-packages/mpiplus/mpiplus.py", line 523, in <listcomp>
    all_results = [task(job_args, *other_args, **kwargs) for job_args in distributed_args]
  File "/lila/home/henrym3/micromamba/envs/openfe-0.10.1/lib/python3.10/site-packages/openmmtools/multistate/multistatesampler.py", line 1337, in _propagate_replica
    raise SimulationNaNError(message)
openmmtools.multistate.utils.SimulationNaNError: Propagating replica 1 at state 1 resulted in a NaN!
The state of the system and integrator before the error were saved in results/easy_rbfe_lig_ejm_46_solvent_lig_jmc_28_solvent/shared_RelativeHybridTopologyProtocolUnit-60df96a488094f63978880d19487d299_attempt_0/nan-error-logs


Unit ProtocolUnitResult-3be6df093b0e4f61ad443dc966595621 ran successfully.

Unit ProtocolUnitResult-5ea0dbdc7ee94e86a547f66e421adb95 ran successfully.
```

</details>


Still needs tests, so that'll come after review comments on output.