### PR TITLE
Fix energy results out

### DIFF
--- a/openfe/protocols/openmm_rfe/equil_rfe_methods.py
+++ b/openfe/protocols/openmm_rfe/equil_rfe_methods.py
@@ -204,10 +204,8 @@ class RelativeHybridTopologyProtocolResult(gufe.ProtocolResult):
         -------
         forward_reverse : dict[str, Union[npt.NDArray, unit.Quantity]]
         """
-        forward_reverse = [
-            pus[0].outputs['_forward_and_reverse_energies']
-            for pus in self.data.values()
-        ]
+        forward_reverse = [pus[0].outputs['forward_and_reverse_energies']
+                           for pus in self.data.values()]
 
         return forward_reverse
 
@@ -227,10 +225,8 @@ class RelativeHybridTopologyProtocolResult(gufe.ProtocolResult):
               state i in state j
         """
         # Loop through and get the repeats and get the matrices
-        overlap_stats = [
-            pus[0].outputs['_unit_mbar_overlap']
-            for pus in self.data.values()
-        ]
+        overlap_stats = [pus[0].outputs['unit_mbar_overlap']
+                         for pus in self.data.values()]
 
         return overlap_stats
 
@@ -254,10 +250,8 @@ class RelativeHybridTopologyProtocolResult(gufe.ProtocolResult):
               from state i to state j.
         """
         try:
-            repex_stats = [
-                pus[0].outputs['_replica_exchange_statistics']
-                for pus in self.data.values()
-            ]
+            repex_stats = [pus[0].outputs['replica_exchange_statistics']
+                           for pus in self.data.values()]
         except KeyError:
             errmsg = ("Replica exchange statistics were not found, "
                       "did you run a repex calculation?")
@@ -274,10 +268,8 @@ class RelativeHybridTopologyProtocolResult(gufe.ProtocolResult):
         replica_states : List[npt.NDArray]
           List of replica states for each repeat
         """
-        replica_states = [
-            pus[0].outputs['_replica_states']
-            for pus in self.data.values()
-        ]
+        replica_states = [pus[0].outputs['replica_states']
+                          for pus in self.data.values()]
 
         return replica_states
 
@@ -290,10 +282,8 @@ class RelativeHybridTopologyProtocolResult(gufe.ProtocolResult):
         -------
         equilibration_lengths : list[float]
         """
-        equilibration_lengths = [
-            pus[0].outputs['_equilibration_iterations']
-            for pus in self.data.values()
-        ]
+        equilibration_lengths = [pus[0].outputs['equilibration_iterations']
+                                 for pus in self.data.values()]
 
         return equilibration_lengths
 
@@ -306,10 +296,8 @@ class RelativeHybridTopologyProtocolResult(gufe.ProtocolResult):
         -------
         production_lengths : list[float]
         """
-        production_lengths = [
-            pus[0].outputs['_production_iterations']
-            for pus in self.data.values()
-        ]
+        production_lengths = [pus[0].outputs['production_iterations']
+                              for pus in self.data.values()]
 
         return production_lengths
 

--- a/openfe/protocols/openmm_utils/multistate_analysis.py
+++ b/openfe/protocols/openmm_utils/multistate_analysis.py
@@ -125,6 +125,9 @@ class MultistateEquilFEAnalysis:
         """
         # Do things that get badly cached later
         self._replica_states = self.analyzer.reporter.read_replica_thermodynamic_states()
+        # convert full masked array to simple array
+        # downcast to int32, we don't have more than 4 billion states thankfully
+        self._replica_states = np.asarray(self._replica_states, dtype=np.int32)
         # float conversions to avoid having to deal with numpy dtype serialization
         self._equil_iters = float(self.analyzer.n_equilibration_iterations)
         self._prod_iters = float(self.analyzer._equilibration_data[2])

--- a/openfe/protocols/openmm_utils/multistate_analysis.py
+++ b/openfe/protocols/openmm_utils/multistate_analysis.py
@@ -312,6 +312,8 @@ class MultistateEquilFEAnalysis:
         try:
             # pymbar 3
             overlap_matrix = self.analyzer.mbar.computeOverlap()
+            # convert matrix to np array
+            overlap_matrix['matrix'] = np.array(overlap_matrix['matrix'])
         except AttributeError:
             overlap_matrix = self.analyzer.mbar.compute_overlap()
 


### PR DESCRIPTION
This fixes a couple of issues in the energetics results dict:
- the overlap matrix came out as a np.matrix object (because of old pymbar), so coerce this into a numpy array
- the states array came out as a masked array, which had a full mask (i.e. didn't lack any data), so again coerce this into a numpy array

This allows the results array to roundtrip, except for an issue with forwards/backwards analysis which requires a fix in gufe

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
