### PR TITLE
print message to stderr when no valid results files are found

### DIFF
--- a/openfecli/commands/gather.py
+++ b/openfecli/commands/gather.py
@@ -508,9 +508,7 @@ def _get_legs_from_result_jsons(
     from collections import defaultdict
 
     legs = defaultdict(lambda: defaultdict(list))
-    if legs == {}:
-        click.secho('No results JSON files found.',err=True)
-        sys.exit(1)
+
     for result_fn in result_fns:
         result_info, result = _load_valid_result_json(result_fn)
 
@@ -532,6 +530,11 @@ def _get_legs_from_result_jsons(
             else:
                 dGs = [v[0]["outputs"]["unit_estimate"] for v in result["protocol_result"]["data"].values()]
             legs[names][simtype].extend(dGs)
+
+    if legs == {}:
+        click.secho('No results JSON files found.',err=True)
+        sys.exit(1)
+
     return legs
 
 @click.command(

--- a/openfecli/commands/gather.py
+++ b/openfecli/commands/gather.py
@@ -531,10 +531,6 @@ def _get_legs_from_result_jsons(
                 dGs = [v[0]["outputs"]["unit_estimate"] for v in result["protocol_result"]["data"].values()]
             legs[names][simtype].extend(dGs)
 
-    if legs == {}:
-        click.secho('No results JSON files found.',err=True)
-        sys.exit(1)
-
     return legs
 
 @click.command(
@@ -601,6 +597,10 @@ def gather(results:List[os.PathLike|str],
     # pair legs of simulations together into dict of dicts
     legs = _get_legs_from_result_jsons(result_fns, report)
 
+    if legs == {}:
+        click.secho('No results JSON files found.',err=True)
+        sys.exit(1)
+
     # compute report
     report_func = {
         'dg': _generate_dg_mle,
@@ -608,6 +608,7 @@ def gather(results:List[os.PathLike|str],
         'raw': _generate_raw,
     }[report.lower()]
     df = report_func(legs, allow_partial)
+
     # write output
     if isinstance(output, click.utils.LazyFile):
         click.echo(f"writing {report} output to '{output.name}'")

--- a/openfecli/commands/gather.py
+++ b/openfecli/commands/gather.py
@@ -508,7 +508,9 @@ def _get_legs_from_result_jsons(
     from collections import defaultdict
 
     legs = defaultdict(lambda: defaultdict(list))
-
+    if legs == {}:
+        click.secho('No results JSON files found.',err=True)
+        sys.exit(1)
     for result_fn in result_fns:
         result_info, result = _load_valid_result_json(result_fn)
 

--- a/openfecli/tests/commands/test_gather.py
+++ b/openfecli/tests/commands/test_gather.py
@@ -116,7 +116,7 @@ class TestResultLoading:
             captured = capsys.readouterr()
             assert result == (None, None)
             assert "Missing ligand names and/or simulation type. Skipping" in captured.err
-    
+
     def test_get_legs_from_result_jsons(self, capsys, sim_result):
         """Test that exceptions are handled correctly at the _get_legs_from_results_json level."""
         sim_result["protocol_result"]["data"] = {}
@@ -126,7 +126,13 @@ class TestResultLoading:
             captured = capsys.readouterr()
             assert result == {}
             assert "Missing ligand names and/or simulation type. Skipping" in captured.err
-    
+
+def test_no_results_found():
+    runner = CliRunner(mix_stderr=False)
+
+    cli_result = runner.invoke(gather, "not_a_file.txt")
+    assert cli_result.exit_code == 1
+    assert "No results JSON files found" in str(cli_result.stderr)
 
 _RBFE_EXPECTED_DG = b"""
 ligand	DG(MLE) (kcal/mol)	uncertainty (kcal/mol)

--- a/openfecli/tests/commands/test_gather.py
+++ b/openfecli/tests/commands/test_gather.py
@@ -275,7 +275,7 @@ class TestGatherCMET:
 
     @pytest.mark.parametrize("allow_partial", [True, False])
     def test_cmet_too_few_edges_error(self, cmet_result_dir, allow_partial):
-        results = [str(cmet_result_dir / f"result_{i}_failed_edge") for i in range(3)]
+        results = [str(cmet_result_dir / f"results_{i}_failed_edge") for i in range(3)]
         args = ["--report", "dg"]
         runner = CliRunner(mix_stderr=False)
         if allow_partial:
@@ -284,7 +284,7 @@ class TestGatherCMET:
         cli_result = runner.invoke(gather, results + args)
         assert cli_result.exit_code == 1
         assert (
-            "The results network has 0 edge(s), but 3 or more edges are required"
+            "The results network has 1 edge(s), but 3 or more edges are required"
             in str(cli_result.stderr)
         )
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
currently, if you pass in an empty dir or mistype the your directory name, ``openfe gather`` will generate an empty table and even silently print it to `-o`.

I find this can be confusing and lead to unexpected behavior, so I'm adding a check up front, so that these scenarios are more transparent.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
