### PR TITLE
Improve error message if missing one leg for ligand pair

### DIFF
--- a/openfecli/commands/gather.py
+++ b/openfecli/commands/gather.py
@@ -107,8 +107,10 @@ def _get_ddgs(legs):
             if not ((DG1_mag is None) or (DG2_mag is None)):
                 DDGhyd = (DG1_mag - DG2_mag).m
                 hyd_unc = np.sqrt(np.sum(np.square([DG1_unc.m, DG2_unc.m])))
-        else:  # -no-cov-
-            raise RuntimeError(f"Unknown DDG type for {vals}")
+        else:
+            raise RuntimeError("Unable to determine type of RFE calculation "
+                               f"for edges with labels {list(vals)} for "
+                               f"ligands {ligpair}")
 
         DDGs.append((*ligpair, DDGbind, bind_unc, DDGhyd, hyd_unc))
 

--- a/openfecli/tests/commands/test_gather.py
+++ b/openfecli/tests/commands/test_gather.py
@@ -2,6 +2,7 @@ from click.testing import CliRunner
 import glob
 from importlib import resources
 import tarfile
+import pathlib
 import pytest
 
 from openfecli.commands.gather import (
@@ -106,3 +107,15 @@ def test_gather(results_dir, report):
 
     assert set(expected.split(b'\n')) == actual_lines
 
+
+def test_missing_leg_error(results_dir):
+    file_to_remove = "easy_rbfe_lig_ejm_31_complex_lig_ejm_42_complex.json"
+    (pathlib.Path("results") / file_to_remove).unlink()
+
+    runner = CliRunner()
+    result = runner.invoke(gather, ['results'] + ['-o', '-'])
+    assert result.exit_code == 1
+    assert isinstance(result.exception, RuntimeError)
+    assert "labels ['solvent']" in str(result.exception)
+    assert "'lig_ejm_31'" in str(result.exception)
+    assert "'lig_ejm_42'" in str(result.exception)


### PR DESCRIPTION
New error message looks something like this:

```pytb
RuntimeError: Unable to determine type of RFE calculation for edges with labels ['solvent'] for ligands ('lig_ejm_31', 'lig_ejm_42')
```

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
