### PR TITLE
Decouple `checkpoint_interval` from `online_analysis_interval`

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,7 @@ dependencies:
   - openff-units==0.2.0
   - openmm >=8.0.0,!=8.1.0,<8.2.0
   - openmmforcefields
-  - openmmtools >=0.24.1
+  - openmmtools >=0.25
   - packaging
   - pandas
   - perses>=0.10.3

--- a/news/checkpoint.rst
+++ b/news/checkpoint.rst
@@ -1,0 +1,27 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* The checkpoint interval default frequency has been increased to every
+  nanosecond. `real_time_analysis_interval` no longer needs to be divisible
+  by the checkpoint interval, allowing users of the HybridTopologyProtocol
+  and AbsoluteSolvationProtocol to write checkpoints less frequently and
+  yielding smaller file sizes.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/openfe/protocols/openmm_utils/omm_settings.py
+++ b/openfe/protocols/openmm_utils/omm_settings.py
@@ -411,9 +411,9 @@ class OutputSettings(SettingsBaseModel):
     Selection string for which part of the system to write coordinates for.
     Default 'not water'.
     """
-    checkpoint_interval: FloatQuantity['picosecond'] = 250.0 * unit.picosecond
+    checkpoint_interval: FloatQuantity['picosecond'] = 1.0 * unit.nanosecond
     """
-    Frequency to write the checkpoint file. Default 1 * unit.picosecond.
+    Frequency to write the checkpoint file. Default 1 * unit.nanosecond.
     """
     checkpoint_storage_filename = 'checkpoint.chk'
     """
@@ -567,8 +567,6 @@ class MultiStateSimulationSettings(SimulationSettings):
 
     If ``None``, no real time analysis will be performed and the yaml
     file will not be written.
-
-    Must be a multiple of ``OutputSettings.checkpoint_interval``
 
     Default `250`.
 


### PR DESCRIPTION
Fixes #1309 

Work done:
 - Clean up docs
 - Increased checkpoint interval frequency to 1 * unit.nanosecond

Checklist
* [x] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
