### PR TITLE
Force the old LomapAtomMapper kwarg defaults on extra test

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,7 @@ dependencies:
   - pydantic >1
   - pyyaml
   - coverage
-  - cinnabar ==0.3.0
+  - cinnabar ~=0.4.0
   - openff-toolkit>=0.13.0
   - openff-nagl-base >=0.3.3
   - openff-units==0.2.0
@@ -27,6 +27,7 @@ dependencies:
   - openfe-analysis>=0.2.0
   - click
   - typing-extensions
+  - openmm !=8.1.0
   - openmmtools
   - openmmforcefields
   - perses

--- a/openfe/tests/setup/atom_mapping/test_lomap_scorers.py
+++ b/openfe/tests/setup/atom_mapping/test_lomap_scorers.py
@@ -189,7 +189,10 @@ def test_heterocycle_score(base, other, name, hit):
     m1 = openfe.SmallMoleculeComponent.from_rdkit(r1)
     m2 = openfe.SmallMoleculeComponent.from_rdkit(r2)
 
-    mapper = openfe.setup.atom_mapping.LomapAtomMapper(threed=False)
+    mapper = openfe.setup.atom_mapping.LomapAtomMapper(
+        time=20, threed=False, max3d=1000.0,
+        element_change=True, seed='', shift=True,
+    )
     mapping = next(mapper.suggest_mappings(m1, m2))
     score = lomap_scorers.heterocycles_score(mapping)
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
