### PR TITLE
remove index column from -raw output

### DIFF
--- a/news/fix_missing_replicates.rst
+++ b/news/fix_missing_replicates.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* fixed bug where `openfe gather --report raw` was only including first replicates.
+
+**Security:**
+
+* <news item>

--- a/news/fix_missing_replicates.rst
+++ b/news/fix_missing_replicates.rst
@@ -16,7 +16,7 @@
 
 **Fixed:**
 
-* fixed bug where `openfe gather --report raw` was only including first replicates.
+* Fixed bug where `openfe gather --report raw` was only including first replicates.
 
 **Security:**
 

--- a/openfecli/commands/gather.py
+++ b/openfecli/commands/gather.py
@@ -193,18 +193,17 @@ def _write_ddg(legs, writer, allow_partial):
 
 
 def _write_raw(legs, writer, allow_partial=True):
-    writer.writerow(["leg", "repeat", "ligand_i", "ligand_j",
+    writer.writerow(["leg", "ligand_i", "ligand_j",
                      "DG(i->j) (kcal/mol)", "MBAR uncertainty (kcal/mol)"])
 
     for ligpair, vals in sorted(legs.items()):
         for simtype, repeats in sorted(vals.items()):
-            for rep, (m, u) in enumerate(repeats):
+            for m, u in repeats:
                 if m is None:
                     m, u = 'NaN', 'NaN'
                 else:
                     m, u = format_estimate_uncertainty(m.m, u.m)
-
-                writer.writerow([simtype, rep, *ligpair, m, u])
+                writer.writerow([simtype, *ligpair, m, u])
 
 
 def _write_dg_raw(legs, writer, allow_partial):  # pragma: no-cover

--- a/openfecli/tests/commands/test_gather.py
+++ b/openfecli/tests/commands/test_gather.py
@@ -87,61 +87,61 @@ solvent	lig_ejm_46	lig_jmc_28	23.41	0.05
 
 
 _EXPECTED_RAW = b"""\
-leg	repeat	ligand_i	ligand_j	DG(i->j) (kcal/mol)	MBAR uncertainty (kcal/mol)
-complex	0	lig_ejm_31	lig_ejm_42	-14.9	0.8
-complex	1	lig_ejm_31	lig_ejm_42	-14.8	0.8
-complex	2	lig_ejm_31	lig_ejm_42	-15.1	0.8
-solvent	0	lig_ejm_31	lig_ejm_42	-15.7	0.8
-solvent	1	lig_ejm_31	lig_ejm_42	-15.7	0.8
-solvent	2	lig_ejm_31	lig_ejm_42	-15.7	0.8
-complex	0	lig_ejm_31	lig_ejm_46	-40.7	0.8
-complex	1	lig_ejm_31	lig_ejm_46	-40.7	0.8
-complex	2	lig_ejm_31	lig_ejm_46	-40.8	0.8
-solvent	0	lig_ejm_31	lig_ejm_46	-39.8	0.8
-solvent	1	lig_ejm_31	lig_ejm_46	-39.9	0.8
-solvent	2	lig_ejm_31	lig_ejm_46	-39.8	0.8
-complex	0	lig_ejm_31	lig_ejm_47	-27.8	0.8
-complex	1	lig_ejm_31	lig_ejm_47	-28.0	0.8
-complex	2	lig_ejm_31	lig_ejm_47	-27.7	0.8
-solvent	0	lig_ejm_31	lig_ejm_47	-27.8	0.8
-solvent	1	lig_ejm_31	lig_ejm_47	-27.8	0.8
-solvent	2	lig_ejm_31	lig_ejm_47	-27.9	0.8
-complex	0	lig_ejm_31	lig_ejm_48	-16.2	0.8
-complex	1	lig_ejm_31	lig_ejm_48	-16.2	0.8
-complex	2	lig_ejm_31	lig_ejm_48	-16.0	0.8
-solvent	0	lig_ejm_31	lig_ejm_48	-16.8	0.8
-solvent	1	lig_ejm_31	lig_ejm_48	-16.7	0.8
-solvent	2	lig_ejm_31	lig_ejm_48	-16.8	0.8
-complex	0	lig_ejm_31	lig_ejm_50	-57.3	0.8
-complex	1	lig_ejm_31	lig_ejm_50	-57.3	0.8
-complex	2	lig_ejm_31	lig_ejm_50	-57.4	0.8
-solvent	0	lig_ejm_31	lig_ejm_50	-58.3	0.8
-solvent	1	lig_ejm_31	lig_ejm_50	-58.4	0.8
-solvent	2	lig_ejm_31	lig_ejm_50	-58.3	0.8
-complex	0	lig_ejm_42	lig_ejm_43	-19.0	0.8
-complex	1	lig_ejm_42	lig_ejm_43	-18.7	0.8
-complex	2	lig_ejm_42	lig_ejm_43	-19.0	0.8
-solvent	0	lig_ejm_42	lig_ejm_43	-20.3	0.8
-solvent	1	lig_ejm_42	lig_ejm_43	-20.3	0.8
-solvent	2	lig_ejm_42	lig_ejm_43	-20.3	0.8
-complex	0	lig_ejm_46	lig_jmc_23	17.3	0.8
-complex	1	lig_ejm_46	lig_jmc_23	17.4	0.8
-complex	2	lig_ejm_46	lig_jmc_23	17.5	0.8
-solvent	0	lig_ejm_46	lig_jmc_23	17.2	0.8
-solvent	1	lig_ejm_46	lig_jmc_23	17.1	0.8
-solvent	2	lig_ejm_46	lig_jmc_23	17.1	0.8
-complex	0	lig_ejm_46	lig_jmc_27	15.9	0.8
-complex	1	lig_ejm_46	lig_jmc_27	15.8	0.8
-complex	2	lig_ejm_46	lig_jmc_27	15.7	0.8
-solvent	0	lig_ejm_46	lig_jmc_27	16.0	0.8
-solvent	1	lig_ejm_46	lig_jmc_27	15.9	0.8
-solvent	2	lig_ejm_46	lig_jmc_27	15.9	0.8
-complex	0	lig_ejm_46	lig_jmc_28	23.1	0.8
-complex	1	lig_ejm_46	lig_jmc_28	23.2	0.8
-complex	2	lig_ejm_46	lig_jmc_28	23.1	0.8
-solvent	0	lig_ejm_46	lig_jmc_28	23.5	0.8
-solvent	1	lig_ejm_46	lig_jmc_28	23.3	0.8
-solvent	2	lig_ejm_46	lig_jmc_28	23.4	0.8
+leg	ligand_i	ligand_j	DG(i->j) (kcal/mol)	MBAR uncertainty (kcal/mol)
+complex	lig_ejm_31	lig_ejm_42	-14.9	0.8
+complex	lig_ejm_31	lig_ejm_42	-14.8	0.8
+complex	lig_ejm_31	lig_ejm_42	-15.1	0.8
+solvent	lig_ejm_31	lig_ejm_42	-15.7	0.8
+solvent	lig_ejm_31	lig_ejm_42	-15.7	0.8
+solvent	lig_ejm_31	lig_ejm_42	-15.7	0.8
+complex	lig_ejm_31	lig_ejm_46	-40.7	0.8
+complex	lig_ejm_31	lig_ejm_46	-40.7	0.8
+complex	lig_ejm_31	lig_ejm_46	-40.8	0.8
+solvent	lig_ejm_31	lig_ejm_46	-39.8	0.8
+solvent	lig_ejm_31	lig_ejm_46	-39.9	0.8
+solvent	lig_ejm_31	lig_ejm_46	-39.8	0.8
+complex	lig_ejm_31	lig_ejm_47	-27.8	0.8
+complex	lig_ejm_31	lig_ejm_47	-28.0	0.8
+complex	lig_ejm_31	lig_ejm_47	-27.7	0.8
+solvent	lig_ejm_31	lig_ejm_47	-27.8	0.8
+solvent	lig_ejm_31	lig_ejm_47	-27.8	0.8
+solvent	lig_ejm_31	lig_ejm_47	-27.9	0.8
+complex	lig_ejm_31	lig_ejm_48	-16.2	0.8
+complex	lig_ejm_31	lig_ejm_48	-16.2	0.8
+complex	lig_ejm_31	lig_ejm_48	-16.0	0.8
+solvent	lig_ejm_31	lig_ejm_48	-16.8	0.8
+solvent	lig_ejm_31	lig_ejm_48	-16.7	0.8
+solvent	lig_ejm_31	lig_ejm_48	-16.8	0.8
+complex	lig_ejm_31	lig_ejm_50	-57.3	0.8
+complex	lig_ejm_31	lig_ejm_50	-57.3	0.8
+complex	lig_ejm_31	lig_ejm_50	-57.4	0.8
+solvent	lig_ejm_31	lig_ejm_50	-58.3	0.8
+solvent	lig_ejm_31	lig_ejm_50	-58.4	0.8
+solvent	lig_ejm_31	lig_ejm_50	-58.3	0.8
+complex	lig_ejm_42	lig_ejm_43	-19.0	0.8
+complex	lig_ejm_42	lig_ejm_43	-18.7	0.8
+complex	lig_ejm_42	lig_ejm_43	-19.0	0.8
+solvent	lig_ejm_42	lig_ejm_43	-20.3	0.8
+solvent	lig_ejm_42	lig_ejm_43	-20.3	0.8
+solvent	lig_ejm_42	lig_ejm_43	-20.3	0.8
+complex	lig_ejm_46	lig_jmc_23	17.3	0.8
+complex	lig_ejm_46	lig_jmc_23	17.4	0.8
+complex	lig_ejm_46	lig_jmc_23	17.5	0.8
+solvent	lig_ejm_46	lig_jmc_23	17.2	0.8
+solvent	lig_ejm_46	lig_jmc_23	17.1	0.8
+solvent	lig_ejm_46	lig_jmc_23	17.1	0.8
+complex	lig_ejm_46	lig_jmc_27	15.9	0.8
+complex	lig_ejm_46	lig_jmc_27	15.8	0.8
+complex	lig_ejm_46	lig_jmc_27	15.7	0.8
+solvent	lig_ejm_46	lig_jmc_27	16.0	0.8
+solvent	lig_ejm_46	lig_jmc_27	15.9	0.8
+solvent	lig_ejm_46	lig_jmc_27	15.9	0.8
+complex	lig_ejm_46	lig_jmc_28	23.1	0.8
+complex	lig_ejm_46	lig_jmc_28	23.2	0.8
+complex	lig_ejm_46	lig_jmc_28	23.1	0.8
+solvent	lig_ejm_46	lig_jmc_28	23.5	0.8
+solvent	lig_ejm_46	lig_jmc_28	23.3	0.8
+solvent	lig_ejm_46	lig_jmc_28	23.4	0.8
 """
 
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
As discussed as a team earlier, I'm removing the `repeat` column from the `gather --raw` output. We may add a `--debug` mode that adds both repeat indexes and json filepaths in a future PR.
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->



## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
