### PR TITLE
use current ofe sphinx theme

### DIFF
--- a/docs/environment.yaml
+++ b/docs/environment.yaml
@@ -26,7 +26,7 @@ dependencies:
   - sphinx-toolbox
   - sphinx<7
   - git+https://github.com/OpenFreeEnergy/gufe@main
-  - git+https://github.com/OpenFreeEnergy/ofe-sphinx-theme@main
+  - git+https://github.com/OpenFreeEnergy/ofe-sphinx-theme@v0.1.0
 
 # These are added automatically by RTD, so we include them here 
 # for a consistent environment.

--- a/docs/environment.yaml
+++ b/docs/environment.yaml
@@ -26,7 +26,7 @@ dependencies:
   - sphinx-toolbox
   - sphinx<7
   - git+https://github.com/OpenFreeEnergy/gufe@main
-  - git+https://github.com/OpenFreeEnergy/ofe-sphinx-theme@a45f3edd5bc3e973c1a01b577c71efa1b62a65d6
+  - git+https://github.com/OpenFreeEnergy/ofe-sphinx-theme@main
 
 # These are added automatically by RTD, so we include them here 
 # for a consistent environment.


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Now that [this bug](https://github.com/OpenFreeEnergy/ofe-sphinx-theme/issues/5) is fixed, we can use the `main` branch of `ofe_sphinx_theme`
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->


## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
