### PR TITLE
Allow extra attributes in AlchemicalSettings

### DIFF
--- a/openfe/protocols/openmm_rfe/equil_rfe_settings.py
+++ b/openfe/protocols/openmm_rfe/equil_rfe_settings.py
@@ -26,6 +26,9 @@ from openfe.protocols.openmm_utils.omm_settings import (
 
 
 class AlchemicalSettings(SettingsBaseModel):
+    class Config:
+        extra = 'ignore'
+
     """Settings for the alchemical protocol
 
     This describes the lambda schedule and the creation of the


### PR DESCRIPTION
a temporary fix following #521 causing grief with `test_gather` which uses older files.

Should probably should go further and raise a warning on bad attributes (with spell correct suggestions too?), will raise an issue.


## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
