### PR TITLE
986 input validation for directory names

### DIFF
--- a/news/986_input_validation.rst
+++ b/news/986_input_validation.rst
@@ -4,7 +4,7 @@
 
 **Changed:**
 
-* ``openfe quickrun`` now fails up-front when the user-supplied output file (``-o``) is invalid.
+* ``openfe quickrun`` now fails up-front when the user-supplied output file (``-o``) already exists or has a non-existent parent directory.
 
 **Deprecated:**
 

--- a/news/986_input_validation.rst
+++ b/news/986_input_validation.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* ``openfe quickrun`` now fails up-front when the user-supplied output file (``-o``) is invalid.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/openfecli/commands/quickrun.py
+++ b/openfecli/commands/quickrun.py
@@ -101,6 +101,15 @@ def quickrun(transformation, work_dir, output):
     if output is None:
         output = work_dir / (str(trans.key) + '_results.json')
 
+    try:
+        with open(output, mode='w') as outf:
+            # json.dump(out_dict, outf, cls=JSON_HANDLER.encoder)
+            outf.write("in-progress")
+    except FileNotFoundError as e:
+        raise click.ClickException(f"Unable to write to {output}, please provide a valid path.")
+
+    # TODO: if it's just a missing directory, should we try creating it?
+
     write("Planning simulations for this edge...")
     dag = trans.create()
     write("Starting the simulations for this edge...")

--- a/openfecli/commands/quickrun.py
+++ b/openfecli/commands/quickrun.py
@@ -34,7 +34,7 @@ def _format_exception(exception) -> str:
 @click.option(
     'output', '-o', default=None,
     type=click.Path(dir_okay=False, file_okay=True, path_type=pathlib.Path),
-    help="output file (JSON format) for the final results",
+    help="Filepath at which to create and write the JSON-formatted results.",
     callback=validate_outfile,
 )
 @print_duration

--- a/openfecli/commands/quickrun.py
+++ b/openfecli/commands/quickrun.py
@@ -102,9 +102,9 @@ def quickrun(transformation, work_dir, output):
         output = work_dir / (str(trans.key) + '_results.json')
 
     try:
+        # make sure the output file is writeable before running simulations
         with open(output, mode='w') as outf:
-            # json.dump(out_dict, outf, cls=JSON_HANDLER.encoder)
-            outf.write("in-progress")
+            outf.write("in-progress")  # TODO: do we just want to pass here?
     except FileNotFoundError as e:
         raise click.ClickException(f"Unable to write to {output}, please provide a valid path.")
 

--- a/openfecli/commands/quickrun.py
+++ b/openfecli/commands/quickrun.py
@@ -97,6 +97,10 @@ def quickrun(transformation, work_dir, output):
     # TODO: change this to `Transformation.load(transformation)`
     dct = json.load(transformation, cls=JSON_HANDLER.decoder)
     trans = gufe.Transformation.from_dict(dct)
+
+    if output is None:
+        output = work_dir / (str(trans.key) + '_results.json')
+
     write("Planning simulations for this edge...")
     dag = trans.create()
     write("Starting the simulations for this edge...")
@@ -126,8 +130,6 @@ def quickrun(transformation, work_dir, output):
         }
     }
 
-    if output is None:
-        output = work_dir / (str(trans.key) + '_results.json')
 
     with open(output, mode='w') as outf:
         json.dump(out_dict, outf, cls=JSON_HANDLER.encoder)

--- a/openfecli/commands/quickrun.py
+++ b/openfecli/commands/quickrun.py
@@ -33,8 +33,7 @@ def _format_exception(exception) -> str:
 )
 @click.option(
     'output', '-o', default=None,
-    type=click.Path(dir_okay=False, file_okay=True, writable=True,
-                    path_type=pathlib.Path),
+    type=click.Path(dir_okay=False, file_okay=True, path_type=pathlib.Path),
     help="output file (JSON format) for the final results",
     callback=validate_outfile,
 )
@@ -97,7 +96,6 @@ def quickrun(transformation, work_dir, output):
     # TODO: change this to `Transformation.load(transformation)`
     dct = json.load(transformation, cls=JSON_HANDLER.decoder)
     trans = gufe.Transformation.from_dict(dct)
-
     write("Planning simulations for this edge...")
     dag = trans.create()
     write("Starting the simulations for this edge...")

--- a/openfecli/parameters/output.py
+++ b/openfecli/parameters/output.py
@@ -9,11 +9,19 @@ def get_file_and_extension(user_input, context):
     return file, ext
 
 
