### PR TITLE
Support outdir created at runtime

### DIFF
--- a/news/986_input_validation.rst
+++ b/news/986_input_validation.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* ``openfe quickrun`` now creates the parent directory as-needed for user-defined output json paths (``-o``).
+
+**Security:**
+
+* <news item>

--- a/news/output_file_handling.rst
+++ b/news/output_file_handling.rst
@@ -4,7 +4,7 @@
 
 **Changed:**
 
-* ``openfe quickrun`` now fails up-front when the user-supplied output file (``-o``) already exists or has a non-existent parent directory.
+* ``openfe quickrun`` now creates the parent directory as-needed for user-defined output json paths (``-o``).
 
 **Deprecated:**
 

--- a/openfecli/commands/quickrun.py
+++ b/openfecli/commands/quickrun.py
@@ -28,7 +28,7 @@ def _format_exception(exception) -> str:
                     path_type=pathlib.Path),
     help=(
         "Directory in which to store files in (defaults to current directory).\
-        If directory does not exist, it will be created at runtime."
+        If the directory does not exist, it will be created at runtime."
     ),
 )
 @click.option(

--- a/openfecli/commands/quickrun.py
+++ b/openfecli/commands/quickrun.py
@@ -6,7 +6,6 @@ import json
 import pathlib
 
 from openfecli import OFECommandPlugin
-from openfecli.parameters.output import validate_outfile
 from openfecli.utils import write, print_duration, configure_logger
 
 
@@ -28,14 +27,14 @@ def _format_exception(exception) -> str:
     type=click.Path(dir_okay=True, file_okay=False, writable=True,
                     path_type=pathlib.Path),
     help=(
-        "directory to store files in (defaults to current directory)"
+        "Directory in which to store files in (defaults to current directory).\
+        If directory does not exist, it will be created at runtime."
     ),
 )
 @click.option(
     'output', '-o', default=None,
-    type=click.Path(dir_okay=False, file_okay=True, path_type=pathlib.Path),
+    type=click.Path(dir_okay=False, file_okay=False, path_type=pathlib.Path),
     help="Filepath at which to create and write the JSON-formatted results.",
-    callback=validate_outfile,
 )
 @print_duration
 def quickrun(transformation, work_dir, output):
@@ -96,6 +95,12 @@ def quickrun(transformation, work_dir, output):
     # TODO: change this to `Transformation.load(transformation)`
     dct = json.load(transformation, cls=JSON_HANDLER.decoder)
     trans = gufe.Transformation.from_dict(dct)
+
+    if output is None:
+        output = work_dir / (str(trans.key) + '_results.json')
+    else:
+        output.parent.mkdir(exist_ok=True, parents=True)
+
     write("Planning simulations for this edge...")
     dag = trans.create()
     write("Starting the simulations for this edge...")
@@ -124,9 +129,6 @@ def quickrun(transformation, work_dir, output):
             for unit in dagresult.protocol_unit_results
         }
     }
-
-    if output is None:
-        output = work_dir / (str(trans.key) + '_results.json')
 
     with open(output, mode='w') as outf:
         json.dump(out_dict, outf, cls=JSON_HANDLER.encoder)

--- a/openfecli/parameters/output.py
+++ b/openfecli/parameters/output.py
@@ -8,21 +8,6 @@ def get_file_and_extension(user_input, context):
     ext = file.name.split('.')[-1] if file else None
     return file, ext
 
-
-def ensure_file_does_not_exist(value):
-    # TODO: I believe we can replace this with click.option(file_okay=False)
-    if value and value.exists():
-        raise click.BadParameter(f"File '{value}' already exists.")
-
-def ensure_parent_dir_exists(value):
-    if value and not value.parent.is_dir():
-        raise click.BadParameter(f"Cannot write to {value}, parent directory does not exist.")
-
-def validate_outfile(ctx, param, value):
-    ensure_file_does_not_exist(value)
-    ensure_parent_dir_exists(value)
-    return value
-
 OUTPUT_FILE_AND_EXT = Option(
     "-o", "--output",
     help="output file",

--- a/openfecli/tests/commands/test_quickrun.py
+++ b/openfecli/tests/commands/test_quickrun.py
@@ -62,6 +62,15 @@ def test_quickrun_output_file_in_nonexistent_directory(json_file):
     assert result.exit_code == 2
     assert "Cannot write" in result.output
  
+def test_quickrun_dir_created_at_runtime(json_file):
+    """It should be valid to have a directory created with the -d flag, such that it exists for -o."""
+    runner = CliRunner()
+    outdir = "not_dir"
+    outfile = outdir+"foo.json"
+    result = runner.invoke(quickrun, [json_file, '-d', outdir, '-o', outfile])
+    assert result.exit_code == 0
+    # assert "Cannot write" in result.output
+
 def test_quickrun_unit_error():
     with resources.files('openfecli.tests.data') as d:
         json_file = str(d / 'bad_transformation.json')


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->


Resolves https://github.com/OpenFreeEnergy/openfe/issues/986#issuecomment-2580783044

Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
