### PR TITLE
Use 1.0 for good AtomMapping scores, 0.0 for bad AtomMapping scores

### DIFF
--- a/docs/cookbook/creating_atom_mappings.rst
+++ b/docs/cookbook/creating_atom_mappings.rst
@@ -110,8 +110,8 @@ Scoring Mappings
 With many possible mappings,
 and many ligand pairs we could form mappings between,
 we use **scorers** to rate if a mapping is a good idea.
-These take a ``LigandAtomMapping`` object and return a value from 0.0 (indicating a great mapping)
-to 1.0 (indicating a terrible mapping).
+These take a ``LigandAtomMapping`` object and return a value from 1.0 (indicating a great mapping)
+to 0.0 (indicating a terrible mapping).
 
 Again, the scoring functions from Lomap are included in the ``openfe`` package.
 The :func:`default_lomap_score` function combines many different criteria together

--- a/docs/cookbook/creating_atom_mappings.rst
+++ b/docs/cookbook/creating_atom_mappings.rst
@@ -110,8 +110,8 @@ Scoring Mappings
 With many possible mappings,
 and many ligand pairs we could form mappings between,
 we use **scorers** to rate if a mapping is a good idea.
-These take a ``LigandAtomMapping`` object and return a value from 1.0 (indicating a great mapping)
-to 0.0 (indicating a terrible mapping).
+These take a ``LigandAtomMapping`` object and return a value from 0.0 (indicating a terrible mapping)
+to 1.0 (indicating a great mapping), and so can be used as objective functions for optimizing ligand networks.
 
 Again, the scoring functions from Lomap are included in the ``openfe`` package.
 The :func:`default_lomap_score` function combines many different criteria together

--- a/openfe/setup/atom_mapping/lomap_scorers.py
+++ b/openfe/setup/atom_mapping/lomap_scorers.py
@@ -26,13 +26,13 @@ def ecr_score(mapping: LigandAtomMapping):
     molA = mapping.componentA.to_rdkit()
     molB = mapping.componentB.to_rdkit()
 
-    return 1 - _dbmol.ecr(molA, molB)
+    return _dbmol.ecr(molA, molB)
 
 
-def mcsr_score(mapping: LigandAtomMapping, beta: float = 0.1):
+def mcsr_score(mapping: LigandAtomMapping, beta: float = 0.1) -> float:
     """Maximum command substructure rule
 
-    This rule was originally defined as::
+    This rule is defined as::
 
         mcsr = exp( - beta * (n1 + n2 - 2 * n_common))
 
@@ -40,8 +40,6 @@ def mcsr_score(mapping: LigandAtomMapping, beta: float = 0.1):
     the number of atoms in the MCS.
 
     Giving a value in the range [0, 1.0], with 1.0 being complete agreement
-
-    This is turned into a score by simply returning (1-mcsr)
     """
     molA = mapping.componentA.to_rdkit()
     molB = mapping.componentB.to_rdkit()
@@ -58,10 +56,10 @@ def mcsr_score(mapping: LigandAtomMapping, beta: float = 0.1):
 
     mcsr = math.exp(-beta * (n1 + n2 - 2 * n_common))
 
-    return 1 - mcsr
+    return mcsr
 
 
-def mncar_score(mapping: LigandAtomMapping, ths: int = 4):
+def mncar_score(mapping: LigandAtomMapping, ths: int = 4) -> float:
     """Minimum number of common atoms rule
 
     Parameters
@@ -83,7 +81,7 @@ def mncar_score(mapping: LigandAtomMapping, ths: int = 4):
 
     ok = (n_common > ths) or (n1 < ths + 3) or (n2 < ths + 3)
 
-    return 0.0 if ok else 1.0
+    return 1.0 if ok else 0.0
 
 
 def tmcsr_score(self, mapping: LigandAtomMapping):
@@ -91,14 +89,14 @@ def tmcsr_score(self, mapping: LigandAtomMapping):
 
 
 def atomic_number_score(mapping: LigandAtomMapping, beta=0.1,
-                        difficulty=None):
+                        difficulty=None) -> float:
     """A score on the elemental changes happening in the mapping
 
     For each transmuted atom, a mismatch score is summed, according to the
     difficulty scores (see difficult parameter).  The final score is then
     given as:
 
