### PR TITLE
Use `from pydantic.v1` everywhere

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,7 @@ dependencies:
   - pytest-xdist
   - pytest-cov
   - pytest-rerunfailures
-  - pydantic >1
+  - pydantic >=1.10.17
   - pyyaml
   - coverage
   - cinnabar ~=0.4.0

--- a/openfe/protocols/openmm_afe/equil_afe_settings.py
+++ b/openfe/protocols/openmm_afe/equil_afe_settings.py
@@ -33,10 +33,7 @@ from openfe.protocols.openmm_utils.omm_settings import (
 )
 import numpy as np
 
-try:
-    from pydantic.v1 import validator
-except ImportError:
-    from pydantic import validator  # type: ignore[assignment]
+from pydantic.v1 import validator
 
 
 class AlchemicalSettings(SettingsBaseModel):

--- a/openfe/protocols/openmm_md/plain_md_settings.py
+++ b/openfe/protocols/openmm_md/plain_md_settings.py
@@ -19,10 +19,7 @@ from gufe.settings import (
     SettingsBaseModel,
     OpenMMSystemGeneratorFFSettings
 )
-try:
-    from pydantic.v1 import validator
-except ImportError:
-    from pydantic import validator  # type: ignore[assignment]
+from pydantic.v1 import validator
 
 
 class PlainMDProtocolSettings(Settings):

--- a/openfe/protocols/openmm_rfe/equil_rfe_settings.py
+++ b/openfe/protocols/openmm_rfe/equil_rfe_settings.py
@@ -27,10 +27,7 @@ from openfe.protocols.openmm_utils.omm_settings import (
     OpenFFPartialChargeSettings,
 )
 
-try:
-    from pydantic.v1 import validator
-except ImportError:
-    from pydantic import validator  # type: ignore[assignment]
+from pydantic.v1 import validator
 
 
 class LambdaSettings(SettingsBaseModel):

--- a/openfe/protocols/openmm_utils/omm_settings.py
+++ b/openfe/protocols/openmm_utils/omm_settings.py
@@ -21,10 +21,7 @@ from gufe.settings import (
 )
 
 
-try:
-    from pydantic.v1 import validator
-except ImportError:
-    from pydantic import validator  # type: ignore[assignment]
+from pydantic.v1 import validator
 
 
 class BaseSolvationSettings(SettingsBaseModel):


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

This patch shouldn't do anything but remove a few LOC and (at least in the eyes of the type-checker) make things a little claener. This does **not** affect any v1/v2 compatibility, it just removes the need for the `try:` block.

See [here](https://docs.pydantic.dev/latest/changelog/#v11017-2024-06-20) for details. The conda package is online as of a few days ago. I didn't see standards/automation for import sorting so I'm just leaving that be.

Checklist
* [ ] Added a ``news`` entry - shouldn't be any need

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
