### PR TITLE
switch ci matrix to test against gufe main again

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ defaults:
 jobs:
   tests:
     runs-on: ${{ matrix.os }}
-    name: "💻-${{matrix.os }} 🐍-${{ matrix.python-version }} 🗃️${{ matrix.pydantic-version }} oechem-${{ matrix.openeye }} gufe-${{ matrix.gufe-version }}"
+    name: "💻-${{matrix.os }} 🐍-${{ matrix.python-version }} 🗃️${{ matrix.pydantic-version }} oechem-${{ matrix.openeye }}"
     strategy:
       fail-fast: false
       matrix:
@@ -41,34 +41,22 @@ jobs:
           - "3.11"
           - "3.12"
         openeye: ["no"]
-        gufe-version: ['main']
         include:
           - os: "macos-latest"
             python-version: "3.12"
             pydantic-version: ">1"
-            gufe-version: 'main'
           - os: "ubuntu-latest"
             python-version: "3.11"
             pydantic-version: "<2"
-            gufe-version: 'main'
           - os: "ubuntu-latest"
             python-version: "3.11"
             pydantic-version: ">1"
             openeye: "yes"
-            gufe-version: 'main'
           - os: "macos-latest"
             python-version: "3.12"
             pydantic-version: ">1"
             omff-version: ">0.13"
             openeye: ["no"]
-            gufe-version: 'main'
-
-          # temporary check against v1.1.0 until issue #1033 is closed
-          - os: "ubuntu-latest"
-            python-version: "3.11"
-            pydantic-version: ">1"
-            openeye: "yes"
-            gufe-version: 'v1.1.0'
 
     env:
       OE_LICENSE: ${{ github.workspace }}/oe_license.txt
@@ -107,10 +95,6 @@ jobs:
           echo "${OE_LICENSE_TEXT}" > ${OE_LICENSE}
           micromamba install -c openeye openeye-toolkits
           python -c "import openeye; assert openeye.oechem.OEChemIsLicensed(), 'oechem license check failed!'"
-
-      - name: "Install GUFE at {{ matrix.gufe-version }}"
-        if: ${{ matrix.gufe-version != 'main' }}
-        run: python -m pip install --no-deps git+https://github.com/OpenFreeEnergy/gufe@${{ matrix.gufe-version }}
 
       - name: "Install"
         run: python -m pip install --no-deps -e .

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ defaults:
 jobs:
   tests:
     runs-on: ${{ matrix.os }}
-    name: "💻-${{matrix.os }} 🐍-${{ matrix.python-version }} 🗃️${{ matrix.pydantic-version }} oechem-${{ matrix.openeye }}"
+    name: "💻-${{matrix.os }} 🐍-${{ matrix.python-version }} 🗃️${{ matrix.pydantic-version }} oechem: ${{ matrix.openeye }}"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,34 +41,34 @@ jobs:
           - "3.11"
           - "3.12"
         openeye: ["no"]
-        gufe-version: ['a9b5982471eb3644ca8c4423c7001e6309a3f544']
+        gufe-version: ['main']
         include:
           - os: "macos-latest"
             python-version: "3.12"
             pydantic-version: ">1"
-            gufe-version: 'a9b5982471eb3644ca8c4423c7001e6309a3f544'
+            gufe-version: 'main'
           - os: "ubuntu-latest"
             python-version: "3.11"
             pydantic-version: "<2"
-            gufe-version: 'a9b5982471eb3644ca8c4423c7001e6309a3f544'
-          - os: "ubuntu-latest"
-            python-version: "3.11"
-            pydantic-version: ">1"
-            openeye: "yes"
-            gufe-version: 'a9b5982471eb3644ca8c4423c7001e6309a3f544'
-          - os: "macos-latest"
-            python-version: "3.12"
-            pydantic-version: ">1"
-            omff-version: ">0.13"
-            openeye: ["no"]
-            gufe-version: 'a9b5982471eb3644ca8c4423c7001e6309a3f544'
-
-          # temporary test against gufe main while we're pinned to a9b5
+            gufe-version: 'main'
           - os: "ubuntu-latest"
             python-version: "3.11"
             pydantic-version: ">1"
             openeye: "yes"
             gufe-version: 'main'
+          - os: "macos-latest"
+            python-version: "3.12"
+            pydantic-version: ">1"
+            omff-version: ">0.13"
+            openeye: ["no"]
+            gufe-version: 'main'
+
+          # temporary check against v1.1.0 until issue #1033 is closed
+          - os: "ubuntu-latest"
+            python-version: "3.11"
+            pydantic-version: ">1"
+            openeye: "yes"
+            gufe-version: 'v1.1.0'
 
     env:
       OE_LICENSE: ${{ github.workspace }}/oe_license.txt


### PR DESCRIPTION
It's my understanding that we want to keep CI red until https://github.com/OpenFreeEnergy/openfe/issues/1033 is closed, but I'm switching us to have the majority of our matrix test against `main` so that we are more likely to catch any new bugs. 


