### PR TITLE
use pandas

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -21,6 +21,7 @@ dependencies:
   - openmmforcefields
   - openmmtools >=0.24.1
   - packaging
+  - pandas
   - perses>=0.10.3
   - plugcli
   - pint<0.22

--- a/openfecli/commands/gather.py
+++ b/openfecli/commands/gather.py
@@ -604,7 +604,8 @@ def gather(results:List[os.PathLike|str],
     }[report.lower()]
     df = report_func(legs, allow_partial)
     # write output
-    if isinstance(output, os.PathLike):
+    if isinstance(output, click.utils.LazyFile):
+        click.echo(f"writing {report} output to '{output.name}'")
         df.to_csv(output, sep="\t", lineterminator='\n', index=False)
     # TODO: we can use rich to make this output prettier
     else:

--- a/openfecli/commands/gather.py
+++ b/openfecli/commands/gather.py
@@ -304,7 +304,7 @@ def _get_ddgs(legs: dict, allow_partial=False) -> None:
     return DDGs
 
 
-def _write_ddg(legs:dict, writer:Callable, allow_partial:bool) -> None:
+def _generate_ddg(legs:dict, writer:Callable, allow_partial:bool) -> None:
     """Compute and write out DDG values for the given legs.
 
     Parameters
@@ -331,7 +331,7 @@ def _write_ddg(legs:dict, writer:Callable, allow_partial:bool) -> None:
             data.append((ligA, ligB, FAIL_STR, FAIL_STR))
     df = pd.DataFrame(data, columns=["ligand_i", "ligand_j", "DDG(i->j) (kcal/mol)", "uncertainty (kcal/mol)"])
     click.echo(df.to_string(index=False, justify='left', col_space=15))
-def _write_raw(legs:dict, writer:Callable, allow_partial=True) -> None:
+def _generate_raw(legs:dict, writer:Callable, allow_partial=True) -> None:
     """
     Write out all legs found and their DG values, or indicate that they have failed.
 
@@ -359,7 +359,7 @@ def _write_raw(legs:dict, writer:Callable, allow_partial=True) -> None:
     df = pd.DataFrame(data)
     click.echo(df.to_string(index=False, justify='left'))
 
-def _write_dg_mle(legs: dict, writer: Callable, allow_partial: bool) -> None:
+def _generate_dg_mle(legs: dict, writer: Callable, allow_partial: bool) -> None:
     """Compute and write out DG values for the given legs.
 
     Parameters
@@ -602,12 +602,12 @@ def gather(results:List[os.PathLike|str],
         delimiter="\t",
         lineterminator="\n",  # to exactly reproduce previous, prefer "\r\n"
     )
-    writing_func = {
-        'dg': _write_dg_mle,
-        'ddg': _write_ddg,
-        'raw': _write_raw,
+    report_func = {
+        'dg': _generate_dg_mle,
+        'ddg': _generate_ddg,
+        'raw': _generate_raw,
     }[report.lower()]
-    writing_func(legs, writer, allow_partial)
+    report_func(legs, writer, allow_partial)
 
 
 PLUGIN = OFECommandPlugin(

--- a/openfecli/commands/gather.py
+++ b/openfecli/commands/gather.py
@@ -606,10 +606,9 @@ def gather(results:List[os.PathLike|str],
     # write output
     if isinstance(output, click.utils.LazyFile):
         click.echo(f"writing {report} output to '{output.name}'")
-        df.to_csv(output, sep="\t", lineterminator='\n', index=False)
+
     # TODO: we can use rich to make this output prettier
-    else:
-        click.echo(df.to_string(output, index=False, justify='left', col_space=15))
+    df.to_csv(output, sep="\t", lineterminator='\n', index=False)
 
 PLUGIN = OFECommandPlugin(
     command=gather,


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
by using pandas, we can streamline our table writing, and make it easier to adjust formatting in a `--report``-agnostic way.

rdkit already pulls in pandas, so this doesn't add a new dependency.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
