### PR TITLE
[skip ci] Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Logo](https://img.shields.io/badge/OSMF-OpenFreeEnergy-%23002f4a)](https://openfree.energy/)
-[![build](https://github.com/OpenFreeEnergy/openfe/actions/workflows/ci.yaml/badge.svg)](https://github.com/OpenFreeEnergy/openfe/actions/workflows/ci.yaml)
+[![build](https://github.com/OpenFreeEnergy/openfe/actions/workflows/ci.yaml/badge.svg?event=schedule)](https://github.com/OpenFreeEnergy/openfe/actions/workflows/ci.yaml)
 [![coverage](https://codecov.io/gh/OpenFreeEnergy/openfe/branch/main/graph/badge.svg)](https://codecov.io/gh/OpenFreeEnergy/openfe)
 [![documentation](https://readthedocs.org/projects/openfe/badge/?version=latest)](https://openfe.readthedocs.io/en/latest/?badge=latest)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.8344248.svg)](https://doi.org/10.5281/zenodo.8344248)


### PR DESCRIPTION
the CI badge was picking up whatever the most recent CI (potentially on a PR) was.  This changes it to show the last scheduled (most comprehensive) CI run.


## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
