### PR TITLE
Make MST network test deterministic 

### DIFF
--- a/openfe/tests/setup/test_network_planning.py
+++ b/openfe/tests/setup/test_network_planning.py
@@ -273,10 +273,21 @@ def test_minimal_spanning_network_mappers(
 def minimal_spanning_network(toluene_vs_others, lomap_old_mapper):
     toluene, others = toluene_vs_others
 
-    mappers = [BadMapper(), lomap_old_mapper]
+    mappers = [lomap_old_mapper]
 
     def scorer(mapping):
-        return len(mapping.componentA_to_componentB)
+        """Scores are designed to give the same mst everytime"""
+        scores = {
+            # MST edges
+            ('1,3,7-trimethylnaphthalene', '2,6-dimethylnaphthalene'): 3,
+            ('1-butyl-4-methylbenzene', '2-methyl-6-propylnaphthalene'): 3,
+            ('2,6-dimethylnaphthalene', '2-methyl-6-propylnaphthalene'): 3,
+            ('2,6-dimethylnaphthalene', '2-methylnaphthalene'): 3,
+            ('2,6-dimethylnaphthalene', '2-naftanol'): 3,
+            ('2,6-dimethylnaphthalene', 'methylcyclohexane'): 3,
+            ('2,6-dimethylnaphthalene', 'toluene'): 3,
+        }
+        return scores.get((mapping.componentA.name, mapping.componentB.name), 1)
 
     network = openfe.setup.ligand_network_planning.generate_minimal_spanning_network(
         ligands=others + [toluene],
@@ -345,10 +356,29 @@ def test_minimal_spanning_network_unreachable(toluene_vs_others,
 def minimal_redundant_network(toluene_vs_others, lomap_old_mapper):
     toluene, others = toluene_vs_others
 
-    mappers = [BadMapper(), lomap_old_mapper]
+    mappers = [lomap_old_mapper]
 
     def scorer(mapping):
-        return len(mapping.componentA_to_componentB)
+        """Scores are designed to give the same mst everytime"""
+        scores = {
+            # MST edges
+            ('1,3,7-trimethylnaphthalene', '2,6-dimethylnaphthalene'): 3,
+            ('1-butyl-4-methylbenzene', '2-methyl-6-propylnaphthalene'): 3,
+            ('2,6-dimethylnaphthalene', '2-methyl-6-propylnaphthalene'): 3,
+            ('2,6-dimethylnaphthalene', '2-methylnaphthalene'): 3,
+            ('2,6-dimethylnaphthalene', '2-naftanol'): 3,
+            ('2,6-dimethylnaphthalene', 'methylcyclohexane'): 3,
+            ('2,6-dimethylnaphthalene', 'toluene'): 3,
+            # MST redundant edges
+            ('1,3,7-trimethylnaphthalene', '2-methyl-6-propylnaphthalene'): 2,
+            ('1-butyl-4-methylbenzene', '2,6-dimethylnaphthalene'): 2,
+            ('1-butyl-4-methylbenzene', 'toluene'): 2,
+            ('2-methyl-6-propylnaphthalene', '2-methylnaphthalene'): 2,
+            ('2-methylnaphthalene', '2-naftanol'): 2,
+            ('2-methylnaphthalene', 'methylcyclohexane'): 2,
+            ('2-methylnaphthalene', 'toluene'): 2,
+        }
+        return scores.get((mapping.componentA.name, mapping.componentB.name), 1)
 
     network = openfe.setup.ligand_network_planning.generate_minimal_redundant_network(
         ligands=others + [toluene],


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->
Fixes #1037 by making the edge scores deterministic, this should ensure we always get the same networks regardless of edge ordering.
Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
