### PR TITLE
Unpin libnetcdf

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -25,7 +25,6 @@ dependencies:
   - perses
   - py3dmol
   - plugcli
-  - libnetcdf<4.9
   - tqdm
   # Issue #443
   - pymbar<4.0


### PR DESCRIPTION
Undoes #273. This appears to be preventing installs, as we require `libnetcdf<4.9` and the only ambertools build on `osx-arm64` requires `libnetcdf=4.9.2`.

No idea if the previous incompatibility has been fixed. Will find out when the tests run!


## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
