### PR TITLE
make gufe lowercase in docs

### DIFF
--- a/docs/reference/api/index.rst
+++ b/docs/reference/api/index.rst
@@ -2,7 +2,7 @@
 
 .. note::
    We have reproduced API documentation from the `gufe`_ package here for convenience.
-   Gufe serves as a foundation layer for openfe, providing abstract base classes and object models, and so might be more useful for developers.
+   `gufe`_ serves as a foundation layer for openfe, providing abstract base classes and object models, and so might be more useful for developers.
 
 OpenFE API Reference
 ====================

--- a/docs/reference/api/index.rst
+++ b/docs/reference/api/index.rst
@@ -1,8 +1,8 @@
 .. _api:
 
 .. note::
-   We have reproduced API documentation from the `GUFE`_ package here for convenience.
-   The GUFE package serves as a foundation layer for openfe, providing abstract base classes and object models, and so might be more useful for developers.
+   We have reproduced API documentation from the `gufe`_ package here for convenience.
+   Gufe serves as a foundation layer for openfe, providing abstract base classes and object models, and so might be more useful for developers.
 
 OpenFE API Reference
 ====================
@@ -20,4 +20,4 @@ OpenFE API Reference
     openmm_md
     openmm_protocol_settings
 
-.. _GUFE: https://gufe.readthedocs.io/en/latest/api.html
+.. _gufe: https://gufe.readthedocs.io/en/latest/api.html

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -6,7 +6,7 @@ command line interface.
 
 .. note::
    We have reproduced API documentation from the `gufe`_ package here for convenience.
-   Gufe serves as a foundation layer for openfe, providing abstract base classes and object models, and so might be more useful for developers.
+   `gufe`_ serves as a foundation layer for openfe, providing abstract base classes and object models, and so might be more useful for developers.
 
 .. toctree::
     :maxdepth: 2

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -5,8 +5,8 @@ This contains details of the Python API as well as a reference to the
 command line interface.
 
 .. note::
-   We have reproduced API documentation from the `GUFE`_ package here for convenience.
-   The GUFE package serves as a foundation layer for openfe, providing abstract base classes and object models, and so might be more useful for developers.
+   We have reproduced API documentation from the `gufe`_ package here for convenience.
+   Gufe serves as a foundation layer for openfe, providing abstract base classes and object models, and so might be more useful for developers.
 
 .. toctree::
     :maxdepth: 2
@@ -14,4 +14,4 @@ command line interface.
     api/index
     cli/index
 
-.. _GUFE: https://gufe.readthedocs.io/en/latest/api.html
+.. _gufe: https://gufe.readthedocs.io/en/latest/api.html


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
while we're addressing this in the gufe docs overhaul, I thought I'd update in openfe docs as well.
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
