### PR TITLE
adding rich as a dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -38,6 +38,7 @@ dependencies:
   - pydantic >=1.10.17
   - pyyaml
   - rdkit
+  - rich
   - tqdm
   - typing-extensions
   - zstandard


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Right now `rich` gets pulled in by other dependencies (`openff-nagl-base` and `perses`), but we should require it specifically.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
