### PR TITLE
adding user message for --n-protocol-repeats transparency

### DIFF
--- a/openfecli/commands/plan_rbfe_network.py
+++ b/openfecli/commands/plan_rbfe_network.py
@@ -229,10 +229,10 @@ def plan_rbfe_network(
     if overwrite_charges:
         write("\tOverwriting partial charges")
     write("")
+    write(f"\t{n_protocol_repeats=} ({n_protocol_repeats} simulation repeat(s) per protocol unit)\n")
 
     # DO
     write("Planning RBFE-Campaign:")
-    write(f"--n_protocol_repeats={n_protocol_repeats} simulation repeats per protocol unit.")
     alchemical_network, ligand_network = plan_rbfe_network_main(
         mapper=[mapper_obj],
         mapping_scorer=mapping_scorer,

--- a/openfecli/commands/plan_rbfe_network.py
+++ b/openfecli/commands/plan_rbfe_network.py
@@ -229,7 +229,7 @@ def plan_rbfe_network(
     if overwrite_charges:
         write("\tOverwriting partial charges")
     write("")
-    write(f"\t{n_protocol_repeats=} ({n_protocol_repeats} simulation repeat(s) per protocol unit)\n")
+    write(f"\t{n_protocol_repeats=} ({n_protocol_repeats} simulation repeat(s) per protocol transformation)\n")
 
     # DO
     write("Planning RBFE-Campaign:")

--- a/openfecli/commands/plan_rbfe_network.py
+++ b/openfecli/commands/plan_rbfe_network.py
@@ -229,7 +229,7 @@ def plan_rbfe_network(
     if overwrite_charges:
         write("\tOverwriting partial charges")
     write("")
-    write(f"\t{n_protocol_repeats=} ({n_protocol_repeats} simulation repeat(s) per protocol transformation)\n")
+    write(f"\t{n_protocol_repeats=} ({n_protocol_repeats} simulation repeat(s) per transformation)\n")
 
     # DO
     write("Planning RBFE-Campaign:")

--- a/openfecli/commands/plan_rbfe_network.py
+++ b/openfecli/commands/plan_rbfe_network.py
@@ -232,6 +232,7 @@ def plan_rbfe_network(
 
     # DO
     write("Planning RBFE-Campaign:")
+    write(f"--n_protocol_repeats={n_protocol_repeats} simulation repeats per protocol unit.")
     alchemical_network, ligand_network = plan_rbfe_network_main(
         mapper=[mapper_obj],
         mapping_scorer=mapping_scorer,

--- a/openfecli/commands/plan_rhfe_network.py
+++ b/openfecli/commands/plan_rhfe_network.py
@@ -185,6 +185,7 @@ def plan_rhfe_network(molecules: List[str], yaml_settings: str, output_dir: str,
     if overwrite_charges:
         write("\tOverwriting partial charges")
     write("")
+    write(f"\t{n_protocol_repeats=} ({n_protocol_repeats} simulation repeat(s) per protocol unit)\n")
 
     # DO
     write("Planning RHFE-Campaign:")

--- a/openfecli/commands/plan_rhfe_network.py
+++ b/openfecli/commands/plan_rhfe_network.py
@@ -185,7 +185,7 @@ def plan_rhfe_network(molecules: List[str], yaml_settings: str, output_dir: str,
     if overwrite_charges:
         write("\tOverwriting partial charges")
     write("")
-    write(f"\t{n_protocol_repeats=} ({n_protocol_repeats} simulation repeat(s) per protocol unit)\n")
+    write(f"\t{n_protocol_repeats=} ({n_protocol_repeats} simulation repeat(s) per transformation)\n")
 
     # DO
     write("Planning RHFE-Campaign:")


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
@mikemhenry let me know if this is helpful
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
