### PR TITLE
Add a note on charge generation during CLI workflows

### DIFF
--- a/docs/guide/cli/cli_yaml.rst
+++ b/docs/guide/cli/cli_yaml.rst
@@ -1,3 +1,5 @@
+.. _userguide_cli_yaml_interface:
+
 Customising CLI planning with YAML settings
 ===========================================
 

--- a/docs/guide/introduction.rst
+++ b/docs/guide/introduction.rst
@@ -66,6 +66,13 @@ The commands used to generate an :class:`.AlchemicalNetwork` using the CLI are:
 * :ref:`cli_plan-rbfe-network`
 * :ref:`cli_plan-rhfe-network`
 
+.. note::
+
+   To ensure a consistent set of partial charges are used for each molecule across different transformations, the CLI
+   network planners will now automatically generate charges ahead of planning the network. The partial charge generation
+   scheme can be configured using the :ref:`YAML settings <userguide_cli_yaml_interface>`.
+
+
 For example, you can create a relative binding free energy (RBFE) network using
 
 .. code:: bash

--- a/docs/guide/introduction.rst
+++ b/docs/guide/introduction.rst
@@ -70,7 +70,9 @@ The commands used to generate an :class:`.AlchemicalNetwork` using the CLI are:
 
    To ensure a consistent set of partial charges are used for each molecule across different transformations, the CLI
    network planners will now automatically generate charges ahead of planning the network. The partial charge generation
-   scheme can be configured using the :ref:`YAML settings <userguide_cli_yaml_interface>`.
+   scheme can be configured using the :ref:`YAML settings <userguide_cli_yaml_interface>`. We also provide tooling to
+   generating the partial charges as a separate CLI step which can be run before network planning, see the :ref:`tutorial <charge_molecules_cli_tutorial>`
+   for more details.
 
 
 For example, you can create a relative binding free energy (RBFE) network using

--- a/docs/guide/introduction.rst
+++ b/docs/guide/introduction.rst
@@ -71,7 +71,7 @@ The commands used to generate an :class:`.AlchemicalNetwork` using the CLI are:
    To ensure a consistent set of partial charges are used for each molecule across different transformations, the CLI
    network planners will now automatically generate charges ahead of planning the network. The partial charge generation
    scheme can be configured using the :ref:`YAML settings <userguide_cli_yaml_interface>`. We also provide tooling to
-   generating the partial charges as a separate CLI step which can be run before network planning, see the :ref:`tutorial <charge_molecules_cli_tutorial>`
+   generate the partial charges as a separate CLI step which can be run before network planning, see the :ref:`tutorial <charge_molecules_cli_tutorial>`
    for more details.
 
 

--- a/docs/tutorials/charge_molecules_cli_tutorial.rst
+++ b/docs/tutorials/charge_molecules_cli_tutorial.rst
@@ -1,0 +1,4 @@
+.. _charge_molecules_cli_tutorial:
+
+.. include:: /ExampleNotebooks/cli_tutorials/cli_charge_molecules.md
+   :parser: myst_parser.sphinx_

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -61,6 +61,10 @@ use the `Cinnabar Python package <https://github.com/OpenFreeEnergy/cinnabar>`_
 to analyze (e.g. generating MLE estimates of absolute free energies)
 and plot networks of relative free energy results.
 
+Generating Partial Charges
+--------------------------
+
+The :any:`<charge_molecules_cli_tutorial>`
 
 .. toctree::
     :maxdepth: 1
@@ -72,3 +76,4 @@ and plot networks of relative free energy results.
     md_tutorial
     ahfe_tutorial
     plotting_with_cinnabar
+    charge_molecules_cli_tutorial

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -16,7 +16,7 @@ Relative Free Energies
 Python API Showcase
 ~~~~~~~~~~~~~~~~~~~
 
-Our :any:`shocase notebook <showcase_notebook>` walks users through
+Our :any:`showcase notebook <showcase_notebook>` walks users through
 how to use the main Python API components of OpenFE to create a
 relative binding free energy calculation.
 
