### PR TITLE
Include tests in coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,6 @@ ignore_missing_imports = true
 [tool.coverage.run]
 omit = [
     "openfe/due.py",
-    "*/tests/dev/*py",
     "*/tests/protocols/test_openmm_rfe_slow.py"
 ]
 


### PR DESCRIPTION
We should include the tests in our code coverage. This will help us see if any tests we made are not running, check if the skips are working how we expect, and help us check for regressions in changes in testing infrastructure. 
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
