### PR TITLE
Explicitly set navigation_keys to False to avoid warning

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -137,6 +137,7 @@ html_theme_options = {
         }
     ],
     "accent_color": "DarkGoldenYellow",
+    "navigation_with_keys": False,
 }
 html_logo = "_static/Squaredcircle.svg"
 


### PR DESCRIPTION
I _think_ this warning is causing builds to fail, either way we should just define it.

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
