### PR TITLE
remove deps in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,20 +23,8 @@ classifiers = [
 ]
 urls = {Homepage = "https://github.com/OpenFreeEnergy/openfe"}
 requires-python = ">= 3.10"
-dependencies = [
-    "numpy",
-    "networkx",
-    "click",
-    "plugcli",
-    "packaging",
-]
-dynamic = ["version"]
 
-[project.optional-dependencies]
-test = [
-    "pytest",
-    "pytest-xdist",
-]
+dynamic = ["version"]
 
 [project.scripts]
 openfe = "openfecli.cli:main"


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.


Same as https://github.com/OpenFreeEnergy/gufe/pull/511

These deps don't really help anyone install or test the package and just get in the way of tooling