### PR TITLE
bump apptainer version

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -112,7 +112,7 @@ jobs:
       - name: Setup Apptainer
         uses: eWaterCycle/setup-apptainer@v2
         with:
-          apptainer-version: 1.1.2
+          apptainer-version: 1.3.4
 
       - name: Build Apptainer Image
         run: singularity build openfe_${{ steps.latest-version.outputs.VERSION }}.sif docker-daemon:${{ steps.fqirp.outputs.FQIRP }}


### PR DESCRIPTION
Trying to build a docker images gives us `FATAL:   While performing build: conveyor failed to get: loading image from docker engine: Error response from daemon: {"message":"client version 1.22 is too old. Minimum supported API version is 1.24, please upgrade your client to a newer version"}` 

We might want to look into dependabot or something that will help us bump these version numbers 