### PR TITLE
pin rdkit to <2025.03.1 until support for gufe 1.4

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -37,7 +37,7 @@ dependencies:
   - pytest-rerunfailures
   - pydantic >=1.10.17
   - pyyaml
-  - rdkit
+  - rdkit <2025.03.1  # https://github.com/OpenFreeEnergy/gufe/issues/541#issuecomment-2834569617
   - rich
   - tqdm
   - typing-extensions


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
see https://github.com/OpenFreeEnergy/gufe/issues/541#issuecomment-2834569617

this rdkit pin can be removed when we pin to gufe >=1.4.
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
