### PR TITLE
docs: fix links from top of each notebook

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -186,17 +186,19 @@ except Exception as e:
         f"Getting ExampleNotebooks failed in {filename} line {lineno}: {e}"
     )
 
+
+# First, create links at top of notebook pages
+# All notebooks are in ExampleNotebooks repo, so link to that
+# Finally, add sphinx reference anchor in prolog so that we can make refs
 nbsphinx_prolog = cleandoc(r"""
-    {%- set path = env.doc2path(env.docname, base="ExampleNotebooks") -%}
-    {%- set gh_repo = "OpenFreeEnergy/openfe" -%}
+    {%- set gh_repo = "OpenFreeEnergy/ExampleNotebooks" -%}
     {%- set gh_branch = "main" -%}
     {%- set path = env.doc2path(env.docname, base=None) -%}
     {%- if path.endswith(".nblink") -%}
         {%- set path = env.metadata[env.docname]["nbsphinx-link-target"] -%}
     {%- endif -%}
-    {%- if path.startswith("docs/ExampleNotebooks") -%}
-        {%- set path = path.replace("docs/ExampleNotebooks/", "", 1) -%}
-        {%- set gh_repo = "OpenFreeEnergy/ExampleNotebooks" -%}
+    {%- if path.startswith("ExampleNotebooks/") -%}
+        {%- set path = path.replace("ExampleNotebooks/", "", 1) -%}
     {%- endif -%}
     {%- set gh_url =
         "https://www.github.com/"


### PR DESCRIPTION
fixes #784

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
