### PR TITLE
Fix ahfe integration tests - missing restraints lamdas

### DIFF
--- a/openfe/tests/protocols/test_openmm_afe_slow.py
+++ b/openfe/tests/protocols/test_openmm_afe_slow.py
@@ -64,12 +64,15 @@ def test_openmm_run_engine(platform,
     s.solvent_output_settings.checkpoint_interval = 20 * unit.femtosecond
     s.vacuum_simulation_settings.n_replicas = 20
     s.solvent_simulation_settings.n_replicas = 20
-    s.lambda_settings.lambda_elec = \
-        [0.0, 0.25, 0.5, 0.75, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
-        1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
-    s.lambda_settings.lambda_vdw = \
-        [0.0, 0.0, 0.0, 0.0, 0.0, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5,
-        0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95, 1.0]
+    s.lambda_settings.lambda_elec = [
+        0.0, 0.25, 0.5, 0.75, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+        1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0
+    ]
+    s.lambda_settings.lambda_vdw = [
+        0.0, 0.0, 0.0, 0.0, 0.0, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5,
+        0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95, 1.0
+    ]
+    s.lambda_settings.lambda_restraints = [0.0 for i in range(20)]
 
 
     protocol = openmm_afe.AbsoluteSolvationProtocol(


### PR DESCRIPTION
Fix the tests for #735 

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
