### PR TITLE
Add warnings & docs for forward and reverse analysis getters

### DIFF
--- a/news/forward_reverse_warning.rst
+++ b/news/forward_reverse_warning.rst
@@ -1,0 +1,25 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Calling `get_forward_and_reverse_energy_analysis` in the RFE and AFE
+  protocols now results a warning if any results are ``None`` due to
+  MBAR convergence issues.
+
+**Security:**
+
+* <news item>

--- a/openfe/protocols/openmm_afe/equil_solvation_afe_method.py
+++ b/openfe/protocols/openmm_afe/equil_solvation_afe_method.py
@@ -218,7 +218,7 @@ class AbsoluteSolvationProtocolResult(gufe.ProtocolResult):
             if None in forward_reverse[key]:
                 wmsg = (
                     "One or more ``None`` entries were found in the forward "
-                    f"and reverse dictionaries of the repeats of the {type} "
+                    f"and reverse dictionaries of the repeats of the {key} "
                     "calculations. This is likely caused by an MBAR convergence "
                     "failure caused by too few independent samples when "
                     "calculating the free energies of the 10% timeseries slice."

--- a/openfe/protocols/openmm_afe/equil_solvation_afe_method.py
+++ b/openfe/protocols/openmm_afe/equil_solvation_afe_method.py
@@ -180,7 +180,7 @@ class AbsoluteSolvationProtocolResult(gufe.ProtocolResult):
 
         Returns
         -------
-        forward_reverse : dict[str, Optional[list[dict[str, Union[npt.NDArray, unit.Quantity]]]]]
+        forward_reverse : dict[str, list[Optional[dict[str, Union[npt.NDArray, unit.Quantity]]]]]
             A dictionary, keyed `solvent` and `vacuum` for each leg of the
             thermodynamic cycle which each contain a list of dictionaries
             containing the forward and reverse analysis of each repeat
@@ -195,19 +195,19 @@ class AbsoluteSolvationProtocolResult(gufe.ProtocolResult):
                   The forward and reverse estimate uncertainty for each
                   fraction of data.
 
-            If the forward and reverse dictionary is ``None`` this indicates
+            If one of the cycle leg list entries is ``None``, this indicates
             that the analysis could not be carried out for that repeat. This
-            is most likely due to MBAR convergence issues when attempting to
+            is most likely caused by MBAR convergence issues when attempting to
             calculate free energies from too few samples.
 
         Raises
         ------
         UserWarning
           * If any of the forward and reverse dictionaries are ``None`` in a
-            given simulation type.
+            given thermodynamic cycle leg.
         """
 
-        forward_reverse: dict[str, list[dict[str, Union[npt.NDArray, unit.Quantity]]]] = {}
+        forward_reverse: dict[str, list[Optional[dict[str, Union[npt.NDArray, unit.Quantity]]]]] = {}
 
         for key in ['solvent', 'vacuum']:
             forward_reverse[key] = [

--- a/openfe/protocols/openmm_rfe/equil_rfe_methods.py
+++ b/openfe/protocols/openmm_rfe/equil_rfe_methods.py
@@ -304,7 +304,7 @@ class RelativeHybridTopologyProtocolResult(gufe.ProtocolResult):
                for pus in self.data.values()]
         return dGs
 
-    def get_forward_and_reverse_energy_analysis(self) -> list[dict[str, Union[npt.NDArray, unit.Quantity]]]:
+    def get_forward_and_reverse_energy_analysis(self) -> list[Optional[dict[str, Union[npt.NDArray, unit.Quantity]]]]:
         """
         Get a list of forward and reverse analysis of the free energies
         for each repeat using uncorrelated production samples.
@@ -317,12 +317,34 @@ class RelativeHybridTopologyProtocolResult(gufe.ProtocolResult):
         The 'fractions' values are a numpy array, while the other arrays are
         Quantity arrays, with units attached.
 
+        If the list entry is ``None`` instead of a dictionary, this indicates
+        that the analysis could not be carried out for that repeat. This
+        is most likely caused by MBAR convergence issues when attempting to
+        calculate free energies from too few samples.
+
+
         Returns
         -------
-        forward_reverse : dict[str, Union[npt.NDArray, unit.Quantity]]
+        forward_reverse : list[Optional[dict[str, Union[npt.NDArray, unit.Quantity]]]]
+
+
+        Raises
+        ------
+        UserWarning
+          If any of the forward and reverse entries are ``None``.
         """
         forward_reverse = [pus[0].outputs['forward_and_reverse_energies']
                            for pus in self.data.values()]
+
+        if None in forward_reverse:
+            wmsg = (
+                "One or more ``None`` entries were found in the list of "
+                "forward and reverse analyses. This is likely caused by "
+                "an MBAR convergence failure caused by too few independent "
+                "samples when calculating the free energies of the 10% "
+                "timeseries slice."
+            )
+            warnings.warn(wmsg)
 
         return forward_reverse
 

--- a/openfe/tests/protocols/test_openmm_afe_solvation_protocol.py
+++ b/openfe/tests/protocols/test_openmm_afe_solvation_protocol.py
@@ -793,6 +793,19 @@ class TestProtocolResult:
                 assert isinstance(far1[k], np.ndarray)
 
     @pytest.mark.parametrize('key', ['solvent', 'vacuum'])
+    def test_get_frwd_reverse_none_return(self, key, protocolresult):
+        # fetch the first result of type key
+        data = [i for i in protocolresult.data[key].values()][0][0]
+        # set the output to None
+        data.outputs['forward_and_reverse_energies'] = None
+
+        # now fetch the analysis results and expect a warning
+        wmsg = ("were found in the forward and reverse dictionaries "
+                f"of the repeats of the {key}")
+        with pytest.warns(UserWarning, match=wmsg):
+            protocolresult.get_forward_and_reverse_energy_analysis()
+
+    @pytest.mark.parametrize('key', ['solvent', 'vacuum'])
     def test_get_overlap_matrices(self, key, protocolresult):
         ovp = protocolresult.get_overlap_matrices()
 

--- a/openfe/tests/protocols/test_openmm_equil_rfe_protocols.py
+++ b/openfe/tests/protocols/test_openmm_equil_rfe_protocols.py
@@ -1543,6 +1543,17 @@ class TestProtocolResult:
                 assert isinstance(far1[k], unit.Quantity)
                 assert far1[k].is_compatible_with(unit.kilojoule_per_mole)
 
+    def test_none_foward_reverse_energies(self, protocolresult):
+        # get the first entry's results
+        data = [i for i in protocolresult.data.values()][0][0]
+        # set the forward and reverse analysis to None
+        data.outputs['forward_and_reverse_energies'] = None
+
+        # now call the getter and expect a user warning
+        wmsg = "One or more ``None`` entries were found in"
+        with pytest.warns(UserWarning, match=wmsg):
+            protocolresult.get_forward_and_reverse_energy_analysis()
+
     def test_get_overlap_matrices(self, protocolresult):
         ovp = protocolresult.get_overlap_matrices()
 


### PR DESCRIPTION
Fixes #740

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [x] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
