### PR TITLE
Remove macos12 ahead of brownout

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,6 +40,7 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
         openeye: ["no"]
         include:
           - os: "macos-latest"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,6 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
-          - "3.13"
         openeye: ["no"]
         include:
           - os: "macos-latest"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,6 +42,9 @@ jobs:
           - "3.12"
         openeye: ["no"]
         include:
+          - os: "macos-latest"
+            python-version: "3.12"
+            pydantic-version: ">1"
           - os: "ubuntu-latest"
             python-version: "3.11"
             pydantic-version: "<2"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,9 +42,6 @@ jobs:
           - "3.12"
         openeye: ["no"]
         include:
-          - os: "macos-12"
-            python-version: "3.12"
-            pydantic-version: ">1"
           - os: "ubuntu-latest"
             python-version: "3.11"
             pydantic-version: "<2"

--- a/.github/workflows/conda_cron.yaml
+++ b/.github/workflows/conda_cron.yaml
@@ -25,9 +25,6 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
-        exclude:
-          - os: 'macos-latest'
-            python-version: '3.9'
 
     steps:
       - name: Setup Micromamba

--- a/.github/workflows/conda_cron.yaml
+++ b/.github/workflows/conda_cron.yaml
@@ -20,9 +20,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest', 'macos-latest', 'macos-13']
+        os: ['ubuntu-latest', 'macos-latest']
         python-version:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"

--- a/.github/workflows/installer.yaml
+++ b/.github/workflows/installer.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, macos-latest, ubuntu-latest]
+        os: [macos-latest, ubuntu-latest]
 
     steps:
     - name: Checkout Code

--- a/.github/workflows/installer.yaml
+++ b/.github/workflows/installer.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, macos-12, ubuntu-latest]
+        os: [macos-13, macos-latest, ubuntu-latest]
 
     steps:
     - name: Checkout Code

--- a/news/no_more_macos12.rst
+++ b/news/no_more_macos12.rst
@@ -12,7 +12,7 @@
 
 **Removed:**
 
-* Removed support for macos-12, macos-14 is now the minimum supported.
+* openfe is no longer tested against macos-12. macos support is, for now, limited to osx-arm64 (macos-14+).
 
 **Fixed:**
 

--- a/news/no_more_macos12.rst
+++ b/news/no_more_macos12.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* Removed support for macos-12, macos-14 is now the minimum supported.
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [x] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
