### PR TITLE
block interchange 0.4.2 in env setup

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -22,6 +22,7 @@ dependencies:
   - openff-nagl-base >=0.3.3
   - openff-nagl-models>=0.1.2
   - openff-units==0.2.0
+  - openff-interchange !=0.4.2
   - pint<0.22
   - openff-models>=0.0.5
   - openfe-analysis>=0.3.1


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
[this PR](https://github.com/openforcefield/openff-interchange/pull/1133) breaks our tests, pinning to `!=0.4.2` fixes it and will pull in the next bugfix release when it's addressed.
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
