### PR TITLE
immediate print planning cli output

### DIFF
--- a/news/cli_responsiveness.rst
+++ b/news/cli_responsiveness.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Improved responsiveness of several CLI commands (`PR #1254 <https://github.com/OpenFreeEnergy/openfe/pull/1254>`_).
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/openfecli/commands/generate_partial_charges.py
+++ b/openfecli/commands/generate_partial_charges.py
@@ -41,7 +41,6 @@ def charge_molecules(
     Generate partial charges for the set of input molecules and write them to file.
     """
     from openfecli.utils import write
-    from openfe.protocols.openmm_utils.charge_generation import bulk_assign_partial_charges
 
     if output.exists():
         raise FileExistsError(f"The output file {output} already exists, choose a new file to write the charged"
@@ -50,6 +49,8 @@ def charge_molecules(
     write("SMALL MOLECULE PARTIAL CHARGE GENERATOR")
     write("_________________________________________")
     write("")
+
+    from openfe.protocols.openmm_utils.charge_generation import bulk_assign_partial_charges
 
     write("Parsing in Files: ")
 

--- a/openfecli/commands/plan_rbfe_network.py
+++ b/openfecli/commands/plan_rbfe_network.py
@@ -180,11 +180,11 @@ def plan_rbfe_network(
     which is detailed in the Options section.
     For more advanced setups, please consider using the Python layer of openfe.
     """
-    from openfecli.plan_alchemical_networks_utils import plan_alchemical_network_output
-
     write("RBFE-NETWORK PLANNER")
     write("______________________")
     write("")
+
+    from openfecli.plan_alchemical_networks_utils import plan_alchemical_network_output
 
     write("Parsing in Files: ")
 

--- a/openfecli/commands/plan_rhfe_network.py
+++ b/openfecli/commands/plan_rhfe_network.py
@@ -145,11 +145,11 @@ def plan_rhfe_network(molecules: List[str], yaml_settings: str, output_dir: str,
     future tools).
     """
 
-    from openfecli.plan_alchemical_networks_utils import plan_alchemical_network_output
-
     write("RHFE-NETWORK PLANNER")
     write("______________________")
     write("")
+
+    from openfecli.plan_alchemical_networks_utils import plan_alchemical_network_output
 
     write("Parsing in Files: ")
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

Imports can take 3-6 seconds, which is around the time that you think something is broken on the CLI. I'm moving our imports to right after the header prints to make it clear that the code is being executed.

Longer term,  I need to see if I can speed up our imports.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [x] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
