### PR TITLE
ci: update to the new start and stop actions 

### DIFF
--- a/.github/workflows/cpu-runner.yaml
+++ b/.github/workflows/cpu-runner.yaml
@@ -18,13 +18,10 @@ jobs:
           aws-region: us-east-2
       - name: Create cloud runner
         id: aws-start
-        uses: omsf-eco-infra/gha-runner@v0.2.0
+        uses: omsf/start-aws-gha-runner@v1.0.0
         with:
-          provider: "aws"
-          action: "start"
           aws_image_id: ami-0b7f661c228e6a4bb
           aws_instance_type: t3a.small  # TODO try t3a.medium next
-          aws_region_name: us-east-2
           aws_home_dir: /home/ubuntu
         env:
           GH_PAT: ${{ secrets.GH_PAT }}
@@ -114,11 +111,8 @@ jobs:
           role-to-assume: arn:aws:iam::010438489691:role/GHARunnerAWS
           aws-region: us-east-2
       - name: Stop instances
-        uses: omsf-eco-infra/gha-runner@v0.2.0
+        uses: omsf/stop-aws-gha-runner@v1.0.0
         with:
-          provider: "aws"
-          action: "stop"
           instance_mapping: ${{ needs.start-aws-runner.outputs.mapping }}
-          aws_region_name: us-east-2
         env:
           GH_PAT: ${{ secrets.GH_PAT }}

--- a/.github/workflows/gpu-runner.yaml
+++ b/.github/workflows/gpu-runner.yaml
@@ -18,13 +18,10 @@ jobs:
           aws-region: us-east-2
       - name: Create cloud runner
         id: aws-start
-        uses: omsf-eco-infra/gha-runner@v0.2.0
+        uses: omsf/start-aws-gha-runner@v1.0.0
         with:
-          provider: "aws"
-          action: "start"
           aws_image_id: ami-0b7f661c228e6a4bb
           aws_instance_type: g4dn.xlarge
-          aws_region_name: us-east-2
           aws_home_dir: /home/ubuntu
         env:
           GH_PAT: ${{ secrets.GH_PAT }}
@@ -114,11 +111,8 @@ jobs:
           role-to-assume: arn:aws:iam::010438489691:role/GHARunnerAWS
           aws-region: us-east-2
       - name: Stop instances
-        uses: omsf-eco-infra/gha-runner@v0.2.0
+        uses: omsf/stop-aws-gha-runner@v1.0.0
         with:
-          provider: "aws"
-          action: "stop"
           instance_mapping: ${{ needs.start-aws-runner.outputs.mapping }}
-          aws_region_name: us-east-2
         env:
           GH_PAT: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.

## Changes
This pull request includes updates to the GitHub Actions workflows for both CPU and GPU runners. The changes primarily focus on updating the actions used and simplifying the configuration by removing redundant parameters. These new actions adhere to the AWS SDK such that we don't need to include the region name anymore. Additionally, these split up the actions so that they are more succinct. We have already merged these changes in `feflow`, for more information OpenFreeEnergy/feflow#112.

Updates to GitHub Actions workflows:

* [`.github/workflows/cpu-runner.yaml`](diffhunk://#diff-96db2e4022814af4a333d2c47a012db264b70ce172746f0e8d7178e9ee144f11L23-L27): Removed the `provider`, `action`, and `aws_region_name` parameters from the `aws-start` and `Stop instances` steps. [[1]](diffhunk://#diff-96db2e4022814af4a333d2c47a012db264b70ce172746f0e8d7178e9ee144f11L23-L27) [[2]](diffhunk://#diff-96db2e4022814af4a333d2c47a012db264b70ce172746f0e8d7178e9ee144f11L119-L122)
* [`.github/workflows/gpu-runner.yaml`](diffhunk://#diff-0086026c407da16a8c2c0765d46e9d25b38320d39729545b00eb64ddfc5af198L21-L27): Updated the action used for starting and stopping instances to `omsf/start-aws-gha-runner@v1.0.0` and `omsf/stop-aws-gha-runner@v1.0.0`, respectively. Removed the `provider`, `action`, and `aws_region_name` parameters from the `aws-start` and `Stop instances` steps. [[1]](diffhunk://#diff-0086026c407da16a8c2c0765d46e9d25b38320d39729545b00eb64ddfc5af198L21-L27) [[2]](diffhunk://#diff-0086026c407da16a8c2c0765d46e9d25b38320d39729545b00eb64ddfc5af198L117-L122)
