### PR TITLE
Split gather

### DIFF
--- a/openfecli/clicktypes/__init__.py
+++ b/openfecli/clicktypes/__init__.py
@@ -1,0 +1,1 @@
+from hyphenchoice import HyphenAwareChoice

--- a/openfecli/clicktypes/__init__.py
+++ b/openfecli/clicktypes/__init__.py
@@ -1,1 +1,1 @@
-from hyphenchoice import HyphenAwareChoice
+from .hyphenchoice import HyphenAwareChoice

--- a/openfecli/clicktypes/hyphenchoice.py
+++ b/openfecli/clicktypes/hyphenchoice.py
@@ -1,0 +1,13 @@
+import click
+
+def _normalize_to_hyphen(string):
+    return string.replace("_", "-")
+
+class HyphenAwareChoice(click.Choice):
+    def __init__(self, choices, case_sensitive=True):
+        choices = [_normalize_to_hyphen(choice) for choice in choices]
+        super().__init__(choices, case_sensitive)
+
+    def convert(self, value, param, ctx):
+        value = _normalize_to_hyphen(value)
+        return super().convert(value, param, ctx)

--- a/openfecli/commands/gather.py
+++ b/openfecli/commands/gather.py
@@ -3,6 +3,7 @@
 
 import click
 from openfecli import OFECommandPlugin
+from openfecli.clicktypes import HyphenAwareChoice
 import pathlib
 
 
