### PR TITLE
Fix CI- GUFE imports

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -35,6 +35,7 @@ dependencies:
   - plugcli
   - tqdm
   - pygraphviz
+  - zstandard
   # Issue #443
   - pymbar<4.0
   # docs


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->
Adds standard to the testing env which is now needed by gufe following https://github.com/OpenFreeEnergy/gufe/pull/438
Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
