### PR TITLE
create test data for quickrun submitted in parallel

### DIFF
--- a/openfecli/commands/gather.py
+++ b/openfecli/commands/gather.py
@@ -4,26 +4,11 @@
 import click
 from openfecli import OFECommandPlugin
 from openfecli.clicktypes import HyphenAwareChoice
-
-import os
 import pathlib
 import warnings
 
 
-def _get_column(val:float|int)->int:
-    """Determine the index (where the 0th index is the decimal) at which the
-    first non-zero value occurs in a full-precision string representation of a value.
-
-    Parameters
-    ----------
-    val : float|int
-        The raw value.
-
-    Returns
-    -------
-    int
-        Column index
-    """
+def _get_column(val):
     import numpy as np
     if val == 0:
         return 0
@@ -42,23 +27,6 @@ def format_estimate_uncertainty(
     unc: float,
     unc_prec: int = 1,
 ) -> tuple[str, str]:
-    """Truncate raw estimate and uncertainty values to the appropriate
-    approximated uncertainty.
-
-    Parameters
-    ----------
-    est : float
-        Raw estimate value.
-    unc : float
-        Raw uncertainty value.
-    unc_prec : int, optional
-        Precision, by default 1
-
-    Returns
-    -------
-    tuple[str, str]
-        The truncated raw and uncertainty values.
-    """
     import numpy as np
     # get the last column needed for uncertainty
     unc_col = _get_column(unc) - (unc_prec - 1)
