### PR TITLE
docs: clarify long tests slightly

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -126,17 +126,25 @@ Now we need to activate our new environment ::
       mamba activate openfe_env
       mamba env config vars set CONDA_SUBDIR=osx-64
 
-To make sure everything is working, run the tests ::
+To quickly check this is working, run the tests ::
 
-  openfe test --long
+  openfe test
 
-The test suite contains several hundred individual tests. This may take up to
-an hour, and all tests should complete with status either passed,
-skipped, or xfailed (expected fail). The very first time you run this, the
+The very first time you run this, the
 initial check that you can import ``openfe`` will take a while, because some
 code is compiled the first time it is encountered. That compilation only
 happens once per installation.
   
+A more expansive test suite can be ran using ::
+
+  openfe test --long
+  
+This test suite contains several hundred individual tests. This may take up to
+an hour, and all tests should complete with status either passed,
+skipped, or xfailed (expected fail).
+This "long" testsuite might be more suited to running as a job on the intended compute
+hardware to run openfe jobs, as it will test GPU specific features.
+
 With that, you should be ready to use ``openfe``!
 
 Single file installer

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -135,15 +135,15 @@ initial check that you can import ``openfe`` will take a while, because some
 code is compiled the first time it is encountered. That compilation only
 happens once per installation.
   
-A more expansive test suite can be ran using ::
+A more expansive test suite can be run using ::
 
   openfe test --long
   
 This test suite contains several hundred individual tests. This may take up to
 an hour, and all tests should complete with status either passed,
 skipped, or xfailed (expected fail).
-This "long" testsuite might be more suited to running as a job on the intended compute
-hardware to run openfe jobs, as it will test GPU specific features.
+This "long" test suite should be run as a job on the compute
+hardware intended to run openfe jobs, as it will test GPU specific features.
 
 With that, you should be ready to use ``openfe``!
 


### PR DESCRIPTION
clarify that `openfe test` is a good smoke test and `openfe test --long` will take while

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
