### PR TITLE
pretty print tables with rich

### DIFF
--- a/news/pretty_print.rst
+++ b/news/pretty_print.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Improved formatting of ``openfe gather`` output tables. Use ``--tsv`` to instead view the raw tsv formatted output (this was the default behavior as of v1.3.x)
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/openfecli/commands/gather.py
+++ b/openfecli/commands/gather.py
@@ -624,10 +624,9 @@ def gather(results:List[os.PathLike|str],
     # write output
     if isinstance(output, click.utils.LazyFile):
         click.echo(f"writing {report} output to '{output.name}'")
-        df.to_csv(output, sep="\t", lineterminator='\n', index=False)
+
     # TODO: we can use rich to make this output prettier
-    else:
-        click.echo(df.to_string(output, index=False, justify='left', col_space=15))
+    df.to_csv(output, sep="\t", lineterminator='\n', index=False)
 
 PLUGIN = OFECommandPlugin(
     command=gather,

--- a/openfecli/commands/gather.py
+++ b/openfecli/commands/gather.py
@@ -554,11 +554,12 @@ def rich_print_to_stdout(df: pd.DataFrame) -> None:
     from rich import box
 
     table = Table(box=box.MINIMAL_HEAVY_HEAD)
+
     for col in df.columns:
         table.add_column(col)
 
-    for value_list in df.values.tolist():
-        row = [str(x) for x in value_list]
+    for row_values in df.values:
+        row = [str(val) for val in row_values]
         table.add_row(*row)
 
     console = Console()

--- a/openfecli/commands/gather.py
+++ b/openfecli/commands/gather.py
@@ -393,7 +393,6 @@ def _generate_dg_mle(legs: dict, allow_partial: bool) -> None:
     DDGs = _get_ddgs(legs, allow_partial=allow_partial)
     MLEs = []
     expected_ligs = []
-    data = []
 
     # perform MLE
     g = nx.DiGraph()
@@ -625,9 +624,10 @@ def gather(results:List[os.PathLike|str],
     # write output
     if isinstance(output, click.utils.LazyFile):
         click.echo(f"writing {report} output to '{output.name}'")
-
+        df.to_csv(output, sep="\t", lineterminator='\n', index=False)
     # TODO: we can use rich to make this output prettier
-    df.to_csv(output, sep="\t", lineterminator='\n', index=False)
+    else:
+        click.echo(df.to_string(output, index=False, justify='left', col_space=15))
 
 PLUGIN = OFECommandPlugin(
     command=gather,

--- a/openfecli/commands/gather.py
+++ b/openfecli/commands/gather.py
@@ -553,7 +553,7 @@ def rich_print_to_stdout(df: pd.DataFrame) -> None:
     from rich.table import Table
     from rich import box
 
-    table = Table(box=box.MINIMAL_HEAVY_HEAD)
+    table = Table(box=box.SQUARE)
 
     for col in df.columns:
         table.add_column(col)

--- a/openfecli/commands/gather.py
+++ b/openfecli/commands/gather.py
@@ -545,6 +545,26 @@ def _get_legs_from_result_jsons(
 
     return legs
 
+
+def rich_print_to_stdout(df: pd.DataFrame) -> None:
+    """Use rich to pretty print a table to stdout."""
+
+    from rich.console import Console
+    from rich.table import Table
+    from rich import box
+
+    table = Table(box=box.MINIMAL_HEAVY_HEAD)
+    for col in df.columns:
+        table.add_column(col)
+
+    for value_list in df.values.tolist():
+        row = [str(x) for x in value_list]
+        table.add_row(*row)
+
+    console = Console()
+    console.print(table)
+
+
 @click.command(
     'gather',
     short_help="Gather result jsons for network of RFE results into a TSV file"
@@ -627,19 +647,7 @@ def gather(results:List[os.PathLike|str],
 
     # TODO: we can add a --pretty flag if we want this to be optional/preserve backwards compatibility
     else:
-        from rich.console import Console
-        from rich.table import Table
-        from rich import box
-
-        table = Table(box=box.MINIMAL_HEAVY_HEAD)
-        for col in df.columns:
-            table.add_column(col)
-
-        for index, value_list in enumerate(df.values.tolist()):
-            row = [str(x) for x in value_list]
-            table.add_row(*row)
-        console = Console()
-        console.print(table)
+        rich_print_to_stdout(df)
 
 
 PLUGIN = OFECommandPlugin(

--- a/openfecli/commands/gather.py
+++ b/openfecli/commands/gather.py
@@ -393,6 +393,7 @@ def _generate_dg_mle(legs: dict, allow_partial: bool) -> None:
     DDGs = _get_ddgs(legs, allow_partial=allow_partial)
     MLEs = []
     expected_ligs = []
+    data = []
 
     # perform MLE
     g = nx.DiGraph()

--- a/openfecli/commands/gather.py
+++ b/openfecli/commands/gather.py
@@ -636,14 +636,15 @@ def gather(results:List[os.PathLike|str],
 
     # compute report
     report_func = {
-        "dg": _generate_dg_mle,
-        "ddg": _generate_ddg,
-        "raw": _generate_raw,
+        'dg': _generate_dg_mle,
+        'ddg': _generate_ddg,
+        'raw': _generate_raw,
     }[report.lower()]
     df = report_func(legs, allow_partial)
 
     # write output
     if isinstance(output, click.utils.LazyFile):
+        click.echo(f"writing {report} output to '{output.name}'")
         df.to_csv(output, sep="\t", lineterminator="\n", index=False)
 
     # TODO: we can add a --pretty flag if we want this to be optional/preserve backwards compatibility
@@ -653,7 +654,7 @@ def gather(results:List[os.PathLike|str],
 
 PLUGIN = OFECommandPlugin(
     command=gather,
-    section="Quickrun Executor",
+    section='Quickrun Executor',
     requires_ofe=(0, 6),
 )
 

--- a/openfecli/commands/gather.py
+++ b/openfecli/commands/gather.py
@@ -579,26 +579,37 @@ def rich_print_to_stdout(df: pd.DataFrame) -> None:
     '--report',
     type=HyphenAwareChoice(['dg', 'ddg', 'raw'],
                            case_sensitive=False),
-    default="dg", show_default=True,
+    default="dg",
+    show_default=True,
     help=(
         "What data to report. 'dg' gives maximum-likelihood estimate of "
         "absolute deltaG,  'ddg' gives delta-delta-G, and 'raw' gives "
         "the raw result of the deltaG for a leg."
     )
 )
-@click.option('output', '-o',
-              type=click.File(mode='w'),
-              default='-')
+@click.option("output", "-o", type=click.File(mode="w"), default="-")
 @click.option(
-    '--allow-partial', is_flag=True, default=False,
+    "--tsv",
+    is_flag=True,
+    default=False,
+    help=("Results that are output to stdout will be formatted as tab-separated, "
+          "identical to the formatting used when writing to file."
+          "By default, the output table will be formatted for human-readability."
+    ),
+)
+@click.option(
+    "--allow-partial",
+    is_flag=True,
+    default=False,
     help=(
         "Do not raise errors if results are missing parts for some edges. "
         "(Skip those edges and issue warning instead.)"
-    )
+    ),
 )
 def gather(results:List[os.PathLike|str],
            output:os.PathLike|str,
            report:Literal['dg','ddg','raw'],
+           tsv:bool,
            allow_partial:bool
            ):
     """Gather simulation result JSON files of relative calculations to a tsv file.
@@ -643,7 +654,7 @@ def gather(results:List[os.PathLike|str],
     df = report_func(legs, allow_partial)
 
     # write output
-    if isinstance(output, click.utils.LazyFile):
+    if isinstance(output, click.utils.LazyFile) or tsv:
         click.echo(f"writing {report} output to '{output.name}'")
         df.to_csv(output, sep="\t", lineterminator="\n", index=False)
 

--- a/openfecli/commands/gather.py
+++ b/openfecli/commands/gather.py
@@ -654,8 +654,10 @@ def gather(results:List[os.PathLike|str],
     df = report_func(legs, allow_partial)
 
     # write output
-    if isinstance(output, click.utils.LazyFile) or tsv:
+    is_output_file = isinstance(output, click.utils.LazyFile)
+    if is_output_file:
         click.echo(f"writing {report} output to '{output.name}'")
+    if is_output_file or tsv:
         df.to_csv(output, sep="\t", lineterminator="\n", index=False)
 
     # TODO: we can add a --pretty flag if we want this to be optional/preserve backwards compatibility

--- a/openfecli/tests/commands/test_gather.py
+++ b/openfecli/tests/commands/test_gather.py
@@ -325,6 +325,17 @@ class TestGatherCMET:
         # TODO: figure out how to mock terminal size, since it affects the table wrapping
         # file_regression.check(cli_result.output, extension='.txt')
 
+    def test_write_to_file(self, cmet_result_dir):
+        runner = CliRunner(mix_stderr=False)
+        with runner.isolated_filesystem():
+            results = [str(cmet_result_dir / f'results_{i}') for i in range(3)]
+            fname = "output.tsv"
+            args = ["--report", "raw", "-o", fname]
+            cli_result = runner.invoke(gather, results + args)
+            assert "writing raw output to 'output.tsv'" in cli_result.output
+            assert pathlib.Path(fname).is_file()
+
+
 @pytest.mark.skipif(not os.path.exists(POOCH_CACHE) and not HAS_INTERNET,reason="Internet seems to be unavailable and test data is not cached locally.")
 @pytest.mark.parametrize('dataset', ['rbfe_results_serial_repeats', 'rbfe_results_parallel_repeats'])
 @pytest.mark.parametrize('report', ["", "dg", "ddg", "raw"])

--- a/openfecli/tests/commands/test_gather.py
+++ b/openfecli/tests/commands/test_gather.py
@@ -129,7 +129,6 @@ class TestResultLoading:
 
 def test_no_results_found():
     runner = CliRunner(mix_stderr=False)
-
     cli_result = runner.invoke(gather, "not_a_file.txt")
     assert cli_result.exit_code == 1
     assert "No results JSON files found" in str(cli_result.stderr)
@@ -315,6 +314,16 @@ class TestGatherCMET:
 
         assert_click_success(cli_result)
         file_regression.check(cli_result.output, extension='.tsv')
+
+    @pytest.mark.parametrize('report', ["dg", "ddg", "raw"])
+    def test_pretty_print(self, cmet_result_dir, report, file_regression):
+        results = [str(cmet_result_dir / f'results_{i}') for i in range(3)]
+        args = ["--report", report]
+        runner = CliRunner(mix_stderr=False)
+        cli_result = runner.invoke(gather, results + args)
+        assert_click_success(cli_result)
+        # TODO: figure out how to mock terminal size, since it affects the table wrapping
+        # file_regression.check(cli_result.output, extension='.txt')
 
 @pytest.mark.skipif(not os.path.exists(POOCH_CACHE) and not HAS_INTERNET,reason="Internet seems to be unavailable and test data is not cached locally.")
 @pytest.mark.parametrize('dataset', ['rbfe_results_serial_repeats', 'rbfe_results_parallel_repeats'])

--- a/openfecli/tests/commands/test_gather.py
+++ b/openfecli/tests/commands/test_gather.py
@@ -241,7 +241,7 @@ class TestGatherCMET:
         results = [str(cmet_result_dir / f'results_{i}') for i in range(3)]
         args = ["--report", report]
         runner = CliRunner(mix_stderr=False)
-        cli_result = runner.invoke(gather, results + args + ['-o', '-'])
+        cli_result = runner.invoke(gather, results + args + ['--tsv'])
 
         assert_click_success(cli_result)
         file_regression.check(cli_result.output, extension='.tsv')
@@ -253,7 +253,7 @@ class TestGatherCMET:
         results = [str(cmet_result_dir / d) for d in ['results_0_partial', 'results_1', "results_2"]]
         args = ["--report", report]
         runner = CliRunner(mix_stderr=False)
-        cli_result = runner.invoke(gather, results + args + ['-o', '-'])
+        cli_result = runner.invoke(gather, results + args + ['--tsv'])
 
         assert_click_success(cli_result)
         file_regression.check(cli_result.output, extension='.tsv')
@@ -263,7 +263,7 @@ class TestGatherCMET:
         results = [str(cmet_result_dir / f'results_{i}_remove_edge') for i in range(3)]
         args = ["--report", report]
         runner = CliRunner(mix_stderr=False)
-        cli_result = runner.invoke(gather, results + args + ['-o', '-'])
+        cli_result = runner.invoke(gather, results + args + ['--tsv'])
         file_regression.check(cli_result.output, extension='.tsv')
 
         assert_click_success(cli_result)
@@ -274,7 +274,7 @@ class TestGatherCMET:
         results = [str(cmet_result_dir / f'results_{i}_failed_edge') for i in range(3)]
         args = ["--report", report]
         runner = CliRunner(mix_stderr=False)
-        cli_result = runner.invoke(gather, results + args)
+        cli_result = runner.invoke(gather, results + args + ['--tsv'])
 
         assert_click_success(cli_result)
         file_regression.check(cli_result.output, extension=".tsv")
@@ -287,7 +287,7 @@ class TestGatherCMET:
         if allow_partial:
             args += ['--allow-partial']
 
-        cli_result = runner.invoke(gather, results + args)
+        cli_result = runner.invoke(gather, results + args + ['--tsv'])
         assert cli_result.exit_code == 1
         assert (
             "The results network has 1 edge(s), but 3 or more edges are required"
@@ -311,7 +311,7 @@ class TestGatherCMET:
         results = glob.glob(f"{cmet_result_dir}/results_*/*solvent*", recursive=True)
         args = ["--report", report, "--allow-partial"]
         runner = CliRunner(mix_stderr=False)
-        cli_result = runner.invoke(gather, results + args + ['-o', '-'])
+        cli_result = runner.invoke(gather, results + args + ['--tsv'])
 
         assert_click_success(cli_result)
         file_regression.check(cli_result.output, extension='.tsv')
@@ -342,7 +342,7 @@ def test_rbfe_gather(rbfe_result_dir, dataset, report, input_mode):
         results = glob.glob(f"{results}/*", recursive=True)
         assert len(results) > 1  # sanity check to make sure we're passing in multiple paths
 
-    cli_result = runner.invoke(gather, results + args + ['-o', '-'])
+    cli_result = runner.invoke(gather, results + args + ['--tsv'])
 
     assert_click_success(cli_result)
 
@@ -355,7 +355,7 @@ def test_rbfe_gather_single_repeats_dg_error(rbfe_result_dir):
     runner = CliRunner(mix_stderr=False)
     results = rbfe_result_dir("rbfe_results_parallel_repeats")
     args = ['report','dg']
-    cli_result = runner.invoke(gather, [f"{results}/replicate_0"] + args)
+    cli_result = runner.invoke(gather, [f"{results}/replicate_0"] + args + ['--tsv'])
     assert cli_result.exit_code == 1
 
 @pytest.mark.skipif(not os.path.exists(POOCH_CACHE) and not HAS_INTERNET,reason="Internet seems to be unavailable and test data is not cached locally.")
@@ -388,7 +388,7 @@ class TestRBFEGatherFailedEdges:
         runner = CliRunner(mix_stderr=False)
         with pytest.warns():
             args =  ["--report", "dg", "--allow-partial"]
-            result = runner.invoke(gather, results_paths_serial_missing_legs + args)
+            result = runner.invoke(gather, results_paths_serial_missing_legs + args + ['--tsv'])
             assert result.exit_code == 1
             assert "The results network is disconnected" in str(result.stderr)
 
@@ -398,5 +398,5 @@ class TestRBFEGatherFailedEdges:
         # we *dont* want the suggestion to use --allow-partial if the user already used it!
         with pytest.warns(match='[^using the \-\-allow\-partial]'):
             args =  ["--report", "ddg", "--allow-partial"]
-            result = runner.invoke(gather, results_paths_serial_missing_legs + args)
+            result = runner.invoke(gather, results_paths_serial_missing_legs + args + ['--tsv'])
             assert_click_success(result)

--- a/openfecli/tests/test_rbfe_tutorial.py
+++ b/openfecli/tests/test_rbfe_tutorial.py
@@ -118,7 +118,7 @@ def test_run_tyk2(tyk2_ligands, tyk2_protein, expected_transformations,
             result2 = runner.invoke(quickrun, [fn])
             assert_click_success(result2)
 
-        gather_result = runner.invoke(gather, ["--report", "ddg", '.'])
+        gather_result = runner.invoke(gather, ["--report", "ddg", '.', '--tsv'])
 
         assert_click_success(gather_result)
         assert gather_result.stdout == ref_gather


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
downstream of https://github.com/OpenFreeEnergy/openfe/pull/1244

I'm open to making this a `--pretty` flag if we want to preserve backwards compatibility. This would be a good idea if users regularly use `>> output.csv` instead of `-o output.csv`. This isn't anything we suggest in the docs, so I'm not sure if it's something people actually do.
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [x] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
