### PR TITLE
Fix OpenMMForceFields gaff tests version checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,7 @@ jobs:
           - "3.11"
           - "3.12"
         openeye: ["no"]
-        ommff-version: ["0.13"]
+        ommff-version: [">0.13"]
         include:
           - os: "macos-12"
             python-version: "3.12"
@@ -57,11 +57,11 @@ jobs:
             python-version: "3.10"
             pydantic-version: ">1"
             openeye: "no"
-            ommff-version: "<0.13"
+            ommff-version: "0.13"
           - os: "macos-latest"
             python-version: "3.12"
             pydantic-version: ">1"
-            omff-version: "0.13"
+            omff-version: ">0.13"
             openeye: ["no"]
 
     env:

--- a/openfe/tests/protocols/test_openmm_equil_rfe_protocols.py
+++ b/openfe/tests/protocols/test_openmm_equil_rfe_protocols.py
@@ -257,7 +257,7 @@ def test_dry_run_gaff_vacuum(benzene_vacuum_system, toluene_vacuum_system,
 
     gaff_should_fail = version.parse(
         ommff_version
-    ) >= version.parse("0.13.0")
+    ) == version.parse("0.13.0")
 
     if gaff_should_fail:
         from openmmforcefields.generators.template_generators import (

--- a/openfe/tests/protocols/test_openmm_plain_md_protocols.py
+++ b/openfe/tests/protocols/test_openmm_plain_md_protocols.py
@@ -188,7 +188,7 @@ def test_dry_run_gaff_vacuum(benzene_vacuum_system, tmpdir):
 
     gaff_should_fail = version.parse(
         ommff_version
-    ) >= version.parse("0.13.0")
+    ) == version.parse("0.13.0")
 
     if gaff_should_fail:
         from openmmforcefields.generators.template_generators import (


### PR DESCRIPTION
Fixes #890 

For now I'm leaving the ommforcefields 0.13 check, this is so that we know the tests don't fail with older versions of OpenMM. Once the next version of OpenMMForceFields is out where gaff is supported with older OpenMM versions then we should remove these checks.

Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