-    score = 1 - exp(-beta * mismatch)
+    score = exp(-beta * mismatch)
 
     Parameters
     ----------
@@ -153,15 +151,15 @@ def atomic_number_score(mapping: LigandAtomMapping, beta=0.1,
 
     atomic_number_rule = math.exp(-beta * nmismatch)
 
-    return 1 - atomic_number_rule
+    return atomic_number_rule
 
 
-def hybridization_score(mapping: LigandAtomMapping, beta=0.15):
+def hybridization_score(mapping: LigandAtomMapping, beta=0.15) -> float:
     """
 
     Score calculated as:
 
-    1 - math.exp(-beta * nmismatch)
+    math.exp(-beta * nmismatch)
 
     Parameters
     ----------
@@ -200,13 +198,13 @@ def hybridization_score(mapping: LigandAtomMapping, beta=0.15):
 
     hybridization_rule = math.exp(- beta * nmismatch)
 
-    return 1 - hybridization_rule
+    return hybridization_rule
 
 
-def sulfonamides_score(mapping: LigandAtomMapping, beta=0.4):
+def sulfonamides_score(mapping: LigandAtomMapping, beta=0.4) -> float:
     """Checks if a sulfonamide appears and disallow this.
 
-    Returns (1 - math.exp(- beta)) if this happens, else 0
+    Returns math.exp(- beta) if this happens, else 0
     """
     molA = mapping.componentA.to_rdkit()
     molB = mapping.componentB.to_rdkit()
@@ -235,17 +233,17 @@ def sulfonamides_score(mapping: LigandAtomMapping, beta=0.4):
         remB.RemoveAtom(j)
 
     if has_sulfonamide(remA.GetMol()) or has_sulfonamide(remB.GetMol()):
-        return 1 - math.exp(-beta)
+        return math.exp(-beta)
     else:
-        return 0
+        return 1.0
 
 
-def heterocycles_score(mapping: LigandAtomMapping, beta=0.4):
+def heterocycles_score(mapping: LigandAtomMapping, beta=0.4) -> float:
     """Checks if a heterocycle is formed from a -H
 
     Pyrrole, furan and thiophene *are* pemitted however
 
-    Returns 1 if this happens, else 0
+    Returns math.exp(-beta) if this happens, else 1.0
     """
     molA = mapping.componentA.to_rdkit()
     molB = mapping.componentB.to_rdkit()
@@ -284,20 +282,20 @@ def heterocycles_score(mapping: LigandAtomMapping, beta=0.4):
 
     if (creates_heterocyle(remA.GetMol()) or
             creates_heterocyle(remB.GetMol())):
-        return 1 - math.exp(- beta)
+        return math.exp(- beta)
     else:
-        return 0
+        return 1.0
 
 
 def transmuting_methyl_into_ring_score(mapping: LigandAtomMapping,
-                                       beta=0.1, penalty=6.0):
+                                       beta=0.1, penalty=6.0) -> float:
     """Penalises having a non-mapped ring atoms become a non-ring
 
     This score would for example penalise R-CH3 to R-Ph where R is the same
     mapped atom and both CH3 and Ph are unmapped. Does not penalise R-H to R-Ph.
     If any atoms trigger the rule returns a score of::
 
-      1 - exp(-1 * beta * penalty)
+      exp(-1 * beta * penalty)
 
     Parameters
     ----------
@@ -346,12 +344,12 @@ def transmuting_methyl_into_ring_score(mapping: LigandAtomMapping,
                     ringbreak = True
 
     if not ringbreak:
-        return 0
+        return 1.0
     else:
-        return 1 - math.exp(- beta * penalty)
+        return math.exp(- beta * penalty)
 
 
-def transmuting_ring_sizes_score(mapping: LigandAtomMapping):
+def transmuting_ring_sizes_score(mapping: LigandAtomMapping) -> float:
     """Checks if mapping alters a ring size"""
     molA = mapping.componentA.to_rdkit()
     molB = mapping.componentB.to_rdkit()
@@ -401,7 +399,7 @@ def transmuting_ring_sizes_score(mapping: LigandAtomMapping):
                         ringdictB[otherB.GetIdx()]):
                     is_bad = True
 
-    return 1 - 0.1 if is_bad else 0
+    return 0.1 if is_bad else 1.0
 
 
 def default_lomap_score(mapping: LigandAtomMapping):
@@ -409,19 +407,18 @@ def default_lomap_score(mapping: LigandAtomMapping):
 
     Note
     ----
-    Like other scores, relative to the original Lomap this is (1 - score)
-    I.e. high values are "bad", low values are "good"
+    Like other scores, high values are "good", low values are "bad"
     """
     score = math.prod((
-        1 - ecr_score(mapping),
-        1 - mncar_score(mapping),
-        1 - mcsr_score(mapping),
-        1 - atomic_number_score(mapping),
-        1 - hybridization_score(mapping),
-        1 - sulfonamides_score(mapping),
-        1 - heterocycles_score(mapping),
-        1 - transmuting_methyl_into_ring_score(mapping),
-        1 - transmuting_ring_sizes_score(mapping)
+        ecr_score(mapping),
+        mncar_score(mapping),
+        mcsr_score(mapping),
+        atomic_number_score(mapping),
+        hybridization_score(mapping),
+        sulfonamides_score(mapping),
+        heterocycles_score(mapping),
+        transmuting_methyl_into_ring_score(mapping),
+        transmuting_ring_sizes_score(mapping)
     ))
 
-    return 1 - score
+    return score

--- a/openfe/setup/atom_mapping/lomap_scorers.py
+++ b/openfe/setup/atom_mapping/lomap_scorers.py
@@ -200,7 +200,15 @@ def hybridization_score(mapping: LigandAtomMapping, beta=0.15) -> float:
 def sulfonamides_score(mapping: LigandAtomMapping, beta=0.4) -> float:
     """Checks if a sulfonamide appears and disallow this.
 
-    Returns math.exp(- beta) if this happens, else 1.0
+    Returns ``math.exp(- beta)`` if a sulfonamide group is mutated in or out, 
+    otherwise 1.0. Testing has shown that growing a sulfonamide from scratch 
+    performs very badly.
+
+    Parameters
+    ==========
+    beta
+        A positive float describing how much to penalise a growing sulfonamide.
+        Smaller values indicate exponentially larger penalties. 
     """
     molA = mapping.componentA.to_rdkit()
     molB = mapping.componentB.to_rdkit()
@@ -239,7 +247,7 @@ def heterocycles_score(mapping: LigandAtomMapping, beta=0.4) -> float:
 
     Pyrrole, furan and thiophene *are* pemitted however
 
-    Returns math.exp(-beta) if this happens, else 1.0
+    Returns ``math.exp(-beta)`` if this happens, else 1.0
     """
     molA = mapping.componentA.to_rdkit()
     molB = mapping.componentB.to_rdkit()
@@ -401,18 +409,20 @@ def transmuting_ring_sizes_score(mapping: LigandAtomMapping) -> float:
 def default_lomap_score(mapping: LigandAtomMapping) -> float:
     """The default score function from Lomap2
 
+
+    This score is a combination of many rules combined and considers factors such as the
+    number of heavy atoms in common, if ring sizes are changed or rings are broken,
+    or if other alchemically unwise transformations are attempted.
+       
     Parameters
     ----------
     mapping : LigandAtomMapping
-      the mapping function to score
+      The atom mapping to score.
 
     Returns
     -------
     score : float
        A rating of how good this mapping is, from 0.0 (terrible) to 1.0 (great).
-       This score is a combination of many rules combined and considers factors such as the
-       number of heavy atoms in common, if ring sizes are changed or rings are broken,
-       or if other alchemically unwise transformations are attempted.
     """
     score = math.prod((
         ecr_score(mapping),

--- a/openfe/setup/atom_mapping/lomap_scorers.py
+++ b/openfe/setup/atom_mapping/lomap_scorers.py
@@ -22,7 +22,7 @@ DEFAULT_ANS_DIFFICULTY = {
 }
 
 
-def ecr_score(mapping: LigandAtomMapping):
+def ecr_score(mapping: LigandAtomMapping) -> float:
     molA = mapping.componentA.to_rdkit()
     molB = mapping.componentB.to_rdkit()
 
@@ -149,9 +149,7 @@ def atomic_number_score(mapping: LigandAtomMapping, beta=0.1,
 
         nmismatch += 1 - diff
 
-    atomic_number_rule = math.exp(-beta * nmismatch)
-
-    return atomic_number_rule
+    return math.exp(-beta * nmismatch)
 
 
 def hybridization_score(mapping: LigandAtomMapping, beta=0.15) -> float:
@@ -196,15 +194,13 @@ def hybridization_score(mapping: LigandAtomMapping, beta=0.15) -> float:
         if mismatch:
             nmismatch += 1
 
-    hybridization_rule = math.exp(- beta * nmismatch)
-
-    return hybridization_rule
+    return math.exp(- beta * nmismatch)
 
 
 def sulfonamides_score(mapping: LigandAtomMapping, beta=0.4) -> float:
     """Checks if a sulfonamide appears and disallow this.
 
-    Returns math.exp(- beta) if this happens, else 0
+    Returns math.exp(- beta) if this happens, else 1.0
     """
     molA = mapping.componentA.to_rdkit()
     molB = mapping.componentB.to_rdkit()
@@ -402,12 +398,21 @@ def transmuting_ring_sizes_score(mapping: LigandAtomMapping) -> float:
     return 0.1 if is_bad else 1.0
 
 
-def default_lomap_score(mapping: LigandAtomMapping):
+def default_lomap_score(mapping: LigandAtomMapping) -> float:
     """The default score function from Lomap2
 
-    Note
-    ----
-    Like other scores, high values are "good", low values are "bad"
+    Parameters
+    ----------
+    mapping : LigandAtomMapping
+      the mapping function to score
+
+    Returns
+    -------
+    score : float
+       A rating of how good this mapping is, from 0.0 (terrible) to 1.0 (great).
+       This score is a combination of many rules combined and considers factors such as the
+       number of heavy atoms in common, if ring sizes are changed or rings are broken,
+       or if other alchemically unwise transformations are attempted.
     """
     score = math.prod((
         ecr_score(mapping),

--- a/openfe/setup/ligand_network_planning.py
+++ b/openfe/setup/ligand_network_planning.py
@@ -54,7 +54,7 @@ def generate_radial_network(ligands: Iterable[SmallMoleculeComponent],
       mapper(s) to use, at least 1 required
     scorer : scoring function, optional
       a callable which returns a float for any LigandAtomMapping.  Used to
-      assign scores to potential mappings, higher scores indicate better
+      assign scores to potential mappings; higher scores indicate better
       mappings.
 
     Raises

--- a/openfe/tests/setup/atom_mapping/test_lomap_scorers.py
+++ b/openfe/tests/setup/atom_mapping/test_lomap_scorers.py
@@ -63,37 +63,37 @@ def test_mcsr_zero(toluene_to_cyclohexane):
     score = lomap_scorers.mcsr_score(toluene_to_cyclohexane)
 
     # all atoms map, so perfect score
-    assert score == 0
+    assert score == 1
 
 
 def test_mcsr_nonzero(toluene_to_methylnaphthalene):
     score = lomap_scorers.mcsr_score(toluene_to_methylnaphthalene)
 
-    assert score == pytest.approx(1 - math.exp(-0.1 * 4))
+    assert score == pytest.approx(math.exp(-0.1 * 4))
 
 
 def test_mcsr_custom_beta(toluene_to_methylnaphthalene):
     score = lomap_scorers.mcsr_score(toluene_to_methylnaphthalene, beta=0.2)
 
-    assert score == pytest.approx(1 - math.exp(-0.2 * 4))
+    assert score == pytest.approx(math.exp(-0.2 * 4))
 
 
 def test_mcnar_score_pass(toluene_to_cyclohexane):
     score = lomap_scorers.mncar_score(toluene_to_cyclohexane)
 
-    assert score == 0
+    assert score == 1.0
 
 
 def test_mcnar_score_fail(toluene_to_heptane):
     score = lomap_scorers.mncar_score(toluene_to_heptane)
 
-    assert score == 1.0
+    assert score == 0.0
 
 
 def test_atomic_number_score_pass(toluene_to_cyclohexane):
     score = lomap_scorers.atomic_number_score(toluene_to_cyclohexane)
 
-    assert score == 0.0
+    assert score == 1.0
 
 
 def test_atomic_number_score_fail(methylnaphthalene_to_naphthol):
@@ -101,7 +101,7 @@ def test_atomic_number_score_fail(methylnaphthalene_to_naphthol):
         methylnaphthalene_to_naphthol)
 
     # single mismatch @ 0.5
-    assert score == pytest.approx(1 - math.exp(-0.1 * 0.5))
+    assert score == pytest.approx(math.exp(-0.1 * 0.5))
 
 
 def test_atomic_number_score_weights(methylnaphthalene_to_naphthol):
@@ -113,7 +113,7 @@ def test_atomic_number_score_weights(methylnaphthalene_to_naphthol):
         methylnaphthalene_to_naphthol, difficulty=difficulty)
 
     # single mismatch @ (1 - 0.75)
-    assert score == pytest.approx(1 - math.exp(-0.1 * 0.25))
+    assert score == pytest.approx(math.exp(-0.1 * 0.25))
 
 
 class TestSulfonamideRule:
@@ -151,7 +151,7 @@ class TestSulfonamideRule:
             componentB=ethylbenzene,
             componentA_to_componentB=from_sulf_mapping,
         )
-        expected = 1 - math.exp(-1 * 0.4)
+        expected = math.exp(-1 * 0.4)
         assert lomap_scorers.sulfonamides_score(mapping) == expected
 
     @staticmethod
@@ -164,7 +164,7 @@ class TestSulfonamideRule:
                                     componentB=sulfonamide,
                                     componentA_to_componentB=AtoB)
 
-        expected = 1 - math.exp(-1 * 0.4)
+        expected = math.exp(-1 * 0.4)
         assert lomap_scorers.sulfonamides_score(mapping) == expected
 
 
@@ -193,7 +193,7 @@ def test_heterocycle_score(base, other, name, hit):
     mapping = next(mapper.suggest_mappings(m1, m2))
     score = lomap_scorers.heterocycles_score(mapping)
 
-    assert score == 0 if not hit else score == 1 - math.exp(-0.4)
+    assert score == 1.0 if not hit else score == math.exp(-0.4)
 
 
 # test individual scoring functions against lomap
@@ -227,7 +227,7 @@ def test_lomap_individual_scores(params,
     mapping = next(mapper.suggest_mappings(molA, molB))
     openfe_version = getattr(lomap_scorers, SCORE_NAMES[scorename])(mapping)
 
-    assert lomap_version == pytest.approx(1 - openfe_version), \
+    assert lomap_version == pytest.approx(openfe_version), \
            f"{molA.name} {molB.name} {scorename}"
 
 
@@ -259,7 +259,6 @@ def test_lomap_regression(lomap_basic_test_files_dir,  # in a dir for lomap
         score = scorer(mapping)
 
         scores[i, j] = scores[j, i] = score
-    scores = 1 - scores
     # fudge diagonal for comparison
     for i in range(matrix.shape[0]):
         scores[i, i] = 0

--- a/openfe/tests/setup/atom_mapping/test_lomap_scorers.py
+++ b/openfe/tests/setup/atom_mapping/test_lomap_scorers.py
@@ -293,5 +293,5 @@ def test_transmuting_methyl_into_ring_score():
     score1 = lomap_scorers.transmuting_methyl_into_ring_score(RC_to_RPh)
     score2 = lomap_scorers.transmuting_methyl_into_ring_score(RH_to_RPh)
 
-    assert score2 == 0.0
-    assert score1 == pytest.approx(1 - math.exp(-0.1 * 6.0))
+    assert score1 == pytest.approx(math.exp(-0.1 * 6.0))
+    assert score2 == 1.0

--- a/openfe/tests/setup/test_network_planning.py
+++ b/openfe/tests/setup/test_network_planning.py
@@ -51,7 +51,7 @@ def test_radial_network_with_scorer(toluene_vs_others):
     toluene, others = toluene_vs_others
 
     def scorer(mapping):
-        return 1.0 / len(mapping.componentA_to_componentB)
+        return len(mapping.componentA_to_componentB)
 
     network = openfe.setup.ligand_network_planning.generate_radial_network(
         ligands=others,
@@ -64,7 +64,7 @@ def test_radial_network_with_scorer(toluene_vs_others):
     for edge in network.edges:
         assert len(edge.componentA_to_componentB) > 1  # we didn't take the bad mapper
         assert 'score' in edge.annotations
-        assert edge.annotations['score'] == 1.0 / len(edge.componentA_to_componentB)
+        assert edge.annotations['score'] == len(edge.componentA_to_componentB)
 
 
 def test_radial_network_multiple_mappers_no_scorer(toluene_vs_others):
@@ -109,7 +109,7 @@ def test_generate_maximal_network(toluene_vs_others, with_progress,
         mappers = openfe.setup.atom_mapping.LomapAtomMapper()
 
     def scoring_func(mapping):
-        return 1.0 / len(mapping.componentA_to_componentB)
+        return len(mapping.componentA_to_componentB)
 
     scorer = scoring_func if with_scorer else None
 
@@ -132,7 +132,7 @@ def test_generate_maximal_network(toluene_vs_others, with_progress,
     if scorer:
         for edge in network.edges:
             score = edge.annotations['score']
-            assert score == 1.0 / len(edge.componentA_to_componentB)
+            assert score == len(edge.componentA_to_componentB)
     else:
         for edge in network.edges:
             assert 'score' not in edge.annotations
@@ -150,7 +150,7 @@ def test_minimal_spanning_network_mappers(atom_mapping_basic_test_files, multi_m
         mappers = openfe.setup.atom_mapping.LomapAtomMapper()
 
     def scorer(mapping):
-        return 1.0 / len(mapping.componentA_to_componentB)
+        return len(mapping.componentA_to_componentB)
 
     network = openfe.ligand_network_planning.generate_minimal_spanning_network(
         ligands=ligands,
@@ -168,7 +168,7 @@ def minimal_spanning_network(toluene_vs_others):
     mappers = [BadMapper(), openfe.setup.atom_mapping.LomapAtomMapper()]
 
     def scorer(mapping):
-        return 1.0 / len(mapping.componentA_to_componentB)
+        return len(mapping.componentA_to_componentB)
 
     network = openfe.setup.ligand_network_planning.generate_minimal_spanning_network(
         ligands=others + [toluene],
@@ -221,7 +221,7 @@ def test_minimal_spanning_network_unreachable(toluene_vs_others):
     nimrod = openfe.SmallMoleculeComponent(mol_from_smiles("N"))
 
     def scorer(mapping):
-        return 1.0 / len(mapping.componentA_to_componentB)
+        return len(mapping.componentA_to_componentB)
 
     with pytest.raises(RuntimeError, match="Unable to create edges"):
         network = openfe.setup.ligand_network_planning.generate_minimal_spanning_network(


### PR DESCRIPTION
Previously 0.0 was used for "good" scores and 1.0 for "bad" scores, so networks could be created according to considering the total sum of all weights across a network as the cost function.  This created friction with existing and ongoing efforts, where 1.0 is considered perfect "similarity" and 0.0 is bad/no similarity.

This PR flips scores around to align with community practice.

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
