### PR TITLE
Change default settings lambda_restraints

### DIFF
--- a/openfe/protocols/openmm_afe/equil_solvation_afe_method.py
+++ b/openfe/protocols/openmm_afe/equil_solvation_afe_method.py
@@ -410,12 +410,14 @@ class AbsoluteSolvationProtocol(gufe.Protocol):
             alchemical_settings=AlchemicalSettings(),
             lambda_settings=LambdaSettings(
                 lambda_elec=[
-                    0.0, 0.25, 0.5, 0.75, 1.0, 1.0, 1.0,
-                    1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0
-                ],
+                    0.0, 0.0, 0.0, 0.0, 0.0, 0.12, 0.24,
+                    0.36, 0.48, 0.6, 0.7, 0.77, 0.85, 1.0],
                 lambda_vdw=[
                     0.0, 0.0, 0.0, 0.0, 0.0, 0.12, 0.24,
                     0.36, 0.48, 0.6, 0.7, 0.77, 0.85, 1.0],
+                lambda_restraints=[
+                    0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                    0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
             ),
             partial_charge_settings=OpenFFPartialChargeSettings(),
             solvation_settings=OpenMMSolvationSettings(),
@@ -587,14 +589,15 @@ class AbsoluteSolvationProtocol(gufe.Protocol):
         n_replicas = simulation_settings.n_replicas
 
         # Ensure that all lambda components have equal amount of windows
-        lambda_components = [lambda_vdw, lambda_elec]
+        lambda_components = [lambda_vdw, lambda_elec, lambda_restraints]
         it = iter(lambda_components)
         the_len = len(next(it))
         if not all(len(l) == the_len for l in it):
             errmsg = (
-                "Components elec and vdw must have equal amount"
+                "Components elec, vdw, and restraints must have equal amount"
                 f" of lambda windows. Got {len(lambda_elec)} elec lambda"
-                f" windows and {len(lambda_vdw)} vdw lambda windows.")
+                f" windows, {len(lambda_vdw)} vdw lambda windows, and"
+                f"{len(lambda_restraints)} restraints lambda windows.")
             raise ValueError(errmsg)
 
         # Ensure that number of overall lambda windows matches number of lambda

--- a/openfe/protocols/openmm_afe/equil_solvation_afe_method.py
+++ b/openfe/protocols/openmm_afe/equil_solvation_afe_method.py
@@ -410,8 +410,8 @@ class AbsoluteSolvationProtocol(gufe.Protocol):
             alchemical_settings=AlchemicalSettings(),
             lambda_settings=LambdaSettings(
                 lambda_elec=[
-                    0.0, 0.0, 0.0, 0.0, 0.0, 0.12, 0.24,
-                    0.36, 0.48, 0.6, 0.7, 0.77, 0.85, 1.0],
+                    0.0, 0.25, 0.5, 0.75, 1.0, 1.0, 1.0,
+                    1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
                 lambda_vdw=[
                     0.0, 0.0, 0.0, 0.0, 0.0, 0.12, 0.24,
                     0.36, 0.48, 0.6, 0.7, 0.77, 0.85, 1.0],

--- a/openfe/tests/protocols/test_openmm_afe_solvation_protocol.py
+++ b/openfe/tests/protocols/test_openmm_afe_solvation_protocol.py
@@ -116,10 +116,6 @@ def test_validate_lambda_schedule_nwindows(val, default_settings):
     default_settings.lambda_settings.lambda_restraints = val['restraints']
     n_replicas = 3
     default_settings.vacuum_simulation_settings.n_replicas = n_replicas
-    # errmsg = (
-    #     "Components elec and vdw must have equal amount"
-    #     f" of lambda windows. Got {len(val['elec'])} elec lambda"
-    #     f" windows and {len(val['vdw'])} vdw lambda windows.")
     errmsg = (
         "Components elec, vdw, and restraints must have equal amount"
         f" of lambda windows. Got {len(val['elec'])} elec lambda"

--- a/openfe/tests/protocols/test_openmm_afe_solvation_protocol.py
+++ b/openfe/tests/protocols/test_openmm_afe_solvation_protocol.py
@@ -116,10 +116,15 @@ def test_validate_lambda_schedule_nwindows(val, default_settings):
     default_settings.lambda_settings.lambda_restraints = val['restraints']
     n_replicas = 3
     default_settings.vacuum_simulation_settings.n_replicas = n_replicas
+    # errmsg = (
+    #     "Components elec and vdw must have equal amount"
+    #     f" of lambda windows. Got {len(val['elec'])} elec lambda"
+    #     f" windows and {len(val['vdw'])} vdw lambda windows.")
     errmsg = (
-        "Components elec and vdw must have equal amount"
+        "Components elec, vdw, and restraints must have equal amount"
         f" of lambda windows. Got {len(val['elec'])} elec lambda"
-        f" windows and {len(val['vdw'])} vdw lambda windows.")
+        f" windows, {len(val['vdw'])} vdw lambda windows, and"
+        f"{len(val['restraints'])} restraints lambda windows.")
     with pytest.raises(ValueError, match=errmsg):
         AbsoluteSolvationProtocol._validate_lambda_schedule(
             default_settings.lambda_settings,

--- a/openfe/tests/protocols/test_solvation_afe_tokenization.py
+++ b/openfe/tests/protocols/test_solvation_afe_tokenization.py
@@ -49,7 +49,7 @@ def protocol_result(afe_solv_transformation_json):
 
 class TestAbsoluteSolvationProtocol(GufeTokenizableTestsMixin):
     cls = openmm_afe.AbsoluteSolvationProtocol
-    key = "AbsoluteSolvationProtocol-b703c870a1b26167bd06b74e5354eb33"
+    key = "AbsoluteSolvationProtocol-e503d3e7d083ad0dc00cc8abb013952d"
     repr = f"<{key}>"
 
     @pytest.fixture()


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
