### PR TITLE
switch kcal/mol to kilocalorie_per_mole for roundtrip consistency

### DIFF
--- a/openfe/protocols/openmm_utils/omm_settings.py
+++ b/openfe/protocols/openmm_utils/omm_settings.py
@@ -573,7 +573,7 @@ class MultiStateSimulationSettings(SimulationSettings):
     Default `250`.
     
     """
-    early_termination_target_error: Optional[FloatQuantity['kcal/mol']] = 0.0 * unit.kilocalorie_per_mole
+    early_termination_target_error: Optional[FloatQuantity['kilocalorie_per_mole']] = 0.0 * unit.kilocalorie_per_mole
     # todo: have default ``None`` or ``0.0 * unit.kilocalorie_per_mole``
     #  (later would give an example of unit).
     """

--- a/openfe/tests/protocols/test_rfe_tokenization.py
+++ b/openfe/tests/protocols/test_rfe_tokenization.py
@@ -3,6 +3,7 @@
 
 from openfe.protocols import openmm_rfe
 from gufe.tests.test_tokenization import GufeTokenizableTestsMixin
+from openff.units import unit
 import pytest
 
 """
@@ -13,13 +14,20 @@ todo:
 """
 
 @pytest.fixture
-def protocol():
+def rfe_protocol():
     return openmm_rfe.RelativeHybridTopologyProtocol(openmm_rfe.RelativeHybridTopologyProtocol.default_settings())
+
+@pytest.fixture
+def rfe_protocol_other_units():
+    """Identical to rfe_protocol, but with `kcal / mol` as input unit instead of `kilocalorie_per_mole`."""
+    new_settings = openmm_rfe.RelativeHybridTopologyProtocol.default_settings()
+    new_settings.simulation_settings.early_termination_target_error = 0.0 * unit.kilocalorie/unit.mol
+    return openmm_rfe.RelativeHybridTopologyProtocol(new_settings)
 
 
 @pytest.fixture
-def protocol_unit(protocol, benzene_system, toluene_system, benzene_to_toluene_mapping):
-    pus = protocol.create(
+def protocol_unit(rfe_protocol, benzene_system, toluene_system, benzene_to_toluene_mapping):
+    pus = rfe_protocol.create(
         stateA=benzene_system, stateB=toluene_system,
         mapping=[benzene_to_toluene_mapping],
     )
@@ -36,6 +44,21 @@ class TestRelativeHybridTopologyProtocolResult(GufeTokenizableTestsMixin):
     def instance(self):
         pass
 
+class TestRelativeHybridTopologyProtocolOtherUnits(GufeTokenizableTestsMixin):
+    cls = openmm_rfe.RelativeHybridTopologyProtocol
+    key = None
+    repr = "<RelativeHybridTopologyProtocol-"
+
+    @pytest.fixture()
+    def instance(self, rfe_protocol_other_units):
+        return rfe_protocol_other_units
+
+    def test_repr(self, instance):
+        """
+        Overwrites the base `test_repr` call.
+        """
+        assert isinstance(repr(instance), str)
+        assert self.repr in repr(instance)
 
 class TestRelativeHybridTopologyProtocol(GufeTokenizableTestsMixin):
     cls = openmm_rfe.RelativeHybridTopologyProtocol
@@ -43,8 +66,8 @@ class TestRelativeHybridTopologyProtocol(GufeTokenizableTestsMixin):
     repr = "<RelativeHybridTopologyProtocol-"
 
     @pytest.fixture()
-    def instance(self, protocol):
-        return protocol
+    def instance(self, rfe_protocol):
+        return rfe_protocol
 
     def test_repr(self, instance):
         """


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

gufe added new tests to ``GufeTokenizableTestsMixin`` for json and msgpack roundtripping, and it caught that roundtripping `RelativeHybridTopologyProtocol` and `AbsoluteSolvationProtocol` does not reproduce the same gufe key. 

This is because the original object's `early_termination_target_error`'s units are `kilocalorie_per_mole`, but when it's loaded back in, it's in units of `kilocalorie / mole`

We think this is because of pydantic casting, and changing the pydantic class to expect `kilocalorie_per_mole` solves this.



<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
