### PR TITLE
fix docker build workflow

### DIFF
--- a/.github/workflows/docker-cron.yaml
+++ b/.github/workflows/docker-cron.yaml
@@ -71,7 +71,7 @@ jobs:
             ${{ steps.latest-version.outputs.VERSION }}
 
       - name: Build and export to Docker
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: production/Dockerfile

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -122,8 +122,8 @@ jobs:
         run: |
           mkdir test_apptainer
           cd test_apptainer
-          singularity run ../openfe_${{ steps.latest-version.outputs.VERSION }}.sif --help
-          singularity run ../openfe_${{ steps.latest-version.outputs.VERSION }}.sif --version
+          singularity run ../openfe_${{ steps.latest-version.outputs.VERSION }}.sif openfe --help
+          singularity run ../openfe_${{ steps.latest-version.outputs.VERSION }}.sif openfe --version
           singularity run ../openfe_${{ steps.latest-version.outputs.VERSION }}.sif pytest --pyargs openfe openfecli -v -n auto
           echo ${{ secrets.GITHUB_TOKEN }} | singularity remote login -u ${{ secrets.GHCR_USERNAME }} --password-stdin oras://ghcr.io
           singularity push ../openfe_${{ steps.latest-version.outputs.VERSION }}.sif oras://${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.latest-version.outputs.VERSION }}-apptainer

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -80,7 +80,7 @@ jobs:
             ${{ steps.latest-version.outputs.VERSION }}
 
       - name: Build and export to Docker
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: production/Dockerfile


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Now that we're running with `shell: bash -leo pipefail {0}`, the singularity calls to `--version` and `--help` are failing because we were actually calling them incorrectly, but it was just failing silently before.

This should fix it.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
