### PR TITLE
Tokenizable atom mappers

### DIFF
--- a/openfe/tests/setup/atom_mapping/test_atommapper.py
+++ b/openfe/tests/setup/atom_mapping/test_atommapper.py
@@ -23,6 +23,17 @@ class TestAtomMapper:
             def __init__(self, mappings):
                 self.mappings = mappings
 
+            @classmethod
+            def _defaults(cls):
+                return {}
+
+            def _to_dict(self):
+                return {'mappings': self.mappings}
+
+            @classmethod
+            def _from_dict(cls, dct):
+                return cls(**dct)
+
             def _mappings_generator(self, componentA, componentB):
                 for mapping in self.mappings:
                     yield mapping.componentA_to_componentB

--- a/openfe/tests/setup/test_network_planning.py
+++ b/openfe/tests/setup/test_network_planning.py
@@ -10,6 +10,17 @@ from ..conftest import mol_from_smiles
 
 
 class BadMapper(openfe.setup.atom_mapping.LigandAtomMapper):
+    @classmethod
+    def _defaults(cls):
+        return {}
+
+    def _to_dict(self):
+        return {}
+
+    @classmethod
+    def _from_dict(cls, d):
+        return cls()
+
     def _mappings_generator(self, molA, molB):
         yield {0: 0}
 


### PR DESCRIPTION
Following this change, https://github.com/OpenFreeEnergy/gufe/pull/266 updates to openfe


## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
