### PR TITLE
fixing a test's `--allow-partial` call

### DIFF
--- a/openfecli/tests/commands/test_gather.py
+++ b/openfecli/tests/commands/test_gather.py
@@ -273,13 +273,15 @@ class TestGatherCMET:
         assert_click_success(cli_result)
         file_regression.check(cli_result.output, extension=".tsv")
 
-    @pytest.mark.parametrize("allow_partial", ["--allow-partial", ""])
+    @pytest.mark.parametrize("allow_partial", [True, False])
     def test_cmet_too_few_edges_error(self, cmet_result_dir, allow_partial):
         results = [str(cmet_result_dir / f"result_{i}_failed_edge") for i in range(3)]
-        args = ["--report", "dg", allow_partial]
+        args = ["--report", "dg"]
         runner = CliRunner(mix_stderr=False)
-        cli_result = runner.invoke(gather, results + args)
+        if allow_partial:
+            args += ['--allow-partial']
 
+        cli_result = runner.invoke(gather, results + args)
         assert cli_result.exit_code == 1
         assert (
             "The results network has 0 edge(s), but 3 or more edges are required"


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
A test was breaking because I was passing in `--allow-partial=""`. Not sure why it's only failing now, but I'm fine writing the test in this more accurate way.
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
