### PR TITLE
updating nb name for openfe fetch

### DIFF
--- a/openfecli/fetchables.py
+++ b/openfecli/fetchables.py
@@ -24,7 +24,7 @@ RBFE_TUTORIAL = URLFetcher(
         (_EXAMPLE_NB_BASE + "rbfe_tutorial/", "tyk2_ligands.sdf"),
         (_EXAMPLE_NB_BASE + "rbfe_tutorial/", "tyk2_protein.pdb"),
         (_EXAMPLE_NB_BASE + "rbfe_tutorial/", "cli_tutorial.md"),
-        (_EXAMPLE_NB_BASE + "rbfe_tutorial/", "python_tutorial.ipynb"),
+        (_EXAMPLE_NB_BASE + "rbfe_tutorial/", "rbfe_python_tutorial.ipynb"),
     ],
     short_name="rbfe-tutorial",
     short_help="CLI and Python tutorial on relative binding free energies",


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
I updated notebook names, but forgot to update for fetchables.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
