### PR TITLE
docs: update badge on front page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Logo](https://img.shields.io/badge/OSMF-OpenFreeEnergy-%23002f4a)](https://openfree.energy/)
 [![build](https://github.com/OpenFreeEnergy/openfe/actions/workflows/ci.yaml/badge.svg?event=schedule)](https://github.com/OpenFreeEnergy/openfe/actions/workflows/ci.yaml)
 [![coverage](https://codecov.io/gh/OpenFreeEnergy/openfe/branch/main/graph/badge.svg)](https://codecov.io/gh/OpenFreeEnergy/openfe)
-[![documentation](https://readthedocs.org/projects/openfe/badge/?version=latest)](https://openfe.readthedocs.io/en/latest/?badge=latest)
+[![documentation](https://readthedocs.org/projects/openfe/badge/?version=stable)](https://docs.openfree.energy/en/stable/?badge=stable)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.8344248.svg)](https://doi.org/10.5281/zenodo.8344248)
 
 
@@ -12,16 +12,13 @@ a pre competitive consortium aiming to provide robust, permissively licensed ope
 
 Using `openfe` you can easily plan and execute alchemical free energy calculations.
 
-See our [website](https://openfree.energy/) for more information,
-or [try for yourself](https://try.openfree.energy) from the comfort of your browser.
+See our [website](https://openfree.energy/) for more information on the project,
+[try for yourself](https://try.openfree.energy) from the comfort of your browser,
+and we have [documentation on using the package](https://docs.openfree.energy/en/latest/index.html).
 
 ## License
 
 This library is made available under the [MIT](https://opensource.org/licenses/MIT) open source license.
-
-## Important note
-
-This is pre-alpha work, it should not be considered ready for production and API changes are expected at any time without prior warning.
 
 ## Install
 


### PR DESCRIPTION
fixes #312 

This badge should point to stable/released docs, so people are linked to what documents the thing that they are most likely to be using.  Most people will be using conda builds, not dev/source builds, if they're using dev builds they'll also know how to get to the dev docs.

Removed disclaimer on pre-alpha status, we're 1.0rc

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