-def ensure_file_does_not_exist(ctx, param, value):
+def ensure_file_does_not_exist(value):
+    # TODO: I believe we can replace this with click.option(file_okay=False)
     if value and value.exists():
         raise click.BadParameter(f"File '{value}' already exists.")
-    return value
 
+def ensure_parent_dir_exists(value):
+    if value and not value.parent.is_dir():
+        raise click.BadParameter(f"Cannot write to {value}, parent directory does not exist.")
+
+def validate_outfile(ctx, param, value):
+    ensure_file_does_not_exist(value)
+    ensure_parent_dir_exists(value)
+    return value
 
 OUTPUT_FILE_AND_EXT = Option(
     "-o", "--output",

--- a/openfecli/tests/commands/test_quickrun.py
+++ b/openfecli/tests/commands/test_quickrun.py
@@ -54,6 +54,19 @@ def test_quickrun_output_file_exists(json_file):
         assert result.exit_code == 2  # usage error
         assert "File 'foo.json' already exists." in result.output
 
+def test_quickrun_output_file_in_nonexistent_directory(json_file):
+    runner = CliRunner()
+    outfile = "not_dir/foo.json"
+    result = runner.invoke(quickrun, [json_file, '-o', outfile])
+    assert result.exit_code == 0
+    assert "Here is the result" in result.output
+
+    assert pathlib.Path(outfile).exists()
+    with open(outfile, mode='r') as outf:
+        dct = json.load(outf, cls=JSON_HANDLER.decoder)
+
+    assert set(dct) == {'estimate', 'uncertainty',
+                        'protocol_result', 'unit_results'}
 
 def test_quickrun_unit_error():
     with resources.files('openfecli.tests.data') as d:

--- a/openfecli/tests/commands/test_quickrun.py
+++ b/openfecli/tests/commands/test_quickrun.py
@@ -60,7 +60,6 @@ def test_quickrun_output_file_in_nonexistent_directory(json_file):
     result = runner.invoke(quickrun, [json_file, '-o', outfile])
     assert result.exit_code == 1  # TODO: which error type is appropriate here?
     assert "Unable to write" in result.output
-
  
 def test_quickrun_unit_error():
     with resources.files('openfecli.tests.data') as d:

--- a/openfecli/tests/commands/test_quickrun.py
+++ b/openfecli/tests/commands/test_quickrun.py
@@ -1,6 +1,7 @@
 import pytest
 import click
 from importlib import resources
+import os
 import pathlib
 import json
 from click.testing import CliRunner
@@ -55,11 +56,12 @@ def test_quickrun_output_file_exists(json_file):
         assert "File 'foo.json' already exists." in result.output
 
 def test_quickrun_output_file_in_nonexistent_directory(json_file):
+    """Should catch invalid filepaths up front."""
     runner = CliRunner()
     outfile = "not_dir/foo.json"
     result = runner.invoke(quickrun, [json_file, '-o', outfile])
-    assert result.exit_code == 1  # TODO: which error type is appropriate here?
-    assert "Unable to write" in result.output
+    assert result.exit_code == 2
+    assert "Cannot write" in result.output
  
 def test_quickrun_unit_error():
     with resources.files('openfecli.tests.data') as d:

--- a/openfecli/tests/commands/test_quickrun.py
+++ b/openfecli/tests/commands/test_quickrun.py
@@ -1,7 +1,6 @@
 import pytest
 import click
 from importlib import resources
-import os
 import pathlib
 import json
 from click.testing import CliRunner

--- a/openfecli/tests/commands/test_quickrun.py
+++ b/openfecli/tests/commands/test_quickrun.py
@@ -58,16 +58,10 @@ def test_quickrun_output_file_in_nonexistent_directory(json_file):
     runner = CliRunner()
     outfile = "not_dir/foo.json"
     result = runner.invoke(quickrun, [json_file, '-o', outfile])
-    assert result.exit_code == 0
-    assert "Here is the result" in result.output
+    assert result.exit_code == 1  # TODO: which error type is appropriate here?
+    assert "Unable to write" in result.output
 
-    assert pathlib.Path(outfile).exists()
-    with open(outfile, mode='r') as outf:
-        dct = json.load(outf, cls=JSON_HANDLER.decoder)
-
-    assert set(dct) == {'estimate', 'uncertainty',
-                        'protocol_result', 'unit_results'}
-
+ 
 def test_quickrun_unit_error():
     with resources.files('openfecli.tests.data') as d:
         json_file = str(d / 'bad_transformation.json')


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
addresses #986 
<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [x] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
