### PR TITLE
Perses mapper

### DIFF
--- a/openfe/setup/atom_mapping/perses_mapper.py
+++ b/openfe/setup/atom_mapping/perses_mapper.py
@@ -6,8 +6,10 @@ The MCS class from Perses shamelessly wrapped and used here to match our API.
 
 """
 
-from openmm import unit
 from openfe.utils import requires_package
+from openff.models.types import FloatQuantity
+from openff.units import unit
+from openff.units.openmm import to_openmm
 
 from ...utils.silence_root_logging import silence_root_logging
 try:
@@ -25,7 +27,7 @@ class PersesAtomMapper(LigandAtomMapper):
     allow_ring_breaking: bool
     preserve_chirality: bool
     use_positions: bool
-    coordinate_tolerance: unit.Quantity
+    coordinate_tolerance: FloatQuantity['angstrom']
 
     def _to_dict(self) -> dict:
         # strip units but record values
@@ -33,7 +35,7 @@ class PersesAtomMapper(LigandAtomMapper):
             "allow_ring_breaking": self.allow_ring_breaking,
             "preserve_chirality": self.preserve_chirality,
             "use_positions": self.use_positions,
-            "coordinate_tolerance": self.coordinate_tolerance.value_in_unit(
+            "coordinate_tolerance": self.coordinate_tolerance.m_as(
                 unit.angstrom
             ),
             "_tolerance_unit": "angstrom"
@@ -67,7 +69,7 @@ class PersesAtomMapper(LigandAtomMapper):
             if mappings must strictly preserve chirality, default: True
         use_positions: bool, optional
             this option defines, if the
-        coordinate_tolerance: openmm.unit.Quantity, optional
+        coordinate_tolerance: openff.units.unit.Quantity, optional
             tolerance on how close coordinates need to be, such they
             can be mapped, default: 0.25*unit.angstrom
 
@@ -81,7 +83,7 @@ class PersesAtomMapper(LigandAtomMapper):
         # Construct Perses Mapper
         _atom_mapper = AtomMapper(
             use_positions=self.use_positions,
-            coordinate_tolerance=self.coordinate_tolerance,
+            coordinate_tolerance=to_openmm(self.coordinate_tolerance),
             allow_ring_breaking=self.allow_ring_breaking)
 
         # Try generating a mapping

--- a/openfe/setup/atom_mapping/perses_mapper.py
+++ b/openfe/setup/atom_mapping/perses_mapper.py
@@ -67,7 +67,7 @@ class PersesAtomMapper(LigandAtomMapper):
             if mappings must strictly preserve chirality, default: True
         use_positions: bool, optional
             this option defines, if the
-        coordinate_tolerance: float, optional
+        coordinate_tolerance: openmm.unit.Quantity, optional
             tolerance on how close coordinates need to be, such they
             can be mapped, default: 0.25*unit.angstrom
 

--- a/openfe/setup/atom_mapping/perses_mapper.py
+++ b/openfe/setup/atom_mapping/perses_mapper.py
@@ -25,6 +25,28 @@ class PersesAtomMapper(LigandAtomMapper):
     allow_ring_breaking: bool
     preserve_chirality: bool
     use_positions: bool
+    coordinate_tolerance: float
+
+    def _to_dict(self) -> dict:
+        # strip units but record values
+        return {
+            "allow_ring_breaking": self.allow_ring_breaking,
+            "preserve_chirality": self.preserve_chirality,
+            "use_positions": self.use_positions,
+            "coordinate_tolerance": self.coordinate_tolerance.value_in_unit(unit.angstrom),
+            "_tolerance_unit": "angstrom"
+        }
+
+    @classmethod
+    def _from_dict(cls, dct: dict):
+        # attach units again
+        tolerence_unit = dct.pop("_tolerance_unit")
+        dct["coordinate_tolerance"] *= getattr(unit, tolerence_unit)
+        return cls(**dct)
+
+    @classmethod
+    def _defaults(cls):
+        return {}
 
     @requires_package("perses")
     def __init__(self, allow_ring_breaking: bool = True,

--- a/openfe/setup/atom_mapping/perses_mapper.py
+++ b/openfe/setup/atom_mapping/perses_mapper.py
@@ -33,7 +33,9 @@ class PersesAtomMapper(LigandAtomMapper):
             "allow_ring_breaking": self.allow_ring_breaking,
             "preserve_chirality": self.preserve_chirality,
             "use_positions": self.use_positions,
-            "coordinate_tolerance": self.coordinate_tolerance.value_in_unit(unit.angstrom),
+            "coordinate_tolerance": self.coordinate_tolerance.value_in_unit(
+                unit.angstrom
+            ),
             "_tolerance_unit": "angstrom"
         }
 

--- a/openfe/setup/atom_mapping/perses_mapper.py
+++ b/openfe/setup/atom_mapping/perses_mapper.py
@@ -25,7 +25,7 @@ class PersesAtomMapper(LigandAtomMapper):
     allow_ring_breaking: bool
     preserve_chirality: bool
     use_positions: bool
-    coordinate_tolerance: float
+    coordinate_tolerance: unit.Quantity
 
     def _to_dict(self) -> dict:
         # strip units but record values
@@ -54,7 +54,7 @@ class PersesAtomMapper(LigandAtomMapper):
     def __init__(self, allow_ring_breaking: bool = True,
                  preserve_chirality: bool = True,
                  use_positions: bool = True,
-                 coordinate_tolerance: float = 0.25 * unit.angstrom):
+                 coordinate_tolerance: unit.Quantity = 0.25 * unit.angstrom):
         """
         Suggest atom mappings with the Perses atom mapper.
 