@@ -205,7 +206,7 @@ def _write_dg_mle(legs, writer):
                 required=True)
 @click.option(
     '--report',
-    type=click.Choice(['dg', 'ddg', 'legs'], case_sensitive=False),
+    type=HyphenAwareChoice(['dg', 'ddg', 'dg-raw'], case_sensitive=False),
     default="dg", show_default=True,
     help=(
         "What data to report. 'dg' gives maximum-likelihood estimate of "

--- a/openfecli/commands/gather.py
+++ b/openfecli/commands/gather.py
@@ -52,6 +52,7 @@ def legacy_get_type(res_fn):
 
 
 def _get_ddgs(legs):
+    import numpy as np
     DDGs = []
     for ligpair, vals in sorted(legs.items()):
         DDGbind = None
@@ -107,6 +108,10 @@ def _write_raw_dg(legs, output):
                          f'{ligpair[1]}\t{m}\t{u}\n')
 
 def _write_dg_mle(legs, output):
+    import networkx as nx
+    import numpy as np
+    from cinnabar.stats import mle
+    DDGs = _get_ddgs(legs)
     MLEs = []
     # 4b) perform MLE
     g = nx.DiGraph()
@@ -154,6 +159,7 @@ def _write_dg_mle(legs, output):
 
 def dp2(v: float) -> str:
     # turns 0.0012345 -> '0.0012', round() would get this wrong
+    import numpy as np
     return np.format_float_positional(v, precision=2, trim='0',
                                       fractional=False)
 
@@ -212,9 +218,6 @@ def gather(rootdir, output, report):
     """
     from collections import defaultdict
     import glob
-    import networkx as nx
-    import numpy as np
-    from cinnabar.stats import mle
 
     # 1) find all possible jsons
     json_fns = glob.glob(str(rootdir) + '/**/*json', recursive=True)

--- a/openfecli/commands/gather.py
+++ b/openfecli/commands/gather.py
@@ -5,7 +5,6 @@ import click
 from openfecli import OFECommandPlugin
 import pathlib
 
-from typing import Tuple
 
 def _get_column(val):
     import numpy as np
@@ -24,7 +23,7 @@ def format_estimate_uncertainty(
     est: float,
     unc: float,
     unc_prec: int = 1,
-) -> Tuple[str, str]:
+) -> tuple[str, str]:
     import numpy as np
     # get the last column needed for uncertainty
     unc_col = _get_column(unc) - (unc_prec - 1)

--- a/openfecli/commands/gather.py
+++ b/openfecli/commands/gather.py
@@ -23,7 +23,7 @@ def _get_column(val):
 def format_estimate_uncertainty(
     est: float,
     unc: float,
-    unc_prec: int = 2,
+    unc_prec: int = 1,
 ) -> Tuple[str, str]:
     import numpy as np
     # get the last column needed for uncertainty
@@ -202,7 +202,7 @@ def _write_dg_mle(legs, writer):
                 required=True)
 @click.option(
     '--report',
-    type=click.Choice(['dg', 'ddg', 'leg'], case_sensitive=False),
+    type=click.Choice(['dg', 'ddg', 'legs'], case_sensitive=False),
     default="dg", show_default=True,
     help=(
         "What data to report. 'dg' gives maximum-likelihood estimate of "
@@ -285,7 +285,7 @@ def gather(rootdir, output, report):
     writing_func = {
         'dg': _write_dg_mle,
         'ddg': _write_ddg,
-        'leg': _write_raw_dg,
+        'legs': _write_raw_dg,
     }[report.lower()]
     writing_func(legs, writer)
 

--- a/openfecli/tests/clicktypes/test_hyphenchoice.py
+++ b/openfecli/tests/clicktypes/test_hyphenchoice.py
@@ -1,0 +1,19 @@
+import pytest
+import click
+from openfecli.clicktypes.hyphenchoice import HyphenAwareChoice
+
+class TestHyphenAwareChoice:
+    @pytest.mark.parametrize('value', [
+        "foo_bar_baz", "foo_bar-baz", "foo-bar_baz", "foo-bar-baz"
+    ])
+    def test_init(self, value):
+        ch = HyphenAwareChoice([value])
+        assert ch.choices == ["foo-bar-baz"]
+
+    @pytest.mark.parametrize('value', [
+        "foo_bar_baz", "foo_bar-baz", "foo-bar_baz", "foo-bar-baz"
+    ])
+    def test_convert(self, value):
+        ch = HyphenAwareChoice(['foo-bar-baz'])
+        # counting on __call__ to get to convert()
+        assert ch(value) == "foo-bar-baz"

--- a/openfecli/tests/commands/test_gather.py
+++ b/openfecli/tests/commands/test_gather.py
@@ -4,7 +4,24 @@ from importlib import resources
 import tarfile
 import pytest
 
-from openfecli.commands.gather import gather
+from openfecli.commands.gather import (
+    gather, format_estimate_uncertainty, _get_column
+)
+
+@pytest.mark.parametrize('est,unc,unc_prec,est_str,unc_str', [
+    (12.432, 0.111, 2, "12.43", "0.11"),
+    (0.9999, 0.01, 2, "1.000", "0.010"),
+    (1234, 100, 2, "1230", "100"),
+])
+def test_format_estimate_uncertainty(est, unc, unc_prec, est_str, unc_str):
+    assert format_estimate_uncertainty(est, unc, unc_prec) == (est_str, unc_str)
+
+@pytest.mark.parametrize('val, col', [
+    (1.0, 1), (0.1, -1), (-0.0, 0), (0.0, 0), (0.2, -1), (0.9, -1),
+    (0.011, -2), (9, 1), (10, 2), (15, 2),
+])
+def test_get_column(val, col):
+    assert _get_column(val) == col
 
 
 @pytest.fixture


### PR DESCRIPTION
This is a PR into #495. This is a major refactor of that PR, so I wanted to give some space for this to be reviewed separately.

Big changes:

* Instead of trying to dump everything into one table, we have `openfe --gather dg/ddg/leg`, with dg (absolute estimates from MLE) as default. Each table has its own set of columns.
* Estimates are now reported to the same precision as the uncertainty estimates. Previously, we would report e.g, `17.0 ± 0.058` when our actual estimate was at `17.418` (so the actual estimate was well outside our reported error bars!) Now that reports as `17.418 ± 0.058`.

Also, although we still use the same TSV format, we now do with tools from the stdlib `csv`, which will make it much easier to provide other approaches in the future.

<details><summary>Example of output from running these commands now</summary>

```
(openfe) Yvette:...tmp-inspect-results/results dwhs$ openfe gather results
ligand	DG(MLE) (kcal/mol)	uncertainty (kcal/mol)
lig_ejm_31	-0.086	0.046
lig_ejm_42	0.67	0.11
lig_ejm_46	-0.977	0.054
lig_ejm_47	-0.06	0.14
lig_ejm_48	0.528	0.092
lig_ejm_50	0.914	0.061
lig_ejm_43	2.02	0.18
lig_jmc_23	-0.682	0.095
lig_jmc_27	-1.08	0.11
lig_jmc_28	-1.250	0.076
(openfe) Yvette:...tmp-inspect-results/results dwhs$ openfe gather --report ddg results
ligand_i	ligand_j	DDG(i->j) (kcal/mol)	uncertainty (kcal/mol)
lig_ejm_31	lig_ejm_42	0.76	0.13
lig_ejm_31	lig_ejm_46	-0.891	0.065
lig_ejm_31	lig_ejm_47	0.02	0.15
lig_ejm_31	lig_ejm_48	0.614	0.089
lig_ejm_31	lig_ejm_50	1.000	0.044
lig_ejm_42	lig_ejm_43	1.35	0.16
lig_ejm_46	lig_jmc_23	0.295	0.087
lig_ejm_46	lig_jmc_27	-0.10	0.10
lig_ejm_46	lig_jmc_28	-0.273	0.060
(openfe) Yvette:...tmp-inspect-results/results dwhs$ openfe gather --report leg results
leg	ligand_i	ligand_j	DG(i->j) (kcal/mol)	uncertainty (kcal/mol)
complex	lig_ejm_31	lig_ejm_42	-14.95	0.12
solvent	lig_ejm_31	lig_ejm_42	-15.707	0.031
complex	lig_ejm_31	lig_ejm_46	-40.749	0.036
solvent	lig_ejm_31	lig_ejm_46	-39.858	0.054
complex	lig_ejm_31	lig_ejm_47	-27.81	0.13
solvent	lig_ejm_31	lig_ejm_47	-27.829	0.060
complex	lig_ejm_31	lig_ejm_48	-16.141	0.085
solvent	lig_ejm_31	lig_ejm_48	-16.755	0.026
complex	lig_ejm_31	lig_ejm_50	-57.333	0.038
solvent	lig_ejm_31	lig_ejm_50	-58.333	0.024
complex	lig_ejm_42	lig_ejm_43	-18.92	0.15
solvent	lig_ejm_42	lig_ejm_43	-20.277	0.026
complex	lig_ejm_46	lig_jmc_23	17.418	0.058
solvent	lig_ejm_46	lig_jmc_23	17.123	0.064
complex	lig_ejm_46	lig_jmc_27	15.813	0.086
solvent	lig_ejm_46	lig_jmc_27	15.914	0.053
complex	lig_ejm_46	lig_jmc_28	23.140	0.037
solvent	lig_ejm_46	lig_jmc_28	23.413	0.047
```

</details>

Biggest concern is that right now, if you combine RBFE and and RHFE results, you can't tell which are which in the DDG setup. I think I'd like to completely disallow combining those in one analysis; I'm not entirely sure that there's a good use case for that in a single output file.

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
