### PR TITLE
Update docs for parallel repeat file structure 

### DIFF
--- a/docs/guide/execution/quickrun_execution.rst
+++ b/docs/guide/execution/quickrun_execution.rst
@@ -49,9 +49,10 @@ Parallel execution of repeats with Quickrun
 
 Serial execution of multiple repeats of a transformation can be inefficient when working with a HPC, in this case higher
 throughput can be achieved by running one repeat per HPC job allowing for parallel execution. Most protocols are setup to
-run ``three repeats in seral`` by default, however, this can be changed via the protocol setting ``protocol_repeats``, see the
-:ref:`protocol configuration guide <cookbook/choose_protocol.nblink>` for more details. Each transformation can then be executed
-multiple times via the ``openfe quickrun`` command to produce a set of repeats, however, you need to ensure to use unique results
+run ``three repeats in seral`` by default, however, this can be changed either via the protocol setting ``protocol_repeats``, see the
+:ref:`protocol configuration guide <cookbook/choose_protocol.nblink>` for more details or overridden via the
+``--n-protocol-repeats`` flag of the ``openfe quickrun`` command. Each transformation can then be executed multiple times via the
+``openfe quickrun`` command to produce a set of repeats, however, you need to ensure to use unique results
 files for each repeat to ensure they don't overwrite each other. We recommend using folders named ``results_x`` where x is 0-2
 to store the repeated calculations as our :ref:`openfe gather <cli_gather>` command also supports this file structure.
 
@@ -70,7 +71,7 @@ results to a unique folder:
        exit 1
      fi
      for repeat in {0..2}; do
-       cmd="openfe quickrun ${file} -o results_${repeat}/${relpath} -d results_${repeat}/${dirpath}"
+       cmd="openfe quickrun ${file} -o results_${repeat}/${relpath} -d results_${repeat}/${dirpath} --n-protocol-repeats 1"
        echo -e "#!/usr/bin/env bash\n${cmd}" > "${jobpath}"
        sbatch "${jobpath}"
      done

--- a/docs/guide/execution/quickrun_execution.rst
+++ b/docs/guide/execution/quickrun_execution.rst
@@ -49,9 +49,10 @@ Parallel execution of repeats with Quickrun
 
 Serial execution of multiple repeats of a transformation can be inefficient when simulation times are long.
 Higher throughput can be achieved with parallel execution by running one repeat per HPC job. Most protocols are set up to
-run ``three repeats in seral`` by default, however, this can be changed either via the protocol setting ``protocol_repeats``, see the
-:ref:`protocol configuration guide <cookbook/choose_protocol.nblink>` for more details or overridden via the
-``--n-protocol-repeats`` flag of the ``openfe quickrun`` command. Each transformation can then be executed multiple times via the
+run three repeats in serial by default, but this can be changed by either:
+ 
+ 1. Defining the protocol setting ``protocol_repeats`` - see the :ref:`protocol configuration guide <cookbook/choose_protocol.nblink>` for more details.
+ 2. Using the ``openfe plan-rhfe-network`` (or ``plan-rbfe-network``) command line flag ``--n-protocol-repeats``.  Each transformation can then be executed multiple times via the
 ``openfe quickrun`` command to produce a set of repeats, however, you need to ensure to use unique results
 files for each repeat to ensure they don't overwrite each other. We recommend using folders named ``results_x`` where x is 0-2
 to store the repeated calculations as our :ref:`openfe gather <cli_gather>` command also supports this file structure.

--- a/docs/guide/execution/quickrun_execution.rst
+++ b/docs/guide/execution/quickrun_execution.rst
@@ -57,7 +57,7 @@ run three repeats in serial by default, but this can be changed by either:
 files for each repeat to ensure they don't overwrite each other. We recommend using folders named ``results_x`` where x is 0-2
 to store the repeated calculations as our :ref:`openfe gather <cli_gather>` command also supports this file structure.
 
-Here is an example of a simple script that will create and submit a separate job script (\*.job named file)
+Here is an example of a simple script that will create and submit a separate job script (``\*.job`` named file)
 for every alchemical transformation (for the simplest SLURM use case) in a network running each repeat in parallel and writing the
 results to a unique folder:
 

--- a/docs/guide/execution/quickrun_execution.rst
+++ b/docs/guide/execution/quickrun_execution.rst
@@ -52,7 +52,9 @@ Higher throughput can be achieved with parallel execution by running one repeat 
 run three repeats in serial by default, but this can be changed by either:
  
  1. Defining the protocol setting ``protocol_repeats`` - see the :ref:`protocol configuration guide <cookbook/choose_protocol.nblink>` for more details.
- 2. Using the ``openfe plan-rhfe-network`` (or ``plan-rbfe-network``) command line flag ``--n-protocol-repeats``.  Each transformation can then be executed multiple times via the
+ 2. Using the ``openfe plan-rhfe-network`` (or ``plan-rbfe-network``) command line flag ``--n-protocol-repeats``.
+
+Each transformation can then be executed multiple times via the
 ``openfe quickrun`` command to produce a set of repeats, however, you need to ensure to use unique results
 files for each repeat to ensure they don't overwrite each other. We recommend using folders named ``results_x`` where x is 0-2
 to store the repeated calculations as our :ref:`openfe gather <cli_gather>` command also supports this file structure.

--- a/docs/guide/execution/quickrun_execution.rst
+++ b/docs/guide/execution/quickrun_execution.rst
@@ -47,8 +47,8 @@ The ``quickrun`` command can be integrated into as:
 Parallel execution of repeats with Quickrun
 ===========================================
 
-Serial execution of multiple repeats of a transformation can be inefficient when working with a HPC, in this case higher
-throughput can be achieved by running one repeat per HPC job allowing for parallel execution. Most protocols are setup to
+Serial execution of multiple repeats of a transformation can be inefficient when simulation times are long.
+Higher throughput can be achieved with parallel execution by running one repeat per HPC job. Most protocols are set up to
 run ``three repeats in seral`` by default, however, this can be changed either via the protocol setting ``protocol_repeats``, see the
 :ref:`protocol configuration guide <cookbook/choose_protocol.nblink>` for more details or overridden via the
 ``--n-protocol-repeats`` flag of the ``openfe quickrun`` command. Each transformation can then be executed multiple times via the


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Fixes #1063 by adding more docs on setting up the parallel execution file structure, and how to gather the results.

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
