### PR TITLE
fixing indexing to include replicates

### DIFF
--- a/openfecli/commands/gather.py
+++ b/openfecli/commands/gather.py
@@ -131,10 +131,11 @@ def _generate_bad_legs_error_message(set_vals, ligpair):
 def _parse_raw_units(results: dict) -> list[tuple]:
     # grab individual unit results from master results dict
     # returns list of (estimate, uncertainty) tuples
-    list_of_pur = list(results['protocol_result']['data'].values())[0]
+    list_of_pur = list(results['protocol_result']['data'].values())
 
-    return [(pu['outputs']['unit_estimate'],
-             pu['outputs']['unit_estimate_error'])
+    # TODO: is pu always a list of len 1? or do we need to iterate over pu as well?
+    return [(pu[0]['outputs']['unit_estimate'],
+             pu[0]['outputs']['unit_estimate_error'])
             for pu in list_of_pur]
 
 
@@ -317,7 +318,7 @@ def gather(rootdir, output, report, allow_partial):
       experimental values.
     * 'ddg' reports pairs of ligand_i and ligand_j, the calculated
       relative free energy DDG(i->j) = DG(j) - DG(i) and its uncertainty.
-    * 'raw' reports the raw results, which each repeat simulation given
+    * 'raw' reports the raw results, with each repeat simulation listed
       separately (i.e. no combining of redundant simulations is performed)
 
     The output is a table of **tab** separated values. By default, this


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

partially addresses https://github.com/OpenFreeEnergy/openfe/issues/925, but this issue might need additional debugging.

This is a draft since I still need to add/update tests as well as address the `TODO`. 

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
