### PR TITLE
Updated installation instructions for conda-lock

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -368,11 +368,19 @@ A `conda-lock`_ file is a cross platform way of specifying a conda environment t
 Unlike the single file installer, an internet connection is required to install from a ``conda-lock`` file.
 We recomend the use of a ``conda-lock`` file when the same conda environment is required across different systems.
 
-See https://github.com/conda/conda-lock?tab=readme-ov-file#installation for instructions on how to install ``conda-lock``.
 
 .. note::
 
-   You will likely need to install ``conda-lock``
+   You will likely need to install ``conda-lock``.
+   We recomend installing ``conda-lock`` in a new virtual environment.
+   This will reduce the chance of dependency conflicts ::
+
+       $ # Install conda lock into a virtual environment
+       $ conda create -n conda-lock -c conda-lock
+       $ # Activate the environment to use the conda-lock command
+       $ conda activate conda-lock
+
+See https://github.com/conda/conda-lock?tab=readme-ov-file#conda-lock for more information on ``conda-lock``.
 
 The latest version of the `conda-lock` file we provide can be downloaded with ::
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -372,7 +372,7 @@ We recomend the use of a ``conda-lock`` file when the same conda environment is 
 .. note::
 
    You will likely need to install ``conda-lock``.
-   We recomend installing ``conda-lock`` in a new virtual environment.
+   We strongly recomend installing ``conda-lock`` in a new virtual environment.
    This will reduce the chance of dependency conflicts ::
 
        $ # Install conda lock into a virtual environment

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -153,8 +153,58 @@ hardware intended to run openfe jobs, as it will test GPU specific features.
 
 With that, you should be ready to use ``openfe``!
 
+``conda-lock`` file
+-------------------
+
+.. _conda-lock: https://github.com/conda/conda-lock?tab=readme-ov-file#conda-lock
+
+A `conda-lock`_ file is a cross platform way of specifying a conda environment that specifies packages in a reproducible way.
+Unlike the single file installer, an internet connection is required to install from a ``conda-lock`` file.
+We recomend the use of a ``conda-lock`` file when the same conda environment is required across different systems.
+
+
+.. note::
+
+   You will likely need to install ``conda-lock``.
+   We strongly recomend installing ``conda-lock`` in a new virtual environment.
+   This will reduce the chance of dependency conflicts ::
+
+       $ # Install conda lock into a virtual environment
+       $ conda create -n conda-lock -c conda-lock
+       $ # Activate the environment to use the conda-lock command
+       $ conda activate conda-lock
+
+See https://github.com/conda/conda-lock?tab=readme-ov-file#conda-lock for more information on ``conda-lock``.
+
+The latest version of the `conda-lock` file we provide can be downloaded with ::
+
+  $ curl -LOJ https://github.com/OpenFreeEnergy/openfe/releases/latest/download/conda-lock-openfe.yml
+
+If a particular version is required, the URL will look like this (using the ``openfe 1.0.1`` release as an example) ::
+
+  $ curl -LOJ https://github.com/OpenFreeEnergy/openfe/releases/download/v1.0.1/conda-lock-openfe-1.0.1.yml
+
+Create a conda environment from the lock file and activate it::
+
+  $ conda-lock install -n openfe conda-lock-openfe.yml
+  $ conda activate openfe
+
+To make sure everything is working, run the tests ::
+
+  $ pytest --pyargs openfe openfecli
+
+The test suite contains several hundred individual tests. This will take a
+few minutes, and all tests should complete with status either passed,
+skipped, or xfailed (expected fail).
+  
+With that, you should be ready to use ``openfe``!
+
 Single file installer
 ---------------------
+
+.. warning::
+
+   The single file installer may modify your ``.bashrc`` in a way that requires manual intervention to access your previous ``conda`` installation 
 
 .. _releases on GitHub: https://github.com/OpenFreeEnergy/openfe/releases
 
@@ -359,51 +409,6 @@ skipped, or xfailed (expected fail).
   
 With that, you should be ready to use ``openfe``!
 
-``conda-lock`` file
--------------------
-
-.. _conda-lock: https://github.com/conda/conda-lock?tab=readme-ov-file#conda-lock
-
-A `conda-lock`_ file is a cross platform way of specifying a conda environment that specifies packages in a reproducible way.
-Unlike the single file installer, an internet connection is required to install from a ``conda-lock`` file.
-We recomend the use of a ``conda-lock`` file when the same conda environment is required across different systems.
-
-
-.. note::
-
-   You will likely need to install ``conda-lock``.
-   We strongly recomend installing ``conda-lock`` in a new virtual environment.
-   This will reduce the chance of dependency conflicts ::
-
-       $ # Install conda lock into a virtual environment
-       $ conda create -n conda-lock -c conda-lock
-       $ # Activate the environment to use the conda-lock command
-       $ conda activate conda-lock
-
-See https://github.com/conda/conda-lock?tab=readme-ov-file#conda-lock for more information on ``conda-lock``.
-
-The latest version of the `conda-lock` file we provide can be downloaded with ::
-
-  $ curl -LOJ https://github.com/OpenFreeEnergy/openfe/releases/latest/download/conda-lock-openfe.yml
-
-If a particular version is required, the URL will look like this (using the ``openfe 1.0.1`` release as an example) ::
-
-  $ curl -LOJ https://github.com/OpenFreeEnergy/openfe/releases/download/v1.0.1/conda-lock-openfe-1.0.1.yml
-
-Create a conda environment from the lock file and activate it::
-
-  $ conda-lock install -n openfe conda-lock-openfe.yml
-  $ conda activate openfe
-
-To make sure everything is working, run the tests ::
-
-  $ pytest --pyargs openfe openfecli
-
-The test suite contains several hundred individual tests. This will take a
-few minutes, and all tests should complete with status either passed,
-skipped, or xfailed (expected fail).
-  
-With that, you should be ready to use ``openfe``!
 
 Containers
 ----------


### PR DESCRIPTION
Instead of just pointing users to the installation instructions, we now provide our own directly in the docs. We emphasise that creating a new env to install conda-lock into will reduce dependency conflict issues.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