@@ -64,7 +64,10 @@ and plot networks of relative free energy results.
 Generating Partial Charges
 --------------------------
 
-The :any:`<charge_molecules_cli_tutorial>`
+The :any:`Generating Partial Charges CLI tutorial <charge_molecules_cli_tutorial>` demonstrates
+ how the command line interface can be used to assign and store partial charges for small molecules which
+can be used throughout the OpenFE eco-system.
+
 
 .. toctree::
     :maxdepth: 1

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -14,7 +14,7 @@ Generating Partial Charges
 
 The :ref:`Generating Partial Charges CLI tutorial <charge_molecules_cli_tutorial>` demonstrates
 how the command line interface can be used to assign and store partial charges for small molecules which
-can be used throughout the OpenFE eco-system.
+can be used throughout the OpenFE ecosystem.
 
 Relative Free Energies
 ----------------------

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -9,6 +9,12 @@ OpenFE has several tutorial notebooks which are maintained on our
 Here is a list of key tutorials which cover the different aspects of the
 OpenFE tooling:
 
+Generating Partial Charges
+--------------------------
+
+The :ref:`Generating Partial Charges CLI tutorial <charge_molecules_cli_tutorial>` demonstrates
+how the command line interface can be used to assign and store partial charges for small molecules which
+can be used throughout the OpenFE eco-system.
 
 Relative Free Energies
 ----------------------
@@ -61,22 +67,16 @@ use the `Cinnabar Python package <https://github.com/OpenFreeEnergy/cinnabar>`_
 to analyze (e.g. generating MLE estimates of absolute free energies)
 and plot networks of relative free energy results.
 
-Generating Partial Charges
---------------------------
-
-The :any:`Generating Partial Charges CLI tutorial <charge_molecules_cli_tutorial>` demonstrates
- how the command line interface can be used to assign and store partial charges for small molecules which
-can be used throughout the OpenFE eco-system.
 
 
 .. toctree::
     :maxdepth: 1
     :hidden:
-    
+
+    charge_molecules_cli_tutorial
     rbfe_cli_tutorial
     rbfe_python_tutorial
     showcase_notebook
     md_tutorial
     ahfe_tutorial
     plotting_with_cinnabar
-    charge_molecules_cli_tutorial

--- a/openfecli/commands/plan_rbfe_network.py
+++ b/openfecli/commands/plan_rbfe_network.py
@@ -158,6 +158,13 @@ def plan_rbfe_network(
     The generated Network will be stored in a folder containing for each
     transformation a JSON file, that can be run with quickrun.
 
+    .. note::
+
+       To ensure a consistent set of partial charges are used for each molecule across different transformations, this
+       tool will automatically generate charges ahead of planning the network. ``am1bcc`` charges will be generated via
+       ``ambertools``, this can also be customized using the settings yaml file.
+
+
     By default, this tool makes the following choices:
 
     * Atom mappings performed by LOMAP, with settings max3d=1.0 and

--- a/openfecli/commands/plan_rhfe_network.py
+++ b/openfecli/commands/plan_rhfe_network.py
@@ -122,6 +122,13 @@ def plan_rhfe_network(molecules: List[str], yaml_settings: str, output_dir: str,
     to run the planned transformations with the quickrun tool.  For more
     sophisticated setups, please consider using the python layer of openfe.
 
+    .. note::
+
+       To ensure a consistent set of partial charges are used for each molecule across different transformations, this
+       tool will automatically generate charges ahead of planning the network. ``am1bcc`` charges will be generated via
+       ``ambertools``, this can also be customized using the settings yaml file.
+
+
     The tool will parse the input and run the rbfe network planner, which
     executes following steps:
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
This PR adds a note to inform users of the CLI that we are now generating charges when planning networks. I have also added a link to the new tutorial in example notebooks which should be merged first https://github.com/OpenFreeEnergy/ExampleNotebooks/pull/187
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
