### PR TITLE
Fix TYK2 example network tests

### DIFF
--- a/openfecli/tests/test_rbfe_tutorial.py
+++ b/openfecli/tests/test_rbfe_tutorial.py
@@ -4,6 +4,7 @@ Tests the easy start guide
 - runs plan_rbfe_network with tyk2 inputs and checks the network created
 - mocks the calculations and performs gathers on the mocked outputs
 """
+import os
 
 import pytest
 from importlib import resources
@@ -43,12 +44,12 @@ def expected_transformations():
             'easy_rbfe_lig_ejm_42_complex_lig_ejm_50_complex.json',
             'easy_rbfe_lig_ejm_42_solvent_lig_ejm_43_solvent.json',
             'easy_rbfe_lig_ejm_42_solvent_lig_ejm_50_solvent.json',
-            'easy_rbfe_lig_ejm_46_complex_lig_jmc_27_complex.json',
-            'easy_rbfe_lig_ejm_46_solvent_lig_jmc_27_solvent.json',
+            'easy_rbfe_lig_ejm_46_solvent_lig_jmc_23_solvent.json',
+            'easy_rbfe_lig_ejm_46_complex_lig_jmc_23_complex.json',
             'easy_rbfe_lig_jmc_23_complex_lig_jmc_27_complex.json',
             'easy_rbfe_lig_jmc_23_solvent_lig_jmc_27_solvent.json',
-            'easy_rbfe_lig_jmc_27_complex_lig_jmc_28_complex.json',
-            'easy_rbfe_lig_jmc_27_solvent_lig_jmc_28_solvent.json']
+            'easy_rbfe_lig_jmc_23_solvent_lig_jmc_28_solvent.json',
+            'easy_rbfe_lig_jmc_23_complex_lig_jmc_28_complex.json']
 
 
 def test_plan_tyk2(tyk2_ligands, tyk2_protein, expected_transformations):
@@ -64,6 +65,8 @@ def test_plan_tyk2(tyk2_ligands, tyk2_protein, expected_transformations):
         for f in expected_transformations:
             assert path.exists(
                 path.join('alchemicalNetwork/transformations', f))
+        # make sure these are the only transforms
+        assert len(os.listdir("alchemicalNetwork/transformations")) == len(expected_transformations)
 
 
 @pytest.fixture
@@ -94,9 +97,9 @@ lig_ejm_31\tlig_ejm_48\t0.0\t0.0
 lig_ejm_31\tlig_ejm_50\t0.0\t0.0
 lig_ejm_42\tlig_ejm_43\t0.0\t0.0
 lig_ejm_42\tlig_ejm_50\t0.0\t0.0
-lig_ejm_46\tlig_jmc_27\t0.0\t0.0
+lig_ejm_46\tlig_jmc_23\t0.0\t0.0
 lig_jmc_23\tlig_jmc_27\t0.0\t0.0
-lig_jmc_27\tlig_jmc_28\t0.0\t0.0
+lig_jmc_23\tlig_jmc_28\t0.0\t0.0
 """
 
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->
Fixes #1038 by changing the expected edges for the TYK2 network. 
Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
