### PR TITLE
updating news entry for clarity

### DIFF
--- a/news/gather_outputs_all_failed_edges.rst
+++ b/news/gather_outputs_all_failed_edges.rst
@@ -4,7 +4,7 @@
 
 **Changed:**
 
-* ``openfe gather`` now includes *all* failed edges (instead of just the first failed edge) when raising a "failed edges" error.
+* ``openfe gather`` now includes *all* edges with missing runs (instead of just the first failing edge) when raising a "missing runs" error.
 
 **Deprecated:**
 

--- a/openfecli/commands/gather.py
+++ b/openfecli/commands/gather.py
@@ -148,7 +148,7 @@ def legacy_get_type(res_fn:os.PathLike|str)->Literal['vacuum','solvent','complex
         return 'complex'
 
 def _generate_bad_legs_error_message(bad_legs:list[tuple[set[str], tuple[str]]])->str:
-    """Format output describing failed RBFE or RHFE legs.
+    """Format output describing RBFE or RHFE legs that are missing runs.
 
     Parameters
     ----------


### PR DESCRIPTION
update news entry to say "edges with missing runs" instead of "failed edges", since improved handling for failed edges/runs is still in progress.