### PR TITLE
News for AFE box fix

### DIFF
--- a/news/afe_box.rst
+++ b/news/afe_box.rst
@@ -1,0 +1,27 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Absolute free energy calculations (e.g. AbsoluteSolvationProtocol) now
+  correctly pass the equilibrated box vectors to the alchemical simulation.
+  In the past default vectors were used, which in some cases led to random
+  crashes due to an abrupt volume change. We do not believe that this
+  significantly affected free energy results.
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
Add a news entry for the AFE box fix.

Checklist
* [x] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
