### PR TITLE
Add bespokefit cookbook to the docs

### DIFF
--- a/docs/cookbook/bespoke_parameters.nblink
+++ b/docs/cookbook/bespoke_parameters.nblink
@@ -1,0 +1,3 @@
+{
+   "path": "../ExampleNotebooks/cookbook/bespoke_parameters_showcase.ipynb"
+}

--- a/docs/cookbook/index.rst
+++ b/docs/cookbook/index.rst
@@ -162,5 +162,6 @@ List of Cookbooks
     create_alchemical_network
     under_the_hood
     user_charges
+    bespoke_parameters
 
     


### PR DESCRIPTION
Fixes #975 

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Adds the Bespokefit cookbook to the main docs
<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