@@ -73,44 +41,21 @@ def format_estimate_uncertainty(
     return est_str, unc_str
 
 
-def is_results_json(fpath:os.PathLike|str)->bool:
-    """Sanity check that file is a result json before we try to deserialize"""
-    return 'estimate' in open(fpath, 'r').read(20)
+def is_results_json(f):
+    # sanity check on files before we try and deserialize
+    return 'estimate' in open(f, 'r').read(20)
 
 
-def load_results(fpath:os.PathLike|str)->dict:
-    """_summary_
-
-    Parameters
-    ----------
-    fpath : os.PathLike | str
-        The path to deserialized results.
-
-
-    Returns
-    -------
-    dict
-        A dict containing data from the results JSON.
-    """
+def load_results(f):
+    # path to deserialized results
     import json
     from gufe.tokenization import JSON_HANDLER
 
-    return json.load(open(fpath, 'r'), cls=JSON_HANDLER.decoder)
+    return json.load(open(f, 'r'), cls=JSON_HANDLER.decoder)
 
 
-def get_names(result:dict) -> tuple[str, str]:
-    """_summary_
-
-    Parameters
-    ----------
-    result : dict
-        A results dict.
-
-    Returns
-    -------
-    tuple[str, str]
-        Ligand names corresponding to the results.
-    """
+def get_names(result) -> tuple[str, str]:
+    # Result to tuple of ligand names
     nm = list(result['unit_results'].values())[0]['name']
     toks = nm.split()
     if toks[2] == 'repeat':
@@ -119,7 +64,7 @@ def get_names(result:dict) -> tuple[str, str]:
         return toks[0], toks[2]
 
 
-def get_type(res:dict):
+def get_type(res):
     list_of_pur = list(res['protocol_result']['data'].values())[0]
     pur = list_of_pur[0]
     components = pur['inputs']['stateA']['components']

--- a/openfecli/tests/commands/test_gather.py
+++ b/openfecli/tests/commands/test_gather.py
@@ -28,13 +28,23 @@ def test_get_column(val, col):
 
 
 @pytest.fixture
-def results_dir(tmpdir):
+def results_dir_serial(tmpdir):
+    """Example output data, with replicates run in serial (3 replicates per results JSON)."""
     with tmpdir.as_cwd():
         with resources.files('openfecli.tests.data') as d:
             t = tarfile.open(d / 'rbfe_results.tar.gz', mode='r')
             t.extractall('.')
-
         yield
+
+@pytest.fixture
+def results_dir_parallel(tmpdir):
+    """Identical data to results_dir_serial(), with replicates run in parallel (1 replicate per results JSON)."""
+    with tmpdir.as_cwd():
+        with resources.files('openfecli.tests.data') as d:
+            t = tarfile.open(d / 'results_parallel.tar.gz', mode='r')
+            t.extractall('.')
+        yield
+
 
 _EXPECTED_DG = b"""
 ligand	DG(MLE) (kcal/mol)	uncertainty (kcal/mol)
@@ -146,7 +156,7 @@ solvent	lig_ejm_46	lig_jmc_28	23.4	0.8
 
 
 @pytest.mark.parametrize('report', ["", "dg", "ddg", "raw"])
-def test_gather(results_dir, report):
+def test_gather(results_dir_serial, report):
     expected = {
         "": _EXPECTED_DG,
         "dg": _EXPECTED_DG,
@@ -185,7 +195,7 @@ def test_generate_bad_legs_error_message(include):
 
 
 @pytest.mark.xfail
-def test_missing_leg_error(results_dir):
+def test_missing_leg_error(results_dir_serial):
     file_to_remove = "easy_rbfe_lig_ejm_31_complex_lig_ejm_42_complex.json"
     (pathlib.Path("results") / file_to_remove).unlink()
 
@@ -199,7 +209,7 @@ def test_missing_leg_error(results_dir):
 
 
 @pytest.mark.xfail
-def test_missing_leg_allow_partial(results_dir):
+def test_missing_leg_allow_partial(results_dir_serial):
     file_to_remove = "easy_rbfe_lig_ejm_31_complex_lig_ejm_42_complex.json"
     (pathlib.Path("results") / file_to_remove).unlink()
 

--- a/openfecli/tests/commands/test_gather.py
+++ b/openfecli/tests/commands/test_gather.py
@@ -34,6 +34,7 @@ def results_dir_serial(tmpdir):
         with resources.files('openfecli.tests.data') as d:
             t = tarfile.open(d / 'rbfe_results.tar.gz', mode='r')
             t.extractall('.')
+
         yield
 
 @pytest.fixture
@@ -43,8 +44,8 @@ def results_dir_parallel(tmpdir):
         with resources.files('openfecli.tests.data') as d:
             t = tarfile.open(d / 'results_parallel.tar.gz', mode='r')
             t.extractall('.')
-        yield
 
+        yield
 
 _EXPECTED_DG = b"""
 ligand	DG(MLE) (kcal/mol)	uncertainty (kcal/mol)

--- a/openfecli/tests/data/restructure_results_data.ipynb
+++ b/openfecli/tests/data/restructure_results_data.ipynb
@@ -139,22 +139,29 @@
     "for leg in leg_names:\n",
     "    json_data = load_json(orig_dir/f\"{leg}.json\")\n",
     "    srckey_to_protocol = {}\n",
-    "    srckey_to_units = {}\n",
+    "    srckey_to_unit_results = {}\n",
     "    srckey_to_estimate = {}\n",
     "    ## collect results on a per-replicate basis\n",
     "    for k in json_data['protocol_result']['data']:    \n",
+    "        print(k)\n",
     "        rep_source_key = json_data['protocol_result']['data'][k][0]['source_key']\n",
-    "        rep_result = json_data['protocol_result'].copy()\n",
+    "        \n",
     "        # keep only the data for this replicate\n",
+    "        rep_result = json_data['protocol_result'].copy()\n",
     "        rep_result['data']={k:json_data['protocol_result']['data'][k]}\n",
     "        srckey_to_protocol[rep_source_key] = rep_result\n",
+    "\n",
+    "        # pull just the estimate value so we can put it at the top of the output\n",
     "        srckey_to_estimate[rep_source_key] = rep_result['data'][k][0]['outputs']['unit_estimate']\n",
     "        \n",
     "    for k in json_data['unit_results']:\n",
     "        rep_source_key = json_data['unit_results'][k]['source_key']\n",
-    "        srckey_to_units[rep_source_key] = json_data['unit_results'][k]\n",
+    "\n",
+    "        rep_unit_result = json_data['unit_results'].copy()\n",
+    "        rep_unit_result = {k: json_data['unit_results'][k]}\n",
+    "        srckey_to_unit_results[rep_source_key] = rep_unit_result\n",
     "    \n",
-    "    assert srckey_to_protocol.keys() == srckey_to_units.keys()\n",
+    "    assert srckey_to_protocol.keys() == srckey_to_unit_results.keys()\n",
     "    \n",
     "    ## write to the new directory\n",
     "    for n, sk in enumerate(sorted(srckey_to_protocol.keys())):\n",
@@ -165,7 +172,7 @@
     "        replicate_data = {'estimate': srckey_to_estimate[sk],\n",
     "                          'uncertainty': 0.0,\n",
     "                          'protocol_result': srckey_to_protocol[sk],\n",
-    "                          'unit_results': srckey_to_units[sk]}\n",
+    "                          'unit_results': srckey_to_unit_results[sk]}\n",
     "    \n",
     "        # write!\n",
     "        dump_json(replicate_data, rep_dir/f\"{leg}.json\")\n",
@@ -188,10 +195,22 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "0f4d44b8-5dbe-49f5-86e5-58fe6c4e4968",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "json_data.keys()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "a8a4be34-6079-4b55-9007-21a4ae2c3ea4",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "json_data['unit_results']['ProtocolUnitResult-1a84266f25684314abb1c5ab94bd2932'].keys()"
+   ]
   },
   {
    "cell_type": "code",

--- a/openfecli/tests/data/restructure_results_data.ipynb
+++ b/openfecli/tests/data/restructure_results_data.ipynb
@@ -131,11 +131,96 @@
     "        # os.symlink(orig_dir/leg/working_dir_name, rep_dir/leg/working_dir_name)\n",
     "        shutil.copytree(orig_dir/leg/working_dir_name, rep_dir/leg/working_dir_name)\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f864dcb3-bebf-425b-9154-bffc2b0e3f07",
+   "metadata": {},
+   "source": [
+    "## check that objects reload correctly"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6c20639c-8ba7-457a-bf8a-76c64aef4a38",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import openfe"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9cba8316-5500-4d5e-a84d-d72d09ba2a42",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "json_reloaded = load_json(\"results_parallel/replicate_0/easy_rbfe_lig_ejm_31_solvent_lig_ejm_47_solvent.json\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c0ce2bc6-d960-4521-b71c-316be0557e9d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pr_reloaded = openfe.ProtocolResult.from_dict(json_reloaded['protocol_result'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a2fbb695-d4ef-45bd-af53-2ef9d0bc8e0a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pr_reloaded.data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "19662eaa-46de-4eb0-8c78-ddd6c68b12db",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "first_pur_key = list(json_reloaded['unit_results'].keys())[0]\n",
+    "pur_reloaded = openfe.ProtocolUnit.from_dict(json_reloaded['unit_results'][first_pur_key])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0154fda2-4c1a-4064-8bcc-03aeecf13365",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pur_reloaded"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c0e90b45-ae83-41c1-8748-0a8c1466b378",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "78fb2997-7c60-4887-90fd-d9521f39a094",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "openfe_env",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -149,7 +234,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.7"
+   "version": "3.12.8"
   }
  },
  "nbformat": 4,

--- a/openfecli/tests/data/restructure_results_data.ipynb
+++ b/openfecli/tests/data/restructure_results_data.ipynb
@@ -1,0 +1,316 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "8d1899bc-337a-4024-9fa3-9cfbc452e091",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json \n",
+    "from gufe.tokenization import JSON_HANDLER\n",
+    "import os \n",
+    "import shutil\n",
+    "from pathlib import Path"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a82b8123-521a-4ca3-a2cf-f73b6504fa14",
+   "metadata": {},
+   "source": [
+    "for this dataset, we know we have 3 replicates run in serial for each leg. We want to manipulate the data so that it is equivalent to the output if we re-ran this dataset with each leg run in parallel, with the following directory structure:\n",
+    "\n",
+    "```\n",
+    "results/\n",
+    "  transformations_0/\n",
+    "      rbfe_lig_ejm_31_complex_lig_ejm_42_complex/\n",
+    "          shared_[hashA]_attempt_0/\n",
+    "      rbfe_lig_ejm_31_complex_lig_ejm_42_complex.json\n",
+    "  transformations_1/\n",
+    "      rbfe_lig_ejm_31_complex_lig_ejm_42_complex/\n",
+    "          shared_[hashB]_attempt_0/\n",
+    "      rbfe_lig_ejm_31_complex_lig_ejm_42_complex.json\n",
+    "  transformations_2/\n",
+    "      rbfe_lig_ejm_31_complex_lig_ejm_42_complex/\n",
+    "          shared_[hashC]_attempt_0/\n",
+    "      rbfe_lig_ejm_31_complex_lig_ejm_42_complex.json\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "1c6ed7fe-b42c-4781-b356-85799e25356f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def load_json(fpath):\n",
+    "    return json.load(open(fpath, 'r'), cls=JSON_HANDLER.decoder)\n",
+    "\n",
+    "def dump_json(data, fpath):\n",
+    "    with open(fpath, \"w\") as f:\n",
+    "        json.dump(data, f, cls=JSON_HANDLER.encoder)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "8eba246a-6123-4d8e-8fd8-2de516fbf881",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "orig_dir = Path(\"/Users/atravitz/software/openfe/openfecli/tests/data/results/\")\n",
+    "new_dir = Path(\"/Users/atravitz/work/sandbox/gather_test_data/results_parallel\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "408512e9-32c8-4c63-bfe2-8ac1fddcd17a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ! ls $orig_dir"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "8047bce2-6a07-4b76-99c6-d6c70f003b00",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tmp_data = load_json(orig_dir/\"easy_rbfe_lig_ejm_31_complex_lig_ejm_42_complex.json\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "f110e93a-2022-4ef2-9fd0-f925627bba06",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "dict_keys(['estimate', 'uncertainty', 'protocol_result', 'unit_results'])"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tmp_data.keys()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "b942e848-bdc0-4012-94dc-1d9545848f09",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "dict_keys(['330714296593777210386804356517366745081', '204826840445410897858355357525897940103', '17154838837715859465403535134173639142'])"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tmp_data['protocol_result']['data'].keys()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "ab4f2587-9b15-422d-9faa-e11ff98fd491",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['easy_rbfe_lig_ejm_31_solvent_lig_ejm_47_solvent',\n",
+       " 'easy_rbfe_lig_ejm_31_complex_lig_ejm_47_complex',\n",
+       " 'easy_rbfe_lig_ejm_31_solvent_lig_ejm_46_solvent',\n",
+       " 'easy_rbfe_lig_ejm_31_complex_lig_ejm_46_complex',\n",
+       " 'easy_rbfe_lig_ejm_46_complex_lig_jmc_27_complex',\n",
+       " 'easy_rbfe_lig_ejm_46_solvent_lig_jmc_27_solvent',\n",
+       " 'easy_rbfe_lig_ejm_31_complex_lig_ejm_50_complex',\n",
+       " 'easy_rbfe_lig_ejm_31_solvent_lig_ejm_50_solvent',\n",
+       " 'easy_rbfe_lig_ejm_46_solvent_lig_jmc_23_solvent',\n",
+       " 'easy_rbfe_lig_ejm_31_complex_lig_ejm_48_complex',\n",
+       " 'easy_rbfe_lig_ejm_46_complex_lig_jmc_23_complex',\n",
+       " 'easy_rbfe_lig_ejm_31_solvent_lig_ejm_48_solvent',\n",
+       " 'easy_rbfe_lig_ejm_42_solvent_lig_ejm_43_solvent',\n",
+       " 'easy_rbfe_lig_ejm_42_complex_lig_ejm_43_complex',\n",
+       " 'easy_rbfe_lig_ejm_46_solvent_lig_jmc_28_solvent',\n",
+       " 'easy_rbfe_lig_ejm_46_complex_lig_jmc_28_complex',\n",
+       " 'easy_rbfe_lig_ejm_31_complex_lig_ejm_42_complex',\n",
+       " 'easy_rbfe_lig_ejm_31_solvent_lig_ejm_42_solvent']"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "leg_names = []\n",
+    "for name in os.listdir(orig_dir):\n",
+    "    if name.endswith(\".json\"):\n",
+    "        continue\n",
+    "    leg_names.append(name)\n",
+    "leg_names"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "5a129134-b73f-4d6c-8c5e-3a08eca29b46",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! rm -rf $new_dir"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "311a7f0e-9c91-47ae-9e09-0e1bef03aca8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0\n",
+      "1\n",
+      "2\n",
+      "0\n",
+      "1\n",
+      "2\n",
+      "0\n",
+      "1\n",
+      "2\n",
+      "0\n",
+      "1\n",
+      "2\n",
+      "0\n",
+      "1\n",
+      "2\n",
+      "0\n",
+      "1\n",
+      "2\n",
+      "0\n",
+      "1\n",
+      "2\n",
+      "0\n",
+      "1\n",
+      "2\n",
+      "0\n",
+      "1\n",
+      "2\n",
+      "0\n",
+      "1\n",
+      "2\n",
+      "0\n",
+      "1\n",
+      "2\n",
+      "0\n",
+      "1\n",
+      "2\n",
+      "0\n",
+      "1\n",
+      "2\n",
+      "0\n",
+      "1\n",
+      "2\n",
+      "0\n",
+      "1\n",
+      "2\n",
+      "0\n",
+      "1\n",
+      "2\n",
+      "0\n",
+      "1\n",
+      "2\n",
+      "0\n",
+      "1\n",
+      "2\n"
+     ]
+    }
+   ],
+   "source": [
+    "for leg in leg_names:\n",
+    "# leg = leg_names[0]\n",
+    "    json_data = load_json(orig_dir/f\"{leg}.json\")\n",
+    "    srckey_to_protocol = {}\n",
+    "    srckey_to_units = {}\n",
+    "    \n",
+    "    ## collect results on a per-replicate basis\n",
+    "    for k in json_data['protocol_result']['data']:    \n",
+    "        rep_source_key = json_data['protocol_result']['data'][k][0]['source_key']\n",
+    "        srckey_to_protocol[rep_source_key] = json_data['protocol_result']\n",
+    "        \n",
+    "    for k in json_data['unit_results']:\n",
+    "        rep_source_key = json_data['unit_results'][k]['source_key']\n",
+    "        srckey_to_units[rep_source_key] = json_data['unit_results'][k]\n",
+    "    \n",
+    "    assert srckey_to_protocol.keys() == srckey_to_units.keys()\n",
+    "    \n",
+    "    ## write to the new directory\n",
+    "    for n, sk in enumerate(sorted(srckey_to_protocol.keys())):\n",
+    "        rep_dir = new_dir/f\"replicate_{n}\"\n",
+    "        os.makedirs(rep_dir/leg)\n",
+    "    \n",
+    "        # build up the data for this replicate\n",
+    "        replicate_data = {'estimate':'NA',\n",
+    "                          'uncertainty':'NA',\n",
+    "                          'protocol_result':srckey_to_protocol[sk],\n",
+    "                          'unit_results':srckey_to_units[sk]}\n",
+    "    \n",
+    "        # write!\n",
+    "        dump_json(replicate_data, rep_dir/f\"{leg}.json\")\n",
+    "        working_dir_name = f\"shared_{sk}_attempt_0\"\n",
+    "        ## TODO: make this work for arbitrary number of attempts \n",
+    "        # os.symlink(orig_dir/leg/working_dir_name, rep_dir/leg/working_dir_name)\n",
+    "        shutil.copytree(orig_dir/leg/working_dir_name, rep_dir/leg/working_dir_name)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e156fb4d-459d-4f33-9162-048cb1c9a476",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/openfecli/tests/data/restructure_results_data.ipynb
+++ b/openfecli/tests/data/restructure_results_data.ipynb
@@ -60,48 +60,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "orig_dir = Path(\"/Users/atravitz/software/openfe/openfecli/tests/data/results/\")\n",
-    "new_dir = Path(\"/Users/atravitz/work/sandbox/gather_test_data/results_parallel\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "408512e9-32c8-4c63-bfe2-8ac1fddcd17a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# ! ls $orig_dir"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8047bce2-6a07-4b76-99c6-d6c70f003b00",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "tmp_data = load_json(orig_dir/\"easy_rbfe_lig_ejm_31_complex_lig_ejm_42_complex.json\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f110e93a-2022-4ef2-9fd0-f925627bba06",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "tmp_data.keys()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b942e848-bdc0-4012-94dc-1d9545848f09",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "tmp_data['protocol_result']['data'].keys()"
+    "orig_dir = Path(\"results/\")\n",
+    "new_dir = Path(\"results_parallel/\")"
    ]
   },
   {
@@ -122,20 +82,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5a129134-b73f-4d6c-8c5e-3a08eca29b46",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "! rm -rf $new_dir"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "311a7f0e-9c91-47ae-9e09-0e1bef03aca8",
    "metadata": {},
    "outputs": [],
    "source": [
+    "! rm -rf $new_dir\n",
     "for leg in leg_names:\n",
     "    json_data = load_json(orig_dir/f\"{leg}.json\")\n",
     "    srckey_to_protocol = {}\n",
@@ -143,7 +94,6 @@
     "    srckey_to_estimate = {}\n",
     "    ## collect results on a per-replicate basis\n",
     "    for k in json_data['protocol_result']['data']:    \n",
-    "        print(k)\n",
     "        rep_source_key = json_data['protocol_result']['data'][k][0]['source_key']\n",
     "        \n",
     "        # keep only the data for this replicate\n",
@@ -181,119 +131,11 @@
     "        # os.symlink(orig_dir/leg/working_dir_name, rep_dir/leg/working_dir_name)\n",
     "        shutil.copytree(orig_dir/leg/working_dir_name, rep_dir/leg/working_dir_name)\n"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e156fb4d-459d-4f33-9162-048cb1c9a476",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "tmp_data = load_json(\"/Users/atravitz/work/sandbox/gather_test_data/complex_11_13_all_reps.json/results_transformations_0/complex_11_13.json\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "0f4d44b8-5dbe-49f5-86e5-58fe6c4e4968",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "json_data.keys()\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a8a4be34-6079-4b55-9007-21a4ae2c3ea4",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "json_data['unit_results']['ProtocolUnitResult-1a84266f25684314abb1c5ab94bd2932'].keys()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "21109657-8450-4eed-b4ac-36c149c30eb2",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "tmp_data['protocol_result']['data']['153739774597735519755877734364465126162'][0]['outputs']['unit_estimate'].keys()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "4eff8697-ca51-4535-99f1-ffc558105e93",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "json_data['protocol_result']['data']['206613422407723609770924271218313554331'][0]['outputs']['unit_estimate']"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5aebc224-9ba7-423e-a638-d7ae8ad2eda7",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "json_data['protocol_result']['data'].keys()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9df0c6f4-b668-41e7-8b87-817a1dc721ee",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "single_rep = load_json(\"/Users/atravitz/work/sandbox/gather_test_data/complex_11_13_all_reps.json/results_transformations_0/complex_11_13.json\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8eb996ff-cffd-4a81-b7c1-072222a918e4",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "single_rep['protocol_result']['data']['153739774597735519755877734364465126162'][0]['outputs']['unit_estimate']"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "53210934-0b1e-4852-84d3-72a7688757d1",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "json_data['protocol_result']['data']['206613422407723609770924271218313554331'][0].keys()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ece1d625-d539-46a5-ac4f-c7fb8ddc0849",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "json_data['protocol_result']['data'].keys()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b1a8e4fc-95c1-4d3d-8ae9-a95d12f152a8",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "openfe_env",
    "language": "python",
    "name": "python3"
   },
@@ -307,7 +149,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,

--- a/openfecli/tests/data/restructure_results_data.ipynb
+++ b/openfecli/tests/data/restructure_results_data.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "8d1899bc-337a-4024-9fa3-9cfbc452e091",
    "metadata": {},
    "outputs": [],
@@ -40,7 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "1c6ed7fe-b42c-4781-b356-85799e25356f",
    "metadata": {},
    "outputs": [],
@@ -55,7 +55,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "8eba246a-6123-4d8e-8fd8-2de516fbf881",
    "metadata": {},
    "outputs": [],
@@ -66,7 +66,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "408512e9-32c8-4c63-bfe2-8ac1fddcd17a",
    "metadata": {},
    "outputs": [],
@@ -76,7 +76,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "8047bce2-6a07-4b76-99c6-d6c70f003b00",
    "metadata": {},
    "outputs": [],
@@ -86,80 +86,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "f110e93a-2022-4ef2-9fd0-f925627bba06",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "dict_keys(['estimate', 'uncertainty', 'protocol_result', 'unit_results'])"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "tmp_data.keys()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "b942e848-bdc0-4012-94dc-1d9545848f09",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "dict_keys(['330714296593777210386804356517366745081', '204826840445410897858355357525897940103', '17154838837715859465403535134173639142'])"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "tmp_data['protocol_result']['data'].keys()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "ab4f2587-9b15-422d-9faa-e11ff98fd491",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['easy_rbfe_lig_ejm_31_solvent_lig_ejm_47_solvent',\n",
-       " 'easy_rbfe_lig_ejm_31_complex_lig_ejm_47_complex',\n",
-       " 'easy_rbfe_lig_ejm_31_solvent_lig_ejm_46_solvent',\n",
-       " 'easy_rbfe_lig_ejm_31_complex_lig_ejm_46_complex',\n",
-       " 'easy_rbfe_lig_ejm_46_complex_lig_jmc_27_complex',\n",
-       " 'easy_rbfe_lig_ejm_46_solvent_lig_jmc_27_solvent',\n",
-       " 'easy_rbfe_lig_ejm_31_complex_lig_ejm_50_complex',\n",
-       " 'easy_rbfe_lig_ejm_31_solvent_lig_ejm_50_solvent',\n",
-       " 'easy_rbfe_lig_ejm_46_solvent_lig_jmc_23_solvent',\n",
-       " 'easy_rbfe_lig_ejm_31_complex_lig_ejm_48_complex',\n",
-       " 'easy_rbfe_lig_ejm_46_complex_lig_jmc_23_complex',\n",
-       " 'easy_rbfe_lig_ejm_31_solvent_lig_ejm_48_solvent',\n",
-       " 'easy_rbfe_lig_ejm_42_solvent_lig_ejm_43_solvent',\n",
-       " 'easy_rbfe_lig_ejm_42_complex_lig_ejm_43_complex',\n",
-       " 'easy_rbfe_lig_ejm_46_solvent_lig_jmc_28_solvent',\n",
-       " 'easy_rbfe_lig_ejm_46_complex_lig_jmc_28_complex',\n",
-       " 'easy_rbfe_lig_ejm_31_complex_lig_ejm_42_complex',\n",
-       " 'easy_rbfe_lig_ejm_31_solvent_lig_ejm_42_solvent']"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "leg_names = []\n",
     "for name in os.listdir(orig_dir):\n",
@@ -171,7 +121,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "5a129134-b73f-4d6c-8c5e-3a08eca29b46",
    "metadata": {},
    "outputs": [],
@@ -181,82 +131,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "311a7f0e-9c91-47ae-9e09-0e1bef03aca8",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0\n",
-      "1\n",
-      "2\n",
-      "0\n",
-      "1\n",
-      "2\n",
-      "0\n",
-      "1\n",
-      "2\n",
-      "0\n",
-      "1\n",
-      "2\n",
-      "0\n",
-      "1\n",
-      "2\n",
-      "0\n",
-      "1\n",
-      "2\n",
-      "0\n",
-      "1\n",
-      "2\n",
-      "0\n",
-      "1\n",
-      "2\n",
-      "0\n",
-      "1\n",
-      "2\n",
-      "0\n",
-      "1\n",
-      "2\n",
-      "0\n",
-      "1\n",
-      "2\n",
-      "0\n",
-      "1\n",
-      "2\n",
-      "0\n",
-      "1\n",
-      "2\n",
-      "0\n",
-      "1\n",
-      "2\n",
-      "0\n",
-      "1\n",
-      "2\n",
-      "0\n",
-      "1\n",
-      "2\n",
-      "0\n",
-      "1\n",
-      "2\n",
-      "0\n",
-      "1\n",
-      "2\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "for leg in leg_names:\n",
-    "# leg = leg_names[0]\n",
     "    json_data = load_json(orig_dir/f\"{leg}.json\")\n",
     "    srckey_to_protocol = {}\n",
     "    srckey_to_units = {}\n",
-    "    \n",
+    "    srckey_to_estimate = {}\n",
     "    ## collect results on a per-replicate basis\n",
     "    for k in json_data['protocol_result']['data']:    \n",
     "        rep_source_key = json_data['protocol_result']['data'][k][0]['source_key']\n",
-    "        srckey_to_protocol[rep_source_key] = json_data['protocol_result']\n",
+    "        rep_result = json_data['protocol_result'].copy()\n",
+    "        # keep only the data for this replicate\n",
+    "        rep_result['data']={k:json_data['protocol_result']['data'][k]}\n",
+    "        srckey_to_protocol[rep_source_key] = rep_result\n",
+    "        srckey_to_estimate[rep_source_key] = rep_result['data'][k][0]['outputs']['unit_estimate']\n",
     "        \n",
     "    for k in json_data['unit_results']:\n",
     "        rep_source_key = json_data['unit_results'][k]['source_key']\n",
@@ -270,10 +162,10 @@
     "        os.makedirs(rep_dir/leg)\n",
     "    \n",
     "        # build up the data for this replicate\n",
-    "        replicate_data = {'estimate':'NA',\n",
-    "                          'uncertainty':'NA',\n",
-    "                          'protocol_result':srckey_to_protocol[sk],\n",
-    "                          'unit_results':srckey_to_units[sk]}\n",
+    "        replicate_data = {'estimate': srckey_to_estimate[sk],\n",
+    "                          'uncertainty': 0.0,\n",
+    "                          'protocol_result': srckey_to_protocol[sk],\n",
+    "                          'unit_results': srckey_to_units[sk]}\n",
     "    \n",
     "        # write!\n",
     "        dump_json(replicate_data, rep_dir/f\"{leg}.json\")\n",
@@ -287,6 +179,94 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e156fb4d-459d-4f33-9162-048cb1c9a476",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tmp_data = load_json(\"/Users/atravitz/work/sandbox/gather_test_data/complex_11_13_all_reps.json/results_transformations_0/complex_11_13.json\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a8a4be34-6079-4b55-9007-21a4ae2c3ea4",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "21109657-8450-4eed-b4ac-36c149c30eb2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tmp_data['protocol_result']['data']['153739774597735519755877734364465126162'][0]['outputs']['unit_estimate'].keys()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4eff8697-ca51-4535-99f1-ffc558105e93",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "json_data['protocol_result']['data']['206613422407723609770924271218313554331'][0]['outputs']['unit_estimate']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5aebc224-9ba7-423e-a638-d7ae8ad2eda7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "json_data['protocol_result']['data'].keys()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9df0c6f4-b668-41e7-8b87-817a1dc721ee",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "single_rep = load_json(\"/Users/atravitz/work/sandbox/gather_test_data/complex_11_13_all_reps.json/results_transformations_0/complex_11_13.json\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8eb996ff-cffd-4a81-b7c1-072222a918e4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "single_rep['protocol_result']['data']['153739774597735519755877734364465126162'][0]['outputs']['unit_estimate']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "53210934-0b1e-4852-84d3-72a7688757d1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "json_data['protocol_result']['data']['206613422407723609770924271218313554331'][0].keys()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ece1d625-d539-46a5-ac4f-c7fb8ddc0849",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "json_data['protocol_result']['data'].keys()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b1a8e4fc-95c1-4d3d-8ae9-a95d12f152a8",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -308,7 +288,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.7"
+   "version": "3.12.8"
   }
  },
  "nbformat": 4,

--- a/openfecli/tests/data/restructure_results_data.ipynb
+++ b/openfecli/tests/data/restructure_results_data.ipynb
@@ -9,6 +9,7 @@
    "source": [
     "import json \n",
     "from gufe.tokenization import JSON_HANDLER\n",
+    "import numpy as np\n",
     "import os \n",
     "import shutil\n",
     "from pathlib import Path"
@@ -120,7 +121,7 @@
     "    \n",
     "        # build up the data for this replicate\n",
     "        replicate_data = {'estimate': srckey_to_estimate[sk],\n",
-    "                          'uncertainty': 0.0,\n",
+    "                          'uncertainty': np.std(srckey_to_estimate[sk]),\n",
     "                          'protocol_result': srckey_to_protocol[sk],\n",
     "                          'unit_results': srckey_to_unit_results[sk]}\n",
     "    \n",
@@ -158,6 +159,16 @@
    "outputs": [],
    "source": [
     "json_reloaded = load_json(\"results_parallel/replicate_0/easy_rbfe_lig_ejm_31_solvent_lig_ejm_47_solvent.json\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c0e90b45-ae83-41c1-8748-0a8c1466b378",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "json_reloaded['estimate'], json_reloaded['uncertainty']"
    ]
   },
   {
@@ -204,15 +215,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c0e90b45-ae83-41c1-8748-0a8c1466b378",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "78fb2997-7c60-4887-90fd-d9521f39a094",
+   "id": "3f2bbc84-f59c-40b9-a176-9a733ff275c1",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
I re-arranged the data in `openfecli/test/data/results` to mimic the results from a `quickrun` submission where every replicate is separate. I'll use this dataset to test the solution to [this issue](https://github.com/OpenFreeEnergy/openfe/issues/987)

I included the notebook I used to generate this data since I expect we might want to use it again in the future. It's not polished, but I think it's good to have some record of where this test data came from.