### PR TITLE
bump single file installers to python 3.11

### DIFF
--- a/.github/workflows/installer.yaml
+++ b/.github/workflows/installer.yaml
@@ -41,7 +41,7 @@ jobs:
         micromamba-binary-path: ~/.local/bin/micromamba
         environment-name: installer
         create-args: >-
-          python=3.10
+          python=3.11
           jinja2
           constructor
         init-shell: bash

--- a/devtools/installer/construct.yaml
+++ b/devtools/installer/construct.yaml
@@ -19,6 +19,8 @@ specs:
   - pip
   - pytest
   - pytest-xdist
+  # python needs to match https://github.com/googlecolab/backend-info/blob/main/os-info.txt
+  # until colab pushes a fix
   - python 3.11.11
 
 # Not building an .exe for windows or a .pkg for macOS

--- a/devtools/installer/construct.yaml
+++ b/devtools/installer/construct.yaml
@@ -19,7 +19,7 @@ specs:
   - pip
   - pytest
   - pytest-xdist
-  - python 3.10.*
+  - python 3.11.11
 
 # Not building an .exe for windows or a .pkg for macOS
 installer_type: sh


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
resolves https://github.com/OpenFreeEnergy/ExampleNotebooks/issues/193#issuecomment-2685945106
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [ x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
