### PR TITLE
update to use openfe_analysis 0.2.0+

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -22,7 +22,7 @@ dependencies:
   - openff-units==0.2.0
   - pint<0.22
   - openff-models>=0.0.5
-  - openfe-analysis>=0.1.2
+  - openfe-analysis>=0.2.0
   - click
   - typing-extensions
   - lomap2>=2.3.0

--- a/openfe/protocols/openmm_rfe/equil_rfe_methods.py
+++ b/openfe/protocols/openmm_rfe/equil_rfe_methods.py
@@ -991,13 +991,17 @@ class RelativeHybridTopologyProtocolUnit(gufe.ProtocolUnit):
     def analyse(where) -> dict:
         # don't put energy analysis in here, it uses the open file reporter
         # whereas structural stuff requires that the file handle is closed
-        ret = subprocess.run(['openfe_analysis', str(where)],
+        analysis_out = where / 'structural_analysis.json'
+
+        ret = subprocess.run(['openfe_analysis', 'RFE_analysis',
+                              str(where), str(analysis_out)],
                              stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE)
         if ret.returncode:
             return {'structural_analysis_error': ret.stderr}
 
-        data = json.loads(ret.stdout)
+        with open(analysis_out, 'rb') as f:
+            data = json.load(f)
 
         savedir = pathlib.Path(where)
         if d := data['protein_2D_RMSD']:

--- a/openfe/tests/protocols/test_openmm_rfe_slow.py
+++ b/openfe/tests/protocols/test_openmm_rfe_slow.py
@@ -84,6 +84,7 @@ def test_openmm_run_engine(benzene_vacuum_system, platform,
         nc = pur.outputs['nc']
         assert nc == unit_shared / "simulation.nc"
         assert nc.exists()
+        assert (unit_shared / "structural_analysis.json").exists()
 
     # Test results methods that need files present
     results = p.gather([r])


### PR DESCRIPTION
this change makes the structural analysis create a file "openfe_analysis.json"

this fixes a previous issue where duecredit output would "contaminate" the stdout, making the previous piping of stdout not viable.


## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
