### PR TITLE
Pass through failed sims

### DIFF
--- a/openfecli/commands/gather.py
+++ b/openfecli/commands/gather.py
@@ -292,19 +292,6 @@ def _write_raw(legs:dict, writer:Callable, allow_partial=True):
                         m, u = format_estimate_uncertainty(m.m, u.m)
                     writer.writerow([simtype, *ligpair, m, u])
 
-
-def _write_dg_raw(legs:dict, writer:Callable,  allow_partial):  # pragma: no-cover
-    writer.writerow(["leg", "ligand_i", "ligand_j", "DG(i->j) (kcal/mol)",
-                     "uncertainty (kcal/mol)"])
-    for ligpair, vals in sorted(legs.items()):
-        for simtype, (m, u) in sorted(vals.items()):
-            if m is None:
-                m, u = 'NaN', 'NaN'
-            else:
-                m, u = format_estimate_uncertainty(m.m, u.m)
-            writer.writerow([simtype, *ligpair, m, u])
-
-
 def _write_dg_mle(legs:dict, writer:Callable, allow_partial:bool):
     import networkx as nx
     import numpy as np

--- a/openfecli/commands/gather.py
+++ b/openfecli/commands/gather.py
@@ -152,8 +152,11 @@ def get_names(result:dict) -> tuple[str, str]:
     tuple[str, str]
         Ligand names corresponding to the results.
     """
+    try:
+        nm = list(result['unit_results'].values())[0]['name']
+    except KeyError:
+        raise ValueError("Failed to guess names")
 
-    nm = list(result['unit_results'].values())[0]['name']
     toks = nm.split()
     if toks[2] == 'repeat':
         return toks[0], toks[1]
@@ -408,10 +411,8 @@ def _get_legs_from_result_jsons(result_fns: list[pathlib.Path], report: Literal[
         if result is None:
             continue
 
-        try:
-            names = get_names(result)
-        except KeyError:
-            raise ValueError("Failed to guess names")
+        names = get_names(result)
+
         try:
             simtype = get_type(result)
         except KeyError:

--- a/openfecli/tests/commands/test_gather.py
+++ b/openfecli/tests/commands/test_gather.py
@@ -38,10 +38,14 @@ class TestResultLoading:
         result = {
             "estimate": {},
             "uncertainty": {},
-            "protocol_result": {'data':{'2294096155646608107660849867019691905': None}},
+            "protocol_result": {'data':{'2294096155646608107660849867019691905':  [
+                {"name": "lig_ejm_31 to lig_ejm_42 repeat 0 generation 0",
+                  "inputs": {"stateA": {"components": {"ligand":None}}}}
+                  ]}},
             "unit_results": {
-                "ProtocolUnitResult-e85": {},
-                "ProtocolUnitFailure-4c9": {"exception": ["Simulation_NanError"]},
+                "ProtocolUnitResult-e85": {"name":"lig_ejm_31 to lig_ejm_42 repeat 0 generation 0"},
+                "ProtocolUnitFailure-4c9": {"name":"lig_ejm_31 to lig_ejm_42 repeat 0 generation 0",
+                                            "exception": ["Simulation_NanError"]},
             },
         }
         yield result
@@ -50,13 +54,13 @@ class TestResultLoading:
         with mock.patch("openfecli.commands.gather.load_json", return_value=sim_result):
             result = load_valid_result_json(fpath="")
             captured = capsys.readouterr()
-            assert result == sim_result
+            assert result == (('lig_ejm_31', 'lig_ejm_42', 'vacuum'), sim_result)
             assert captured.err == ""
 
     def test_skip_missing_filepath(self, capsys):
         result = load_valid_result_json(fpath="")
         captured = capsys.readouterr()
-        assert result is None
+        assert result == (None, None)
         assert "does not exist. Skipping" in captured.err
 
     def test_skip_missing_unit_result(self, capsys, sim_result):
@@ -65,8 +69,8 @@ class TestResultLoading:
         with mock.patch("openfecli.commands.gather.load_json", return_value=sim_result):
             result = load_valid_result_json(fpath="")
             captured = capsys.readouterr()
-            assert result is None
-            assert "No 'unit_results'" in captured.err
+            assert result == (None, None)
+            assert "Missing ligand names and/or simulation type. Skipping" in captured.err
 
     def test_skip_missing_estimate(self, capsys, sim_result):
         sim_result["estimate"] = None
@@ -74,7 +78,7 @@ class TestResultLoading:
         with mock.patch("openfecli.commands.gather.load_json", return_value=sim_result):
             result = load_valid_result_json(fpath="")
             captured = capsys.readouterr()
-            assert result is None
+            assert result == (('lig_ejm_31', 'lig_ejm_42', 'vacuum'), None)
             assert "No 'estimate' found" in captured.err
 
     def test_skip_missing_uncertainty(self, capsys, sim_result):
@@ -83,7 +87,7 @@ class TestResultLoading:
         with mock.patch("openfecli.commands.gather.load_json", return_value=sim_result):
             result = load_valid_result_json(fpath="")
             captured = capsys.readouterr()
-            assert result is None
+            assert result == (('lig_ejm_31', 'lig_ejm_42', 'vacuum'), None)
             assert "No 'uncertainty' found" in captured.err
 
     def test_skip_all_failed_runs(self, capsys, sim_result):
@@ -91,7 +95,7 @@ class TestResultLoading:
         with mock.patch("openfecli.commands.gather.load_json", return_value=sim_result):
             result = load_valid_result_json(fpath="")
             captured = capsys.readouterr()
-            assert result is None
+            assert result == (('lig_ejm_31', 'lig_ejm_42', 'vacuum'), None)
             assert "Exception found in all" in captured.err
 
     def test_missing_pr_data(self, capsys, sim_result):
@@ -99,8 +103,8 @@ class TestResultLoading:
         with mock.patch("openfecli.commands.gather.load_json", return_value=sim_result):
             result = load_valid_result_json(fpath="")
             captured = capsys.readouterr()
-            assert result is None
-            assert "No data found" in captured.err
+            assert result == (None, None)
+            assert "Missing ligand names and/or simulation type. Skipping" in captured.err
 
 _EXPECTED_DG = b"""
 ligand	DG(MLE) (kcal/mol)	uncertainty (kcal/mol)


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
This PR is work that should be done in preparation of resolving https://github.com/OpenFreeEnergy/openfe/issues/1211.

The purpose of using the AlchemicalNetwork in the gathering stage is to better report on missing legs. 
The desired end state is for output tables (raw, dg, ddg) to include failed or missing simulations. 

Before we check for missing simulations though, we can add support for passing through failed simulation information such that it is reported in these outputs. 


<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
