### PR TITLE
remove "easy_" prefix from cli output

### DIFF
--- a/docs/guide/execution/quickrun_execution.rst
+++ b/docs/guide/execution/quickrun_execution.rst
@@ -86,23 +86,23 @@ This should result in the following file structure after execution:
 
     results_parallel/
     ├── results_0
-    │   ├── easy_rbfe_lig_ejm_31_complex_lig_ejm_42_complex
+    │   ├── rbfe_lig_ejm_31_complex_lig_ejm_42_complex
     │   │   └── shared_RelativeHybridTopologyProtocolUnit-79c279f04ec84218b7935bc0447539a9_attempt_0
     │   │       ├── checkpoint.nc
     │   │       ├── simulation.nc
-    │   ├── easy_rbfe_lig_ejm_31_complex_lig_ejm_42_complex.json
+    │   ├── rbfe_lig_ejm_31_complex_lig_ejm_42_complex.json
     ├── results_1
-    │   ├── easy_rbfe_lig_ejm_31_complex_lig_ejm_42_complex
+    │   ├── rbfe_lig_ejm_31_complex_lig_ejm_42_complex
     │   │   └── shared_RelativeHybridTopologyProtocolUnit-a3cef34132aa4e9cbb824fcbcd043b0e_attempt_0
     │   │       ├── checkpoint.nc
     │   │       ├── simulation.nc
-    │   ├── easy_rbfe_lig_ejm_31_complex_lig_ejm_42_complex.json
+    │   ├── rbfe_lig_ejm_31_complex_lig_ejm_42_complex.json
     └── results_2
-        ├── easy_rbfe_lig_ejm_31_complex_lig_ejm_42_complex
+        ├── rbfe_lig_ejm_31_complex_lig_ejm_42_complex
         │   └── shared_RelativeHybridTopologyProtocolUnit-abb2b104151c45fc8b0993fa0a7ee0af_attempt_0
         │       ├── checkpoint.nc
         │       ├── simulation.nc
-        └── easy_rbfe_lig_ejm_31_complex_lig_ejm_42_complex.json
+        └── rbfe_lig_ejm_31_complex_lig_ejm_42_complex.json
 
 The results of which can be gathered from the CLI using the ``openfe gather`` command, in this case you should direct
 it to the root directory which includes the repeat results and it will automatically collate the information

--- a/docs/guide/troubleshooting.rst
+++ b/docs/guide/troubleshooting.rst
@@ -53,7 +53,7 @@ Save this configuration file as ``debug_logging.conf`` and then run ``openfe qui
 
 .. code-block:: bash
 
-   $ openfe --log debug_logging.conf quickrun -d results/ -o results/result_lig_ejm_31_solvent_lig_ejm_42_solvent.json transformations/easy_rbfe_lig_ejm_31_solvent_lig_ejm_42_solvent.json
+   $ openfe --log debug_logging.conf quickrun -d results/ -o results/result_lig_ejm_31_solvent_lig_ejm_42_solvent.json transformations/rbfe_lig_ejm_31_solvent_lig_ejm_42_solvent.json
 
 Note that the ``--log debug_logging.conf`` argument goes between ``openfe`` and ``quickrun`` on the command line.
 

