### PR TITLE
remove version name and upload files

### DIFF
--- a/.github/workflows/installer.yaml
+++ b/.github/workflows/installer.yaml
@@ -63,6 +63,7 @@ jobs:
         export PATH="$HOME/openfeforge/bin:$PATH"
         OFE_SLOW_TESTS=FALSE pytest -v --pyargs openfe pytest -v --pyargs openfe
         # Copy for "latest" release by removing version
+        # Inspired by https://github.com/conda-forge/miniforge/blob/main/.github/workflows/ci.yml
         cp ${{ steps.file-name.outputs.FILE_NAME }} $(echo ${{ steps.file-name.outputs.FILE_NAME }} | sed -e 's/-[^-]*//')
 
     - uses: actions/upload-artifact@v3

--- a/.github/workflows/installer.yaml
+++ b/.github/workflows/installer.yaml
@@ -62,9 +62,21 @@ jobs:
         ./${{ steps.file-name.outputs.FILE_NAME }} -b
         export PATH="$HOME/openfeforge/bin:$PATH"
         OFE_SLOW_TESTS=FALSE pytest -v --pyargs openfe pytest -v --pyargs openfe
+        # Copy for "latest" release by removing version
+        cp ${{ steps.file-name.outputs.FILE_NAME }} $(echo ${{ steps.file-name.outputs.FILE_NAME }} | sed -e 's/-[^-]*//')
 
     - uses: actions/upload-artifact@v3
       with:
         name: ${{ steps.file-name.outputs.FILE_NAME }}
         path: OpenFEforge*
         if-no-files-found: error
+
+    - name: Upload openfe forge to release
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: OpenFEforge*
+        tag: ${{ github.ref }}
+        overwrite: true
+        file_glob: true
+      if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.

Still need to keep #464 but this will make it so our "latest" trick for the release works and now you don't need to download the assets. All that we have left to do is figure out how we want to automate this being triggered when we get a new conda-forge release 