### PR TITLE
move slow import inside function call

### DIFF
--- a/openfecli/commands/plan_rbfe_network.py
+++ b/openfecli/commands/plan_rbfe_network.py
@@ -7,8 +7,6 @@ from openfecli import OFECommandPlugin
 from openfecli.parameters import (
     MOL_DIR, PROTEIN, OUTPUT_DIR, COFACTORS, YAML_OPTIONS,
 )
-from openfecli.plan_alchemical_networks_utils import plan_alchemical_network_output
-
 
 def plan_rbfe_network_main(
     mapper,
@@ -116,6 +114,8 @@ def plan_rbfe_network(
     which is detailed in the Options section.
     For more advanced setups, please consider using the Python layer of openfe.
     """
+    from openfecli.plan_alchemical_networks_utils import plan_alchemical_network_output
+
     write("RBFE-NETWORK PLANNER")
     write("______________________")
     write("")

--- a/openfecli/commands/plan_rhfe_network.py
+++ b/openfecli/commands/plan_rhfe_network.py
@@ -10,8 +10,6 @@ from openfecli import OFECommandPlugin
 from openfecli.parameters import (
     MOL_DIR, MAPPER, OUTPUT_DIR, YAML_OPTIONS,
 )
-from openfecli.plan_alchemical_networks_utils import plan_alchemical_network_output
-
 
 def plan_rhfe_network_main(
     mapper, mapping_scorer, ligand_network_planner, small_molecules,
@@ -100,6 +98,9 @@ def plan_rhfe_network(molecules: List[str], yaml_settings: str, output_dir: str)
     transformation a JSON file, that can be run with quickrun (or other
     future tools).
     """
+
+    from openfecli.plan_alchemical_networks_utils import plan_alchemical_network_output
+
     write("RHFE-NETWORK PLANNER")
     write("______________________")
     write("")


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
For cli commands, slow imports should be moved inside functions (as recommended [here](https://github.com/OpenFreeEnergy/openfe/tree/main/openfecli/commands#delay-slow-imports)). 

By moving the `plan_alchemical_network_output` import from the top of the file to inside the functions for rbfe and rhfe  network planning, we avoid importing `openfe` during the command-gathering process.  

The `--help` and `--version` calls now take 0.15 seconds instead of ~4 seconds.

Ideally, we will also speed up `import openfe`, which was the root cause of this slow behavior, in another PR.


<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
