### PR TITLE
move import to speed up cli

### DIFF
--- a/openfecli/commands/gather.py
+++ b/openfecli/commands/gather.py
@@ -7,8 +7,6 @@ import pathlib
 from typing import Callable, Literal
 import warnings
 
-from openfe.protocols.openmm_rfe.equil_rfe_methods import RelativeHybridTopologyProtocolResult as rfe_result
-from openfe.protocols import openmm_rfe
 from openfecli import OFECommandPlugin
 from openfecli.clicktypes import HyphenAwareChoice
 
@@ -204,6 +202,8 @@ def _parse_raw_units(results: dict) -> list[tuple]:
 
 def _get_ddgs(legs:dict, error_on_missing=True):
     import numpy as np
+    from openfe.protocols.openmm_rfe.equil_rfe_methods import RelativeHybridTopologyProtocolResult as rfe_result
+
     DDGs = []
     for ligpair, vals in sorted(legs.items()):
         set_vals = set(vals)


### PR DESCRIPTION
In the [recent gather PR,](https://github.com/OpenFreeEnergy/openfe/pull/1044/files) I accidentally put a slow import at the top of `gather.py`.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
