### PR TITLE
Add `gather --allow-partial`, improve related error message

### DIFF
--- a/openfecli/commands/gather.py
+++ b/openfecli/commands/gather.py
@@ -110,7 +110,7 @@ def _generate_bad_legs_error_message(set_vals, ligpair):
             f"for ligands {ligpair}. Those ligands are missing one "
             f"of: {(expected_rhfe | expected_rbfe) - set_vals}."
         )
-    else:
+    else:  # -no-cov-
         # this should never happen
         msg = (
             "Something went very wrong while determining the type "

--- a/openfecli/commands/gather.py
+++ b/openfecli/commands/gather.py
@@ -164,7 +164,7 @@ def _get_ddgs(legs, error_on_missing=True):
 
 
 def _write_ddg(legs, writer, allow_partial):
-    DDGs = _get_ddgs(legs)
+    DDGs = _get_ddgs(legs, error_on_missing=not allow_partial)
     writer.writerow(["ligand_i", "ligand_j", "DDG(i->j) (kcal/mol)",
                       "uncertainty (kcal/mol)"])
     for ligA, ligB, DDGbind, bind_unc, DDGhyd, hyd_unc in DDGs:

--- a/openfecli/commands/gather.py
+++ b/openfecli/commands/gather.py
@@ -138,20 +138,25 @@ def _get_ddgs(legs, error_on_missing=True):
         bind_unc = None
         hyd_unc = None
 
-        if set_vals == {'complex', 'solvent'}:
+        do_rbfe = (len(set_vals & {'complex', 'solvent'}) == 2)
+        do_rhfe = (len(set_vals & {'vacuum', 'solvent'}) == 2)
+
+        if do_rbfe:
             DG1_mag, DG1_unc = vals['complex']
             DG2_mag, DG2_unc = vals['solvent']
             if not ((DG1_mag is None) or (DG2_mag is None)):
                 # DDG(2,1)bind = DG(1->2)complex - DG(1->2)solvent
                 DDGbind = (DG1_mag - DG2_mag).m
                 bind_unc = np.sqrt(np.sum(np.square([DG1_unc.m, DG2_unc.m])))
-        elif set_vals == {'vacuum', 'solvent'}:
+
+        if do_rhfe:
             DG1_mag, DG1_unc = vals['solvent']
             DG2_mag, DG2_unc = vals['vacuum']
             if not ((DG1_mag is None) or (DG2_mag is None)):
                 DDGhyd = (DG1_mag - DG2_mag).m
                 hyd_unc = np.sqrt(np.sum(np.square([DG1_unc.m, DG2_unc.m])))
-        else:
+
+        if not do_rbfe and not do_rhfe:
             msg = _generate_bad_legs_error_message(set_vals, ligpair)
             if error_on_missing:
                 raise RuntimeError(msg)

--- a/openfecli/tests/commands/test_gather.py
+++ b/openfecli/tests/commands/test_gather.py
@@ -132,6 +132,16 @@ def test_missing_leg_error(results_dir):
     result = runner.invoke(gather, ['results'] + ['-o', '-'])
     assert result.exit_code == 1
     assert isinstance(result.exception, RuntimeError)
-    assert "labels ['solvent']" in str(result.exception)
+    assert "Unable to determine" in str(result.exception)
     assert "'lig_ejm_31'" in str(result.exception)
     assert "'lig_ejm_42'" in str(result.exception)
+
+
+def test_missing_leg_allow_partial(results_dir):
+    file_to_remove = "easy_rbfe_lig_ejm_31_complex_lig_ejm_42_complex.json"
+    (pathlib.Path("results") / file_to_remove).unlink()
+
+    runner = CliRunner()
+    result = runner.invoke(gather,
+                           ['results'] + ['--allow-partial', '-o', '-'])
+    assert result.exit_code == 0

--- a/openfecli/tests/commands/test_gather.py
+++ b/openfecli/tests/commands/test_gather.py
@@ -6,7 +6,8 @@ import pathlib
 import pytest
 
 from openfecli.commands.gather import (
-    gather, format_estimate_uncertainty, _get_column
+    gather, format_estimate_uncertainty, _get_column,
+    _generate_bad_legs_error_message,
 )
 
 @pytest.mark.parametrize('est,unc,unc_prec,est_str,unc_str', [
@@ -106,6 +107,21 @@ def test_gather(results_dir, report):
     actual_lines = set(result.stdout_bytes.split(b'\n'))
 
     assert set(expected.split(b'\n')) == actual_lines
+
+
+@pytest.mark.parametrize('include', ['complex', 'solvent', 'vacuum'])
+def test_generate_bad_legs_error_message(include):
+    expected = {
+        'complex': ("appears to be an RBFE", "missing {'solvent'}"),
+        'vacuum': ("appears to be an RHFE", "missing {'solvent'}"),
+        'solvent': ("whether this is an RBFE or an RHFE",
+                    "'complex'", "'solvent'"),
+    }[include]
+    set_vals = {include}
+    ligpair = {'lig1', 'lig2'}
+    msg = _generate_bad_legs_error_message(set_vals, ligpair)
+    for string in expected:
+        assert string in msg
 
 
 def test_missing_leg_error(results_dir):


### PR DESCRIPTION
1. Improves error messages for the case that not all edges have both legs.

2. Adds `--allow-partial` flag to allow results to be collected even if some parts of legs are missing.

The error messages will now look like this:


`This appears to be an RBFE calculation, but we're missing {'solvent'} runs for the edge with ligands {'lig1', 'lig2'}.`
`You can force partial gathering of results, without problematic edges, by using the --allow-partial flag of the gather command. Note that this may cause problems with predicting absolute free energies from the relative free energies.`

`This appears to be an RHFE calculation, but we're missing {'solvent'} runs for the edge with ligands {'lig1', 'lig2'}.`
`You can force partial gathering of results, without problematic edges, by using the --allow-partial flag of the gather command. Note that this may cause problems with predicting absolute free energies from the relative free energies.`

`Unable to determine whether this is an RBFE or an RHFE calculation. Found legs {'solvent'} for ligands {'lig2', 'lig1'}. Those ligands are missing one of: {'complex', 'vacuum'}.`
`You can force partial gathering of results, without problematic edges, by using the --allow-partial flag of the gather command. Note that this may cause problems with predicting absolute free energies from the relative free energies.`


# Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
