### PR TITLE
Remove softcore electrostatics entry

### DIFF
--- a/openfe/protocols/openmm_rfe/_rfe_utils/relative.py
+++ b/openfe/protocols/openmm_rfe/_rfe_utils/relative.py
@@ -86,9 +86,6 @@ class HybridTopologyFactory:
                  softcore_alpha=0.5,
                  softcore_LJ_v2=True,
                  softcore_LJ_v2_alpha=0.85,
-                 softcore_electrostatics=True,
-                 softcore_electrostatics_alpha=0.3,
-                 softcore_sigma_Q=1.0,
                  interpolate_old_and_new_14s=False,
                  flatten_torsions=False,
                  **kwargs):
@@ -125,12 +122,6 @@ class HybridTopologyFactory:
             Implement the softcore LJ as defined by Gapsys et al. JCTC 2012.
         softcore_LJ_v2_alpha : float, default 0.85
             Softcore alpha parameter for LJ v2
-        softcore_electrostatics : bool, default True
-            Use softcore electrostatics as defined by Gapsys et al. JCTC 2021.
-        softcore_electrostatics_alpha : float, default 0.3
-            Softcore alpha parameter for softcore electrostatics.
-        softcore_sigma_Q : float, default 1.0
-            Softcore sigma parameter for softcore electrostatics.
         interpolate_old_and_new_14s : bool, default False
             Whether to turn off interactions for new exceptions (not just
             1,4s) at lambda = 0 and old exceptions at lambda = 1; if False,
@@ -171,14 +162,6 @@ class HybridTopologyFactory:
         if self._softcore_LJ_v2:
             self._check_bounds(softcore_LJ_v2_alpha, "softcore_LJ_v2_alpha")
             self._softcore_LJ_v2_alpha = softcore_LJ_v2_alpha
-
-        self._softcore_electrostatics = softcore_electrostatics
-        if self._softcore_electrostatics:
-            self._softcore_electrostatics_alpha = softcore_electrostatics_alpha
-            self._check_bounds(softcore_electrostatics_alpha,
-                               "softcore_electrostatics_alpha")
-            self._softcore_sigma_Q = softcore_sigma_Q
-            self._check_bounds(softcore_sigma_Q, "softcore_sigma_Q")
 
         # TODO: end __init__ here and move everything else to
         # create_hybrid_system() or equivalent

--- a/openfe/protocols/openmm_rfe/equil_rfe_methods.py
+++ b/openfe/protocols/openmm_rfe/equil_rfe_methods.py
@@ -489,9 +489,6 @@ class RelativeHybridTopologyProtocolUnit(gufe.ProtocolUnit):
             softcore_alpha=alchem_settings.softcore_alpha,
             softcore_LJ_v2=alchem_settings.softcore_LJ_v2,
             softcore_LJ_v2_alpha=alchem_settings.softcore_alpha,
-            softcore_electrostatics=alchem_settings.softcore_electrostatics,
-            softcore_electrostatics_alpha=alchem_settings.softcore_electrostatics_alpha,
-            softcore_sigma_Q=alchem_settings.softcore_sigma_Q,
             interpolate_old_and_new_14s=alchem_settings.interpolate_old_and_new_14s,
             flatten_torsions=alchem_settings.flatten_torsions,
         )

--- a/openfe/protocols/openmm_rfe/equil_rfe_settings.py
+++ b/openfe/protocols/openmm_rfe/equil_rfe_settings.py
@@ -56,16 +56,8 @@ class AlchemicalSettings(SettingsBaseModel):
     Whether to use the LJ softcore function as defined by
     Gapsys et al. JCTC 2012 Default True.
     """
-    softcore_electrostatics = True
-    """Whether to use softcore electrostatics. Default True."""
     softcore_alpha = 0.85
     """Softcore alpha parameter. Default 0.85"""
-    softcore_electrostatics_alpha = 0.3
-    """Softcore alpha parameter for electrostatics. Default 0.3"""
-    softcore_sigma_Q = 1.0
-    """
-    Softcore sigma parameter for softcore electrostatics. Default 1.0.
-    """
     interpolate_old_and_new_14s = False
     """
     Whether to turn off interactions for new exceptions (not just 1,4s)

--- a/openfe/tests/protocols/test_rfe_tokenization.py
+++ b/openfe/tests/protocols/test_rfe_tokenization.py
@@ -39,7 +39,7 @@ class TestRelativeHybridTopologyProtocolResult(GufeTokenizableTestsMixin):
 
 class TestRelativeHybridTopologyProtocol(GufeTokenizableTestsMixin):
     cls = openmm_rfe.RelativeHybridTopologyProtocol
-    key = "RelativeHybridTopologyProtocol-ba8bae8ffc0f48e0839312daa7e74e98"
+    key = "RelativeHybridTopologyProtocol-8fe3eb4c318673db7d57c1bffca602df"
     repr = f"<{key}>"
 
     @pytest.fixture()


### PR DESCRIPTION
This is a source of much confusion, but as far as I can tell we don't softcore our electrostatics, nor do we have the ability to do so easily in OpenMM (at least there's no way to change the functional form for PME).

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
