### PR TITLE
Temporarily disable structural analysis

### DIFF
--- a/news/disable_structural_analysis.rst
+++ b/news/disable_structural_analysis.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* Structural analysis plots embedded in RelativeHybridTopologyProtocol ProtocolUnitResult are temporarily removed.
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/openfe/protocols/openmm_rfe/equil_rfe_methods.py
+++ b/openfe/protocols/openmm_rfe/equil_rfe_methods.py
@@ -1097,34 +1097,39 @@ class RelativeHybridTopologyProtocolUnit(gufe.ProtocolUnit):
 
     @staticmethod
     def analyse(where) -> dict:
+        # NB: Structural analysis is disabled for now due to creation of very
+        # large files. This will be re-enabled in the future, see openfe/issues/926
+
         # don't put energy analysis in here, it uses the open file reporter
         # whereas structural stuff requires that the file handle is closed
-        analysis_out = where / 'structural_analysis.json'
+        # analysis_out = where / 'structural_analysis.json'
 
-        ret = subprocess.run(['openfe_analysis', 'RFE_analysis',
-                              str(where), str(analysis_out)],
-                             stdout=subprocess.PIPE,
-                             stderr=subprocess.PIPE)
-        if ret.returncode:
-            return {'structural_analysis_error': ret.stderr}
+        # ret = subprocess.run(['openfe_analysis', 'RFE_analysis',
+        #                       str(where), str(analysis_out)],
+        #                      stdout=subprocess.PIPE,
+        #                      stderr=subprocess.PIPE)
+        # if ret.returncode:
+        #     return {'structural_analysis_error': ret.stderr}
 
-        with open(analysis_out, 'rb') as f:
-            data = json.load(f)
+        # with open(analysis_out, 'rb') as f:
+        #     data = json.load(f)
 
-        savedir = pathlib.Path(where)
-        if d := data['protein_2D_RMSD']:
-            fig = plotting.plot_2D_rmsd(d)
-            fig.savefig(savedir / "protein_2D_RMSD.png")
-            plt.close(fig)
-            f2 = plotting.plot_ligand_COM_drift(data['time(ps)'], data['ligand_wander'])
-            f2.savefig(savedir / "ligand_COM_drift.png")
-            plt.close(f2)
+        # savedir = pathlib.Path(where)
+        # if d := data['protein_2D_RMSD']:
+        #     fig = plotting.plot_2D_rmsd(d)
+        #     fig.savefig(savedir / "protein_2D_RMSD.png")
+        #     plt.close(fig)
+        #     f2 = plotting.plot_ligand_COM_drift(data['time(ps)'], data['ligand_wander'])
+        #     f2.savefig(savedir / "ligand_COM_drift.png")
+        #     plt.close(f2)
 
-        f3 = plotting.plot_ligand_RMSD(data['time(ps)'], data['ligand_RMSD'])
-        f3.savefig(savedir / "ligand_RMSD.png")
-        plt.close(f3)
+        # f3 = plotting.plot_ligand_RMSD(data['time(ps)'], data['ligand_RMSD'])
+        # f3.savefig(savedir / "ligand_RMSD.png")
+        # plt.close(f3)
 
-        return {'structural_analysis': data}
+        # return {'structural_analysis': data}
+
+        return {'structural_analysis': {}}
 
     def _execute(
         self, ctx: gufe.Context, **kwargs,

--- a/openfe/protocols/openmm_rfe/equil_rfe_methods.py
+++ b/openfe/protocols/openmm_rfe/equil_rfe_methods.py
@@ -1098,7 +1098,7 @@ class RelativeHybridTopologyProtocolUnit(gufe.ProtocolUnit):
     @staticmethod
     def analyse(where) -> dict:
         # NB: Structural analysis is disabled for now due to creation of very
-        # large files. This will be re-enabled in the future, see openfe/issues/926
+        # large files. This will be re-enabled in the future, see #926
 
         # don't put energy analysis in here, it uses the open file reporter
         # whereas structural stuff requires that the file handle is closed

--- a/openfe/tests/protocols/test_openmm_rfe_slow.py
+++ b/openfe/tests/protocols/test_openmm_rfe_slow.py
@@ -84,7 +84,8 @@ def test_openmm_run_engine(benzene_vacuum_system, platform,
         nc = pur.outputs['nc']
         assert nc == unit_shared / "simulation.nc"
         assert nc.exists()
-        assert (unit_shared / "structural_analysis.json").exists()
+        # structural analysis is temporarily disabled see openfe/issues/926
+        # assert (unit_shared / "structural_analysis.json").exists()
 
     # Test results methods that need files present
     results = p.gather([r])

--- a/openfe/tests/protocols/test_openmm_rfe_slow.py
+++ b/openfe/tests/protocols/test_openmm_rfe_slow.py
@@ -84,7 +84,7 @@ def test_openmm_run_engine(benzene_vacuum_system, platform,
         nc = pur.outputs['nc']
         assert nc == unit_shared / "simulation.nc"
         assert nc.exists()
-        # structural analysis is temporarily disabled see openfe/issues/926
+        # structural analysis is temporarily disabled see see #926
         # assert (unit_shared / "structural_analysis.json").exists()
 
     # Test results methods that need files present


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Possible fix for #926. Depending on how you want this implemented this should provide a temporary solution disabling the writing of the offending JSON. Please let me know if this isn't what the team had in mind. 

This is also probably something intertwined with possible releases and backwards compatibility. LMK if there are any blocking issues there. :smile: 

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [x] Added a ``news`` entry

## Developers certificate of origin
- [X] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
