### PR TITLE
require -o option for CLI charge generation

### DIFF
--- a/openfecli/commands/generate_partial_charges.py
+++ b/openfecli/commands/generate_partial_charges.py
@@ -18,6 +18,7 @@ from openfecli.parameters import MOL_DIR, YAML_OPTIONS, OUTPUT_FILE_AND_EXT, NCO
 )
 @OUTPUT_FILE_AND_EXT.parameter(
     help="The name of the SDF file the charged ligands should be written to.",
+    required=True,
     type=click.Path(exists=False, path_type=pathlib.Path)
 )
 @NCORES.parameter(

--- a/openfecli/tests/commands/test_charge_generation.py
+++ b/openfecli/tests/commands/test_charge_generation.py
@@ -1,3 +1,4 @@
+from click import ClickException
 import pytest
 from click.testing import CliRunner
 
@@ -30,6 +31,15 @@ def methane_with_charges(methane) -> Molecule:
     methane._partial_charges = [-1.0, 0.25, 0.25, 0.25, 0.25] * unit.elementary_charge
     return methane
 
+def test_missing_output(methane, tmpdir):
+    runner = CliRunner()
+    mol_path = tmpdir / "methane.sdf"
+    methane.to_file(str(mol_path), "sdf")
+
+    cli_result = runner.invoke(charge_molecules,["-M", mol_path,])
+    assert cli_result.exit_code==2
+    assert "Missing option '-o'" in cli_result.output
+    
 
 def test_write_charges_to_input(methane, tmpdir):
     runner = CliRunner()


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Without requiring `-o`, this fails in a confusing way.

Other option is to add a default `_charged` suffix. 


<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
