### PR TITLE
fix to Protocol keys after off v2.1.1 bump in gufe base settings

### DIFF
--- a/openfe/tests/protocols/test_rfe_tokenization.py
+++ b/openfe/tests/protocols/test_rfe_tokenization.py
@@ -39,7 +39,7 @@ class TestRelativeHybridTopologyProtocolResult(GufeTokenizableTestsMixin):
 
 class TestRelativeHybridTopologyProtocol(GufeTokenizableTestsMixin):
     cls = openmm_rfe.RelativeHybridTopologyProtocol
-    key = "RelativeHybridTopologyProtocol-5f055c0d41c2b02da33c05af5815eff4"
+    key = "RelativeHybridTopologyProtocol-bfb2f60bea0352a15bf6832d14d6e46e"
     repr = f"<{key}>"
 
     @pytest.fixture()

--- a/openfe/tests/protocols/test_solvation_afe_tokenization.py
+++ b/openfe/tests/protocols/test_solvation_afe_tokenization.py
@@ -49,7 +49,7 @@ def protocol_result(afe_solv_transformation_json):
 
 class TestAbsoluteSolvationProtocol(GufeTokenizableTestsMixin):
     cls = openmm_afe.AbsoluteSolvationProtocol
-    key = "AbsoluteSolvationProtocol-67418dcea09d10511183707680e12235"
+    key = "AbsoluteSolvationProtocol-c602c05772bd839d7717f4820d2961e1"
     repr = f"<{key}>"
 
     @pytest.fixture()


### PR DESCRIPTION
following: https://github.com/OpenFreeEnergy/gufe/pull/304

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
