### PR TITLE
add support for one repeat per json

### DIFF
--- a/news/add_n_protocol_repeats.rst
+++ b/news/add_n_protocol_repeats.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* Added ``--n-protocol-repeats`` CLI option to allow user-defined number of repeats per unit.
+* Added ``--n-protocol-repeats`` CLI option to allow user-defined number of repeats per quickrun execution. This allows for parallelizing execution of repeats by setting ``--n-protocol-repeats=1`` and calling ``quickrun`` on the same input file multiple times.
 
 **Changed:**
 

--- a/news/add_n_protocol_repeats.rst
+++ b/news/add_n_protocol_repeats.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Added ``--n-protocol-repeats`` CLI option to allow user-defined number of repeats per unit.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/openfe/setup/alchemical_network_planner/relative_alchemical_network_planner.py
+++ b/openfe/setup/alchemical_network_planner/relative_alchemical_network_planner.py
@@ -303,7 +303,7 @@ class RBFEAlchemicalNetworkPlanner(RelativeAlchemicalNetworkPlanner):
     """
     def __init__(
         self,
-        name: str = "easy_rbfe",
+        name: str = "easy_rbfe",  # TODO: change this default to "" in 2.0
         mappers: Optional[Iterable[LigandAtomMapper]] = None,
         mapping_scorer: Callable[[LigandAtomMapping], float]  = default_lomap_score,
         ligand_network_planner: Callable = generate_minimal_spanning_network,

--- a/openfecli/commands/plan_rbfe_network.py
+++ b/openfecli/commands/plan_rbfe_network.py
@@ -161,9 +161,9 @@ def plan_rbfe_network(
     write("")
 
     write("Using Options:")
-    write("\tMapper: " + str(mapper_obj)) 
+    write("\tMapper: " + str(mapper_obj))
 
-    # TODO:  write nice parameter  
+    # TODO:  write nice parameter
     write("\tMapping Scorer: " + str(mapping_scorer))
 
     # TODO:  write nice parameter

--- a/openfecli/commands/plan_rbfe_network.py
+++ b/openfecli/commands/plan_rbfe_network.py
@@ -16,7 +16,7 @@ def plan_rbfe_network_main(
     solvent,
     protein,
     cofactors,
-    protocol,
+    n_protocol_repeats,
 ):
     """Utility method to plan a relative binding free energy network.
 
