### PR TITLE
Test rdkit mypy failure

### DIFF
--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -35,7 +35,7 @@ jobs:
           cache-environment-key: environment-${{ steps.date.outputs.date }}
           cache-downloads-key: downloads-${{ steps.date.outputs.date }}
           create-args: >-
-            python="3.10"
+            python=3.10
           init-shell: bash
 
       - name: "Install steps"

--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -35,7 +35,7 @@ jobs:
           cache-environment-key: environment-${{ steps.date.outputs.date }}
           cache-downloads-key: downloads-${{ steps.date.outputs.date }}
           create-args: >-
-            python=3.9
+            python="3.10"
           init-shell: bash
 
       - name: "Install steps"

--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -35,7 +35,7 @@ jobs:
           cache-environment-key: environment-${{ steps.date.outputs.date }}
           cache-downloads-key: downloads-${{ steps.date.outputs.date }}
           create-args: >-
-            python=3.10
+            python=3.11
           init-shell: bash
 
       - name: "Install steps"

--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,7 @@ dependencies:
   - coverage
   - cinnabar ==0.3.0
   - openff-toolkit>=0.13.0
-  - openff-nagl-base >=0.3.3
+  - openff-nagl-base >=0.3.3,<0.3.7
   - openff-units==0.2.0
   - pint<0.22
   - openff-models>=0.0.5


### PR DESCRIPTION
Quickly testing something whilst I'm looking at CI.

Mypy doesn't fail for me locally (python 3.11 build), so I'm not sure why it would fail in CI :/


Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