--- a/news/remove_easy_prefix.rst
+++ b/news/remove_easy_prefix.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* CLI network planners' default names use prefixes `rbfe_` or `rhfe_` , instead of `easy_rbfe` or `easy_rhfe`, to simplify default transformation names.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/openfe/setup/alchemical_network_planner/relative_alchemical_network_planner.py
+++ b/openfe/setup/alchemical_network_planner/relative_alchemical_network_planner.py
@@ -303,7 +303,7 @@ class RBFEAlchemicalNetworkPlanner(RelativeAlchemicalNetworkPlanner):
     """
     def __init__(
         self,
-        name: str = "rbfe",  # TODO: change this default to "" in 2.0
+        name: str = "rbfe",
         mappers: Optional[Iterable[LigandAtomMapper]] = None,
         mapping_scorer: Callable[[LigandAtomMapping], float]  = default_lomap_score,
         ligand_network_planner: Callable = generate_minimal_spanning_network,

--- a/openfe/setup/alchemical_network_planner/relative_alchemical_network_planner.py
+++ b/openfe/setup/alchemical_network_planner/relative_alchemical_network_planner.py
@@ -303,7 +303,7 @@ class RBFEAlchemicalNetworkPlanner(RelativeAlchemicalNetworkPlanner):
     """
     def __init__(
         self,
-        name: str = "easy_rbfe",  # TODO: change this default to "" in 2.0
+        name: str = "rbfe",  # TODO: change this default to "" in 2.0
         mappers: Optional[Iterable[LigandAtomMapper]] = None,
         mapping_scorer: Callable[[LigandAtomMapping], float]  = default_lomap_score,
         ligand_network_planner: Callable = generate_minimal_spanning_network,

--- a/openfe/setup/alchemical_network_planner/relative_alchemical_network_planner.py
+++ b/openfe/setup/alchemical_network_planner/relative_alchemical_network_planner.py
@@ -241,7 +241,7 @@ class RHFEAlchemicalNetworkPlanner(RelativeAlchemicalNetworkPlanner):
 
     def __init__(
         self,
-        name: str = "easy_rhfe",
+        name: str = "rhfe",
         mappers: Optional[Iterable[LigandAtomMapper]] = None,
         mapping_scorer: Callable[[LigandAtomMapping], float]  = default_lomap_score,
         ligand_network_planner: Callable = generate_minimal_spanning_network,

--- a/openfe/tests/setup/alchemical_network_planner/test_relative_alchemical_network_planner.py
+++ b/openfe/tests/setup/alchemical_network_planner/test_relative_alchemical_network_planner.py
@@ -19,7 +19,7 @@ def test_rhfe_alchemical_network_planner_init():
 def test_rbfe_alchemical_network_planner_init():
     alchem_planner = RBFEAlchemicalNetworkPlanner()
     
-    assert alchem_planner.name == "easy_rbfe"
+    assert alchem_planner.name == "rbfe"
 
 
 def test_rbfe_alchemical_network_planner_call(atom_mapping_basic_test_files, T4_protein_component):

--- a/openfe/tests/setup/alchemical_network_planner/test_relative_alchemical_network_planner.py
+++ b/openfe/tests/setup/alchemical_network_planner/test_relative_alchemical_network_planner.py
@@ -13,7 +13,7 @@ import openfe
 def test_rhfe_alchemical_network_planner_init():
     alchem_planner = RHFEAlchemicalNetworkPlanner()
     
-    assert alchem_planner.name == "easy_rhfe"
+    assert alchem_planner.name == "rhfe"
 
 
 def test_rbfe_alchemical_network_planner_init():

--- a/openfecli/tests/commands/test_gather.py
+++ b/openfecli/tests/commands/test_gather.py
@@ -189,8 +189,8 @@ class TestGatherFailedEdges:
                 tar.extractall('.')
 
                 results_dir_path = os.path.abspath(tar.getnames()[0])
-                files_to_remove = ["easy_rbfe_lig_ejm_31_complex_lig_ejm_42_complex.json",
-                                   "easy_rbfe_lig_ejm_46_solvent_lig_jmc_28_solvent.json"
+                files_to_remove = ["rbfe_lig_ejm_31_complex_lig_ejm_42_complex.json",
+                                   "rbfe_lig_ejm_46_solvent_lig_jmc_28_solvent.json"
                                    ]
                 for fname in files_to_remove:
                     (pathlib.Path(results_dir_path)/ fname).unlink()

--- a/openfecli/tests/commands/test_plan_rbfe_network.py
+++ b/openfecli/tests/commands/test_plan_rbfe_network.py
@@ -147,13 +147,13 @@ def test_plan_rbfe_network(mol_dir_args, protein_args, tmpdir, yaml_nagl_setting
     # we can get these in either order: 22 first or 55 first
     expected_output_1 = [
         "Small Molecules: SmallMoleculeComponent(name=ligand_23) SmallMoleculeComponent(name=ligand_55)",
-        "- easy_rbfe_ligand_23_complex_ligand_55_complex.json",
-        "- easy_rbfe_ligand_23_solvent_ligand_55_solvent.json",
+        "- rbfe_ligand_23_complex_ligand_55_complex.json",
+        "- rbfe_ligand_23_solvent_ligand_55_solvent.json",
     ]
     expected_output_2 = [
         "Small Molecules: SmallMoleculeComponent(name=ligand_55) SmallMoleculeComponent(name=ligand_23)",
-        "- easy_rbfe_ligand_55_complex_ligand_23_complex.json",
-        "- easy_rbfe_ligand_55_solvent_ligand_23_solvent.json",
+        "- rbfe_ligand_55_complex_ligand_23_complex.json",
+        "- rbfe_ligand_55_solvent_ligand_23_solvent.json",
     ]
 
     patch_base = (

--- a/openfecli/tests/commands/test_plan_rhfe_network.py
+++ b/openfecli/tests/commands/test_plan_rhfe_network.py
@@ -123,13 +123,13 @@ def test_plan_rhfe_network(mol_dir_args, tmpdir, yaml_nagl_settings):
     # we can get these in either order: 22 then 55 or 55 then 22
     expected_output_1 = [
         "Small Molecules: SmallMoleculeComponent(name=ligand_23) SmallMoleculeComponent(name=ligand_55)",
-        "- easy_rhfe_ligand_23_vacuum_ligand_55_vacuum.json",
-        "- easy_rhfe_ligand_23_solvent_ligand_55_solvent.json",
+        "- rhfe_ligand_23_vacuum_ligand_55_vacuum.json",
+        "- rhfe_ligand_23_solvent_ligand_55_solvent.json",
     ]
     expected_output_2 = [
         "Small Molecules: SmallMoleculeComponent(name=ligand_55) SmallMoleculeComponent(name=ligand_23)",
-        "- easy_rhfe_ligand_55_vacuum_ligand_23_vacuum.json",
-        "- easy_rhfe_ligand_55_solvent_ligand_23_solvent.json",
+        "- rhfe_ligand_55_vacuum_ligand_23_vacuum.json",
+        "- rhfe_ligand_55_solvent_ligand_23_solvent.json",
     ]
 
     patch_base = (

--- a/openfecli/tests/test_rbfe_tutorial.py
+++ b/openfecli/tests/test_rbfe_tutorial.py
@@ -32,24 +32,24 @@ def tyk2_protein():
 
 @pytest.fixture
 def expected_transformations():
-    return ['easy_rbfe_lig_ejm_31_complex_lig_ejm_46_complex.json',
-            'easy_rbfe_lig_ejm_31_complex_lig_ejm_47_complex.json',
-            'easy_rbfe_lig_ejm_31_complex_lig_ejm_48_complex.json',
-            'easy_rbfe_lig_ejm_31_complex_lig_ejm_50_complex.json',
-            'easy_rbfe_lig_ejm_31_solvent_lig_ejm_46_solvent.json',
-            'easy_rbfe_lig_ejm_31_solvent_lig_ejm_47_solvent.json',
-            'easy_rbfe_lig_ejm_31_solvent_lig_ejm_48_solvent.json',
-            'easy_rbfe_lig_ejm_31_solvent_lig_ejm_50_solvent.json',
-            'easy_rbfe_lig_ejm_42_complex_lig_ejm_43_complex.json',
-            'easy_rbfe_lig_ejm_42_complex_lig_ejm_50_complex.json',
-            'easy_rbfe_lig_ejm_42_solvent_lig_ejm_43_solvent.json',
-            'easy_rbfe_lig_ejm_42_solvent_lig_ejm_50_solvent.json',
-            'easy_rbfe_lig_ejm_46_solvent_lig_jmc_23_solvent.json',
-            'easy_rbfe_lig_ejm_46_complex_lig_jmc_23_complex.json',
-            'easy_rbfe_lig_jmc_23_complex_lig_jmc_27_complex.json',
-            'easy_rbfe_lig_jmc_23_solvent_lig_jmc_27_solvent.json',
-            'easy_rbfe_lig_jmc_23_solvent_lig_jmc_28_solvent.json',
-            'easy_rbfe_lig_jmc_23_complex_lig_jmc_28_complex.json']
+    return ['rbfe_lig_ejm_31_complex_lig_ejm_46_complex.json',
+            'rbfe_lig_ejm_31_complex_lig_ejm_47_complex.json',
+            'rbfe_lig_ejm_31_complex_lig_ejm_48_complex.json',
+            'rbfe_lig_ejm_31_complex_lig_ejm_50_complex.json',
+            'rbfe_lig_ejm_31_solvent_lig_ejm_46_solvent.json',
+            'rbfe_lig_ejm_31_solvent_lig_ejm_47_solvent.json',
+            'rbfe_lig_ejm_31_solvent_lig_ejm_48_solvent.json',
+            'rbfe_lig_ejm_31_solvent_lig_ejm_50_solvent.json',
+            'rbfe_lig_ejm_42_complex_lig_ejm_43_complex.json',
+            'rbfe_lig_ejm_42_complex_lig_ejm_50_complex.json',
+            'rbfe_lig_ejm_42_solvent_lig_ejm_43_solvent.json',
+            'rbfe_lig_ejm_42_solvent_lig_ejm_50_solvent.json',
+            'rbfe_lig_ejm_46_solvent_lig_jmc_23_solvent.json',
+            'rbfe_lig_ejm_46_complex_lig_jmc_23_complex.json',
+            'rbfe_lig_jmc_23_complex_lig_jmc_27_complex.json',
+            'rbfe_lig_jmc_23_solvent_lig_jmc_27_solvent.json',
+            'rbfe_lig_jmc_23_solvent_lig_jmc_28_solvent.json',
+            'rbfe_lig_jmc_23_complex_lig_jmc_28_complex.json']
 
 
 def test_plan_tyk2(tyk2_ligands, tyk2_protein, expected_transformations):


### PR DESCRIPTION
see https://github.com/OpenFreeEnergy/ExampleNotebooks/pull/190 for corresponding example notebooks PR

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [x] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