@@ -36,8 +36,7 @@ def plan_rbfe_network_main(
         protein component for complex simulations, to which the ligands are bound
     cofactors : Iterable[SmallMoleculeComponent]
         any cofactors alongside the protein, can be empty list
-    protocol: Protocol
-        The Protocol to perform on the transformations within this network
+    n_protocol_repeats: int
 
     Returns
     -------
@@ -49,6 +48,11 @@ def plan_rbfe_network_main(
     from openfe.setup.alchemical_network_planner.relative_alchemical_network_planner import (
         RBFEAlchemicalNetworkPlanner,
     )
+    from openfe.setup.alchemical_network_planner.relative_alchemical_network_planner import RelativeHybridTopologyProtocol
+
+    protocol_settings = RelativeHybridTopologyProtocol.default_settings()
+    protocol_settings.protocol_repeats = n_protocol_repeats
+    protocol = RelativeHybridTopologyProtocol(protocol_settings)
 
     network_planner = RBFEAlchemicalNetworkPlanner(
         mappers=mapper,
@@ -121,8 +125,6 @@ def plan_rbfe_network(
     For more advanced setups, please consider using the Python layer of openfe.
     """
     from openfecli.plan_alchemical_networks_utils import plan_alchemical_network_output
-    from openfe.setup.alchemical_network_planner.relative_alchemical_network_planner import RelativeHybridTopologyProtocol
-
 
     write("RBFE-NETWORK PLANNER")
     write("______________________")
@@ -147,10 +149,6 @@ def plan_rbfe_network(
     else:
         cofactors = []
     write("\t\tCofactors: " + str(cofactors))
-
-    protocol_settings = RelativeHybridTopologyProtocol.default_settings()
-    protocol_settings.protocol_repeats = n_protocol_repeats
-    protocol = RelativeHybridTopologyProtocol(protocol_settings)
 
     yaml_options = YAML_OPTIONS.get(yaml_settings)
     mapper_obj = yaml_options.mapper
@@ -181,7 +179,7 @@ def plan_rbfe_network(
         solvent=solvent,
         protein=protein,
         cofactors=cofactors,
-        protocol=protocol,
+        n_protocol_repeats=n_protocol_repeats,
     )
     write("\tDone")
     write("")

--- a/openfecli/commands/plan_rbfe_network.py
+++ b/openfecli/commands/plan_rbfe_network.py
@@ -37,6 +37,7 @@ def plan_rbfe_network_main(
     cofactors : Iterable[SmallMoleculeComponent]
         any cofactors alongside the protein, can be empty list
     n_protocol_repeats: int
+        number of completely independent repeats of the entire sampling process
 
     Returns
     -------

--- a/openfecli/commands/plan_rhfe_network.py
+++ b/openfecli/commands/plan_rhfe_network.py
@@ -29,8 +29,8 @@ def plan_rhfe_network_main(
         molecules of the system
     solvent : SolventComponent
         Solvent component used for solvation
-    protocol: Protocol
-        The Protocol to perform on the transformations within this network
+    n_protocol_repeats: int
+        number of completely independent repeats of the entire sampling process
 
     Returns
     -------

--- a/openfecli/commands/plan_rhfe_network.py
+++ b/openfecli/commands/plan_rhfe_network.py
@@ -13,7 +13,7 @@ from openfecli.parameters import (
 
 def plan_rhfe_network_main(
     mapper, mapping_scorer, ligand_network_planner, small_molecules,
-    solvent, protocol,
+    solvent, n_protocol_repeats,
 ):
     """Utility method to plan a relative hydration free energy network.
 
@@ -41,6 +41,12 @@ def plan_rhfe_network_main(
     from openfe.setup.alchemical_network_planner.relative_alchemical_network_planner import (
         RHFEAlchemicalNetworkPlanner
     )
+    from openfe.setup.alchemical_network_planner.relative_alchemical_network_planner import RelativeHybridTopologyProtocol
+
+
+    protocol_settings = RelativeHybridTopologyProtocol.default_settings()
+    protocol_settings.protocol_repeats = n_protocol_repeats
+    protocol = RelativeHybridTopologyProtocol(protocol_settings)
 
     network_planner = RHFEAlchemicalNetworkPlanner(
         mappers=mapper,
@@ -105,7 +111,6 @@ def plan_rhfe_network(molecules: List[str], yaml_settings: str, output_dir: str,
     """
 
     from openfecli.plan_alchemical_networks_utils import plan_alchemical_network_output
-    from openfe.setup.alchemical_network_planner.relative_alchemical_network_planner import RelativeHybridTopologyProtocol
     
     write("RHFE-NETWORK PLANNER")
     write("______________________")
@@ -121,10 +126,6 @@ def plan_rhfe_network(molecules: List[str], yaml_settings: str, output_dir: str,
         "\t\tSmall Molecules: "
         + " ".join([str(sm) for sm in small_molecules])
     )
-
-    protocol_settings = RelativeHybridTopologyProtocol.default_settings()
-    protocol_settings.protocol_repeats = n_protocol_repeats
-    protocol = RelativeHybridTopologyProtocol(protocol_settings)
 
     yaml_options = YAML_OPTIONS.get(yaml_settings)
     mapper_obj = yaml_options.mapper
@@ -153,7 +154,7 @@ def plan_rhfe_network(molecules: List[str], yaml_settings: str, output_dir: str,
         ligand_network_planner=ligand_network_planner,
         small_molecules=small_molecules,
         solvent=solvent,
-        protocol=protocol,
+        n_protocol_repeats=n_protocol_repeats,
     )
     write("\tDone")
     write("")

--- a/openfecli/commands/plan_rhfe_network.py
+++ b/openfecli/commands/plan_rhfe_network.py
@@ -111,7 +111,7 @@ def plan_rhfe_network(molecules: List[str], yaml_settings: str, output_dir: str,
     """
 
     from openfecli.plan_alchemical_networks_utils import plan_alchemical_network_output
-    
+
     write("RHFE-NETWORK PLANNER")
     write("______________________")
     write("")

--- a/openfecli/parameters/__init__.py
+++ b/openfecli/parameters/__init__.py
@@ -8,3 +8,4 @@ from .output_dir import OUTPUT_DIR
 from .protein import PROTEIN
 from .molecules import MOL_DIR, COFACTORS
 from .plan_network_options import YAML_OPTIONS
+from .misc import N_PROTOCOL_REPEATS

--- a/openfecli/parameters/misc.py
+++ b/openfecli/parameters/misc.py
@@ -5,5 +5,7 @@ N_PROTOCOL_REPEATS = Option(
     "-n",
     "--n-protocol-repeats",
     type=click.INT,
-    help="The number of completely independent repeats of the entire sampling process.",
+    help="The number of completely independent repeats per protocol unit.  "\
+        "For example, setting ``--n-protocol-repeats=1`` can allow for each individual repeat to be submitted in parallel,"\
+        "whereas ``--n-protocol-repeats=3`` would run 3 repeats in serial within a single unit.",
 )

--- a/openfecli/parameters/misc.py
+++ b/openfecli/parameters/misc.py
@@ -4,7 +4,7 @@ from plugcli.params import Option
 N_PROTOCOL_REPEATS = Option(
     "--n-protocol-repeats",
     type=click.INT,
-    help="The number of completely independent repeats per protocol unit.\n"
+    help="Number of independent repeats per protocol unit.\n"
     "For example, setting ``--n-protocol-repeats=1`` can allow for each individual repeat to be submitted in parallel, "
-    "whereas ``--n-protocol-repeats=3`` would run 3 repeats in serial within a single unit.",
+    "whereas ``--n-protocol-repeats=3`` would run 3 repeats in serial within a single protocol unit.",
 )

--- a/openfecli/parameters/misc.py
+++ b/openfecli/parameters/misc.py
@@ -4,7 +4,7 @@ from plugcli.params import Option
 N_PROTOCOL_REPEATS = Option(
     "--n-protocol-repeats",
     type=click.INT,
-    help="Number of independent run(s) to be run per execution of a transformation using the `openfe quickrun` command.\n\n"
+    help="Number of independent repeats(s) to be run per execution of a transformation using the `openfe quickrun` command.\n\n"
     "For example:\n\n  `--n-protocol-repeats=3` means `openfe quickrun` will execute 3 repeats in serial.\n\n"
     "  `--n-protocol-repeats=1` means `openfe quickrun` will execute only 1 repeat per call, "
     "which allows for individual repeats to be submitted in parallel by calling `openfe quickrun` on the same input JSON file multiple times.",

--- a/openfecli/parameters/misc.py
+++ b/openfecli/parameters/misc.py
@@ -2,7 +2,6 @@ import click
 from plugcli.params import Option
 
 N_PROTOCOL_REPEATS = Option(
-    "-n",
     "--n-protocol-repeats",
     type=click.INT,
     help="The number of completely independent repeats per protocol unit."

--- a/openfecli/parameters/misc.py
+++ b/openfecli/parameters/misc.py
@@ -5,7 +5,7 @@ N_PROTOCOL_REPEATS = Option(
     "-n",
     "--n-protocol-repeats",
     type=click.INT,
-    help="The number of completely independent repeats per protocol unit.  "\
-        "For example, setting ``--n-protocol-repeats=1`` can allow for each individual repeat to be submitted in parallel,"\
-        "whereas ``--n-protocol-repeats=3`` would run 3 repeats in serial within a single unit.",
+    help="The number of completely independent repeats per protocol unit."
+    "For example, setting ``--n-protocol-repeats=1`` can allow for each individual repeat to be submitted in parallel,"
+    "whereas ``--n-protocol-repeats=3`` would run 3 repeats in serial within a single unit.",
 )

--- a/openfecli/parameters/misc.py
+++ b/openfecli/parameters/misc.py
@@ -4,7 +4,7 @@ from plugcli.params import Option
 N_PROTOCOL_REPEATS = Option(
     "--n-protocol-repeats",
     type=click.INT,
-    help="The number of completely independent repeats per protocol unit."
-    "For example, setting ``--n-protocol-repeats=1`` can allow for each individual repeat to be submitted in parallel,"
+    help="The number of completely independent repeats per protocol unit.\n"
+    "For example, setting ``--n-protocol-repeats=1`` can allow for each individual repeat to be submitted in parallel, "
     "whereas ``--n-protocol-repeats=3`` would run 3 repeats in serial within a single unit.",
 )

--- a/openfecli/parameters/misc.py
+++ b/openfecli/parameters/misc.py
@@ -4,7 +4,8 @@ from plugcli.params import Option
 N_PROTOCOL_REPEATS = Option(
     "--n-protocol-repeats",
     type=click.INT,
-    help="Number of independent repeats per protocol unit.\n"
-    "For example, setting ``--n-protocol-repeats=1`` can allow for each individual repeat to be submitted in parallel, "
-    "whereas ``--n-protocol-repeats=3`` would run 3 repeats in serial within a single protocol unit.",
+    help="Number of independent run(s) to be run per execution of a transformation using the `openfe quickrun` command.\n\n"
+    "For example:\n\n  `--n-protocol-repeats=3` means `openfe quickrun` will execute 3 repeats in serial.\n\n"
+    "  `--n-protocol-repeats=1` means `openfe quickrun` will execute only 1 repeat per call, "
+    "which allows for individual repeats to be submitted in parallel by calling `openfe quickrun` on the same input JSON file multiple times.",
 )

--- a/openfecli/parameters/misc.py
+++ b/openfecli/parameters/misc.py
@@ -1,0 +1,9 @@
+import click
+from plugcli.params import Option
+
+N_PROTOCOL_REPEATS = Option(
+    "-n",
+    "--n-protocol-repeats",
+    type=click.INT,
+    help="The number of completely independent repeats of the entire sampling process.",
+)

--- a/openfecli/tests/commands/test_plan_rbfe_network.py
+++ b/openfecli/tests/commands/test_plan_rbfe_network.py
@@ -63,7 +63,7 @@ def test_plan_rbfe_network_main():
             for f in ['ligand_23.sdf', 'ligand_55.sdf']
         ]
     with resources.files("openfe.tests.data") as d:
-        protein_compontent = ProteinComponent.from_pdb_file(
+        protein_component = ProteinComponent.from_pdb_file(
             str(d / "181l_only.pdb")
         )
 
@@ -74,7 +74,7 @@ def test_plan_rbfe_network_main():
         ligand_network_planner=ligand_network_planning.generate_minimal_spanning_network,
         small_molecules=smallM_components,
         solvent=solvent_component,
-        protein=protein_compontent,
+        protein=protein_component,
         cofactors=[],
     )
     print(alchemical_network)

--- a/openfecli/tests/commands/test_plan_rbfe_network.py
+++ b/openfecli/tests/commands/test_plan_rbfe_network.py
@@ -126,7 +126,7 @@ def test_plan_rbfe_network(mol_dir_args, protein_args):
             for l1, l2 in zip(expected_output_1, expected_output_2):
                 assert l1 in result.output or l2 in result.output
 
-@pytest.mark.parametrize(['input_n_repeat', 'expected_n_repeat'], [([], 3), (["-n 1"], 1)])
+@pytest.mark.parametrize(['input_n_repeat', 'expected_n_repeat'], [([], 3), (["--n-protocol-repeats", "1"], 1)])
 def test_plan_rbfe_network_n_repeats(mol_dir_args, protein_args, input_n_repeat, expected_n_repeat):
     runner = CliRunner()
 

--- a/openfecli/tests/commands/test_plan_rbfe_network.py
+++ b/openfecli/tests/commands/test_plan_rbfe_network.py
@@ -9,7 +9,6 @@ from openfecli.commands.plan_rbfe_network import (
     plan_rbfe_network,
     plan_rbfe_network_main,
 )
-from openfe.setup.alchemical_network_planner.relative_alchemical_network_planner import RelativeHybridTopologyProtocol
 
 from gufe import AlchemicalNetwork
 from gufe.tokenization import JSON_HANDLER
@@ -78,7 +77,7 @@ def test_plan_rbfe_network_main():
         solvent=solvent_component,
         protein=protein_component,
         cofactors=[],
-        protocol=RelativeHybridTopologyProtocol(RelativeHybridTopologyProtocol.default_settings()),
+        n_protocol_repeats=3,
     )
     print(alchemical_network)
 

--- a/openfecli/tests/commands/test_plan_rbfe_network.py
+++ b/openfecli/tests/commands/test_plan_rbfe_network.py
@@ -126,14 +126,6 @@ def test_plan_rbfe_network(mol_dir_args, protein_args):
             for l1, l2 in zip(expected_output_1, expected_output_2):
                 assert l1 in result.output or l2 in result.output
 
-            network = AlchemicalNetwork.from_dict(
-            json.load(open("alchemicalNetwork/alchemicalNetwork.json"), cls=JSON_HANDLER.decoder)
-            )
-            for edge in network.edges:
-                if "protein" in edge.stateA.components:
-                    assert "cofactor1" in edge.stateA.components
-                    assert "cofactor1" in edge.stateB.components
-
 @pytest.mark.parametrize(['input_n_repeat', 'expected_n_repeat'], [([], 3), (["-n 1"], 1)])
 def test_plan_rbfe_network_n_repeats(mol_dir_args, protein_args, input_n_repeat, expected_n_repeat):
     runner = CliRunner()

--- a/openfecli/tests/commands/test_plan_rbfe_network.py
+++ b/openfecli/tests/commands/test_plan_rbfe_network.py
@@ -9,6 +9,8 @@ from openfecli.commands.plan_rbfe_network import (
     plan_rbfe_network,
     plan_rbfe_network_main,
 )
+from openfe.setup.alchemical_network_planner.relative_alchemical_network_planner import RelativeHybridTopologyProtocol
+
 from gufe import AlchemicalNetwork
 from gufe.tokenization import JSON_HANDLER
 import json
@@ -76,6 +78,7 @@ def test_plan_rbfe_network_main():
         solvent=solvent_component,
         protein=protein_component,
         cofactors=[],
+        protocol=RelativeHybridTopologyProtocol(RelativeHybridTopologyProtocol.default_settings()),
     )
     print(alchemical_network)
 

--- a/openfecli/tests/commands/test_plan_rhfe_network.py
+++ b/openfecli/tests/commands/test_plan_rhfe_network.py
@@ -10,6 +10,7 @@ from openfecli.commands.plan_rhfe_network import (
     plan_rhfe_network,
     plan_rhfe_network_main,
 )
+from openfe.setup.alchemical_network_planner.relative_alchemical_network_planner import RelativeHybridTopologyProtocol
 
 
 @pytest.fixture(scope='session')
@@ -54,6 +55,7 @@ def test_plan_rhfe_network_main():
         ligand_network_planner=ligand_network_planning.generate_minimal_spanning_network,
         small_molecules=smallM_components,
         solvent=solvent_component,
+        protocol=RelativeHybridTopologyProtocol(RelativeHybridTopologyProtocol.default_settings())
     )
 
     assert alchemical_network

--- a/openfecli/tests/commands/test_plan_rhfe_network.py
+++ b/openfecli/tests/commands/test_plan_rhfe_network.py
@@ -10,8 +10,6 @@ from openfecli.commands.plan_rhfe_network import (
     plan_rhfe_network,
     plan_rhfe_network_main,
 )
-from openfe.setup.alchemical_network_planner.relative_alchemical_network_planner import RelativeHybridTopologyProtocol
-
 
 @pytest.fixture(scope='session')
 def mol_dir_args(tmpdir_factory):
@@ -55,7 +53,7 @@ def test_plan_rhfe_network_main():
         ligand_network_planner=ligand_network_planning.generate_minimal_spanning_network,
         small_molecules=smallM_components,
         solvent=solvent_component,
-        protocol=RelativeHybridTopologyProtocol(RelativeHybridTopologyProtocol.default_settings())
+        n_protocol_repeats=3,
     )
 
     assert alchemical_network


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Resolves https://github.com/OpenFreeEnergy/openfe/issues/1071
<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

The intention is to change the default behavior to be `--n-protocol-repeats=1` in v2.0, and for now this change allows for users to control this parameter via a CLI flag.

Checklist
* [x] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