--- a/openfe/tests/setup/atom_mapping/test_perses_atommapper.py
+++ b/openfe/tests/setup/atom_mapping/test_perses_atommapper.py
@@ -9,7 +9,6 @@ pytest.importorskip('openeye')
 USING_NEW_OFF = True  # by default we are now
 
 
-# @pytest.mark.xfail(USING_NEW_OFF, reason="Perses #1108")
 def test_simple(atom_mapping_basic_test_files):
     # basic sanity check on the LigandAtomMapper
     mol1 = atom_mapping_basic_test_files['methylcyclohexane']
@@ -25,7 +24,6 @@ def test_simple(atom_mapping_basic_test_files):
     assert len(mapping.componentA_to_componentB) == 4
 
 
-# @pytest.mark.xfail(USING_NEW_OFF, reason="Perses #1108")
 def test_generator_length(atom_mapping_basic_test_files):
     # check that we get one mapping back from Lomap LigandAtomMapper then the
     # generator stops correctly
@@ -41,7 +39,6 @@ def test_generator_length(atom_mapping_basic_test_files):
         next(mapping_gen)
 
 
-# @pytest.mark.xfail(USING_NEW_OFF, reason="Perses #1108")
 def test_empty_atommappings(mol_pair_to_shock_perses_mapper):
     mol1, mol2 = mol_pair_to_shock_perses_mapper
     mapper = PersesAtomMapper()
@@ -53,3 +50,10 @@ def test_empty_atommappings(mol_pair_to_shock_perses_mapper):
 
     with pytest.raises(StopIteration):
         next(mapping_gen)
+
+
+def test_dict_round_trip():
+    # use some none defaults
+    mapper1 = PersesAtomMapper(allow_ring_breaking=False, preserve_chirality=False)
+    mapper2 = PersesAtomMapper.from_dict(mapper1.to_dict())
+    assert mapper2.to_dict() == mapper1.to_dict()

--- a/openfe/tests/setup/atom_mapping/test_perses_atommapper.py
+++ b/openfe/tests/setup/atom_mapping/test_perses_atommapper.py
@@ -2,6 +2,7 @@
 # For details, see https://github.com/OpenFreeEnergy/openfe
 import pytest
 from openfe.setup.atom_mapping import PersesAtomMapper, LigandAtomMapping
+from openff.units import unit
 
 pytest.importorskip('perses')
 pytest.importorskip('openeye')
@@ -54,6 +55,10 @@ def test_empty_atommappings(mol_pair_to_shock_perses_mapper):
 
 def test_dict_round_trip():
     # use some none defaults
-    mapper1 = PersesAtomMapper(allow_ring_breaking=False, preserve_chirality=False)
+    mapper1 = PersesAtomMapper(
+        allow_ring_breaking=False,
+        preserve_chirality=False,
+        coordinate_tolerance=0.01 * unit.nanometer
+    )
     mapper2 = PersesAtomMapper.from_dict(mapper1.to_dict())
     assert mapper2.to_dict() == mapper1.to_dict()

--- a/openfe/tests/setup/atom_mapping/test_perses_atommapper.py
+++ b/openfe/tests/setup/atom_mapping/test_perses_atommapper.py
@@ -9,7 +9,7 @@ pytest.importorskip('openeye')
 USING_NEW_OFF = True  # by default we are now
 
 
-@pytest.mark.xfail(USING_NEW_OFF, reason="Perses #1108")
+# @pytest.mark.xfail(USING_NEW_OFF, reason="Perses #1108")
 def test_simple(atom_mapping_basic_test_files):
     # basic sanity check on the LigandAtomMapper
     mol1 = atom_mapping_basic_test_files['methylcyclohexane']
@@ -25,7 +25,7 @@ def test_simple(atom_mapping_basic_test_files):
     assert len(mapping.componentA_to_componentB) == 4
 
 
-@pytest.mark.xfail(USING_NEW_OFF, reason="Perses #1108")
+# @pytest.mark.xfail(USING_NEW_OFF, reason="Perses #1108")
 def test_generator_length(atom_mapping_basic_test_files):
     # check that we get one mapping back from Lomap LigandAtomMapper then the
     # generator stops correctly
@@ -41,7 +41,7 @@ def test_generator_length(atom_mapping_basic_test_files):
         next(mapping_gen)
 
 
-@pytest.mark.xfail(USING_NEW_OFF, reason="Perses #1108")
+# @pytest.mark.xfail(USING_NEW_OFF, reason="Perses #1108")
 def test_empty_atommappings(mol_pair_to_shock_perses_mapper):
     mol1, mol2 = mol_pair_to_shock_perses_mapper
     mapper = PersesAtomMapper()


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->
Replaces #929 to enable openeye tests

Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
