### PR TITLE
Use MBAR error as uncertainty with a single protocol repeat in RBFE

### DIFF
--- a/openfe/protocols/openmm_rfe/equil_rfe_methods.py
+++ b/openfe/protocols/openmm_rfe/equil_rfe_methods.py
@@ -288,8 +288,9 @@ class RelativeHybridTopologyProtocolResult(gufe.ProtocolResult):
             vals = [dG.to(u).m for dG in dGs]
             unc = np.std(vals) * u
         else:
+            # use MBAR estimate error directly for a single repeat
             uncs = [pus[0].outputs['unit_estimate_error'] for pus in self.data.values()]
-            assert len(uncs) == 1
+            assert len(uncs) == 1, "Protocol unit estimates and errors number mismatch"
             unc = uncs[0]
         return unc
 

--- a/openfe/protocols/openmm_rfe/equil_rfe_methods.py
+++ b/openfe/protocols/openmm_rfe/equil_rfe_methods.py
@@ -278,15 +278,20 @@ class RelativeHybridTopologyProtocolResult(gufe.ProtocolResult):
 
     def get_uncertainty(self) -> unit.Quantity:
         """The uncertainty/error in the dG value: The std of the estimates of
-        each independent repeat
+        each independent repeat or the MBAR estimate error for a single repeat
         """
-        dGs = [pus[0].outputs['unit_estimate'] for pus in self.data.values()]
-        u = dGs[0].u
-        # convert all values to units of the first value, then take average of magnitude
-        # this would avoid a screwy case where each value was in different units
-        vals = [dG.to(u).m for dG in dGs]
-
-        return np.std(vals) * u
+        if len(self.data.values()) > 1:
+            dGs = [pus[0].outputs['unit_estimate'] for pus in self.data.values()]
+            u = dGs[0].u
+            # convert all values to units of the first value, then take average of magnitude
+            # this would avoid a screwy case where each value was in different units
+            vals = [dG.to(u).m for dG in dGs]
+            unc = np.std(vals) * u
+        else:
+            uncs = [pus[0].outputs['unit_estimate_error'] for pus in self.data.values()]
+            assert len(uncs) == 1
+            unc = uncs[0]
+        return unc
 
     def get_individual_estimates(self) -> list[tuple[unit.Quantity, unit.Quantity]]:
         """Return a list of tuples containing the individual free energy


### PR DESCRIPTION
When only a single repeat of the RBFE ProtocolUnit is used in a project (which is the approach in e.g., FEP+), the MBAR error estimate should be used as the uncertainty of the free energy estimate. If not, the uncertainty is 0 (applying np.std() to a list of one number returns 0).


Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
