### PR TITLE
bump openff-units and pint pins

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -16,7 +16,7 @@ dependencies:
   - openff-nagl-base >=0.3.3
   - openff-nagl-models>=0.1.2
   - openff-toolkit>=0.16.2
-  - openff-units==0.2.0
+  - openff-units>=0.3.0
   - openmm >=8.2.0
   - openmmforcefields
   - openmmtools >=0.25.0
@@ -24,7 +24,7 @@ dependencies:
   - pandas
   - perses>=0.10.3
   - plugcli
-  - pint<0.22
+  - pint
   - pip
   - pooch
   - py3dmol

--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,7 @@ dependencies:
   - openff-nagl-base >=0.3.3
   - openff-nagl-models>=0.1.2
   - openff-toolkit>=0.16.2
-  - openff-units>=0.3.0
+  - openff-units==0.3.0
   - openmm >=8.2.0
   - openmmforcefields
   - openmmtools >=0.25.0
@@ -25,7 +25,7 @@ dependencies:
   - pandas
   - perses>=0.10.3
   - plugcli
-  - pint
+  - pint>=0.24.0
   - pip
   - pooch
   - py3dmol

--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,7 @@ dependencies:
   - openff-nagl-base >=0.3.3
   - openff-nagl-models>=0.1.2
   - openff-toolkit>=0.16.2
-  - openff-units==0.3.0
+  - openff-units==0.3.1
   - openmm >=8.2.0
   - openmmforcefields
   - openmmtools >=0.25.0

--- a/openfe/analysis/plotting.py
+++ b/openfe/analysis/plotting.py
@@ -182,30 +182,30 @@ def plot_convergence(
     ax.yaxis.set_ticks_position("left")
 
     # Set the overall error bar to the final error for the reverse results
-    overall_error = forward_and_reverse['reverse_dDGs'][-1].m
-    final_value = forward_and_reverse['reverse_DGs'][-1].m
+    overall_error = forward_and_reverse['reverse_dDGs'][-1].m  # type: ignore
+    final_value = forward_and_reverse['reverse_DGs'][-1].m  # type: ignore
     ax.fill_between([0, 1],
                     final_value - overall_error,
                     final_value + overall_error,
                     color='#D2B9D3', zorder=1)
 
     ax.errorbar(
-        forward_and_reverse['fractions'],
+        forward_and_reverse['fractions'],  # type: ignore
         [val.m
          for val in forward_and_reverse['forward_DGs']],
         yerr=[err.m
-              for err in forward_and_reverse['forward_dDGs']],
+              for err in forward_and_reverse['forward_dDGs']],  # type: ignore
         color="#736AFF", lw=3, zorder=2,
         marker="o", mfc="w", mew=2.5,
         mec="#736AFF", ms=8, label='Forward'
     )
 
     ax.errorbar(
-        forward_and_reverse['fractions'],
+        forward_and_reverse['fractions'],  # type: ignore
         [val.m
-         for val in forward_and_reverse['reverse_DGs']],
+         for val in forward_and_reverse['reverse_DGs']],  # type: ignore
         yerr=[err.m
-              for err in forward_and_reverse['reverse_dDGs']],
+              for err in forward_and_reverse['reverse_dDGs']],  # type: ignore
         color="#C11B17", lw=3, zorder=2,
         marker="o", mfc="w", mew=2.5,
         mec="#C11B17", ms=8, label='Reverse',

--- a/openfe/analysis/plotting.py
+++ b/openfe/analysis/plotting.py
@@ -1,11 +1,10 @@
 # This code is part of OpenFE and is licensed under the MIT license.
 # For details, see https://github.com/OpenFreeEnergy/openfe
-from itertools import chain
 import matplotlib.pyplot as plt
 from matplotlib.axes import Axes
 import numpy as np
 import numpy.typing as npt
-from openff.units import unit, Quantity
+from openff.units import Quantity
 from typing import Optional, Union
 import warnings
 

--- a/openfe/analysis/plotting.py
+++ b/openfe/analysis/plotting.py
@@ -5,7 +5,7 @@ import matplotlib.pyplot as plt
 from matplotlib.axes import Axes
 import numpy as np
 import numpy.typing as npt
-from openff.units import unit
+from openff.units import unit, Quantity
 from typing import Optional, Union
 import warnings
 
@@ -129,8 +129,8 @@ def plot_lambda_transition_matrix(matrix: npt.NDArray) -> Axes:
 
 
 def plot_convergence(
-    forward_and_reverse: dict[str, Union[npt.NDArray, unit.Quantity]],
-    units: unit.Quantity
+    forward_and_reverse: dict[str, Union[npt.NDArray, Quantity]],
+    units: Quantity
 ) -> Axes:
     """
     Plot a Reverse and Forward convergence analysis of the
@@ -142,7 +142,7 @@ def plot_convergence(
       A dictionary containing the reverse and forward
       values of the free energies sampled along a given fraction
       of the sample size.
-    units : unit.Quantity
+    units : openff.units.Quantity
       The units the free energies are provided in.
 
     Returns

--- a/openfe/analysis/plotting.py
+++ b/openfe/analysis/plotting.py
@@ -192,7 +192,7 @@ def plot_convergence(
     ax.errorbar(
         forward_and_reverse['fractions'],  # type: ignore
         [val.m
-         for val in forward_and_reverse['forward_DGs']],
+         for val in forward_and_reverse['forward_DGs']],  # type: ignore
         yerr=[err.m
               for err in forward_and_reverse['forward_dDGs']],  # type: ignore
         color="#736AFF", lw=3, zorder=2,

--- a/openfe/protocols/openmm_afe/equil_solvation_afe_method.py
+++ b/openfe/protocols/openmm_afe/equil_solvation_afe_method.py
@@ -37,7 +37,7 @@ from gufe.components import Component
 import itertools
 import numpy as np
 import numpy.typing as npt
-from openff.units import unit
+from openff.units import unit, Quantity
 from openmmtools import multistate
 from typing import Optional, Union
 from typing import Any, Iterable
@@ -97,13 +97,13 @@ class AbsoluteSolvationProtocolResult(gufe.ProtocolResult):
                in itertools.chain(self.data['solvent'].values(), self.data['vacuum'].values())):
             raise NotImplementedError("Can't stitch together results yet")
 
-    def get_individual_estimates(self) -> dict[str, list[tuple[unit.Quantity, unit.Quantity]]]:
+    def get_individual_estimates(self) -> dict[str, list[tuple[Quantity, Quantity]]]:
         """
         Get the individual estimate of the free energies.
 
         Returns
         -------
-        dGs : dict[str, list[tuple[unit.Quantity, unit.Quantity]]]
+        dGs : dict[str, list[tuple[openff.units.Quantity, openff.units.Quantity]]]
           A dictionary, keyed `solvent` and `vacuum` for each leg
           of the thermodynamic cycle, with lists of tuples containing
           the individual free energy estimates and associated MBAR
@@ -131,7 +131,7 @@ class AbsoluteSolvationProtocolResult(gufe.ProtocolResult):
 
         Returns
         -------
-        dG : unit.Quantity
+        dG : openff.units.Quantity
           The solvation free energy. This is a Quantity defined with units.
         """
         def _get_average(estimates):
@@ -154,7 +154,7 @@ class AbsoluteSolvationProtocolResult(gufe.ProtocolResult):
 
         Returns
         -------
-        err : unit.Quantity
+        err : openff.units.Quantity
           The standard deviation between estimates of the solvation free
           energy. This is a Quantity defined with units.
         """
@@ -174,13 +174,13 @@ class AbsoluteSolvationProtocolResult(gufe.ProtocolResult):
         # return the combined error
         return np.sqrt(vac_err**2 + solv_err**2)
 
-    def get_forward_and_reverse_energy_analysis(self) -> dict[str, list[Optional[dict[str, Union[npt.NDArray, unit.Quantity]]]]]:
+    def get_forward_and_reverse_energy_analysis(self) -> dict[str, list[Optional[dict[str, Union[npt.NDArray, Quantity]]]]]:
         """
         Get the reverse and forward analysis of the free energies.
 
         Returns
         -------
-        forward_reverse : dict[str, list[Optional[dict[str, Union[npt.NDArray, unit.Quantity]]]]]
+        forward_reverse : dict[str, list[Optional[dict[str, Union[npt.NDArray, openff.units.Quantity]]]]]
             A dictionary, keyed `solvent` and `vacuum` for each leg of the
             thermodynamic cycle which each contain a list of dictionaries
             containing the forward and reverse analysis of each repeat
@@ -189,9 +189,9 @@ class AbsoluteSolvationProtocolResult(gufe.ProtocolResult):
             The forward and reverse analysis dictionaries contain:
               - `fractions`: npt.NDArray
                   The fractions of data used for the estimates
-              - `forward_DGs`, `reverse_DGs`: unit.Quantity
+              - `forward_DGs`, `reverse_DGs`: openff.units.Quantity
                   The forward and reverse estimates for each fraction of data
-              - `forward_dDGs`, `reverse_dDGs`: unit.Quantity
+              - `forward_dDGs`, `reverse_dDGs`: openff.units.Quantity
                   The forward and reverse estimate uncertainty for each
                   fraction of data.
 
@@ -207,7 +207,7 @@ class AbsoluteSolvationProtocolResult(gufe.ProtocolResult):
             given thermodynamic cycle leg.
         """
 
-        forward_reverse: dict[str, list[Optional[dict[str, Union[npt.NDArray, unit.Quantity]]]]] = {}
+        forward_reverse: dict[str, list[Optional[dict[str, Union[npt.NDArray, Quantity]]]]] = {}
 
         for key in ['solvent', 'vacuum']:
             forward_reverse[key] = [

--- a/openfe/protocols/openmm_md/plain_md_methods.py
+++ b/openfe/protocols/openmm_md/plain_md_methods.py
@@ -15,7 +15,7 @@ import logging
 from collections import defaultdict
 import gufe
 import openmm
-from openff.units import unit
+from openff.units import unit, Quantity
 from openff.units.openmm import from_openmm, to_openmm
 import openmm.unit as omm_unit
 from typing import Optional
@@ -272,9 +272,9 @@ class PlainMDProtocolUnit(gufe.ProtocolUnit):
                 positions: omm_unit.Quantity,
                 simulation_settings: MDSimulationSettings,
                 output_settings: MDOutputSettings,
-                temperature: unit.Quantity,
-                barostat_frequency: unit.Quantity,
-                timestep: unit.Quantity,
+                temperature: Quantity,
+                barostat_frequency: Quantity,
+                timestep: Quantity,
                 equil_steps_nvt: Optional[int],
                 equil_steps_npt: int,
                 prod_steps: int,
@@ -297,7 +297,7 @@ class PlainMDProtocolUnit(gufe.ProtocolUnit):
           Settings for output of MD simulation
         temperature: FloatQuantity["kelvin"]
           temperature setting
-        barostat_frequency: unit.Quantity
+        barostat_frequency: openff.units.Quantity
           Frequency for the barostat
         timestep: FloatQuantity["femtosecond"]
           Simulation integration timestep

--- a/openfe/protocols/openmm_rfe/_rfe_utils/topologyhelpers.py
+++ b/openfe/protocols/openmm_rfe/_rfe_utils/topologyhelpers.py
@@ -16,7 +16,7 @@ import numpy as np
 import numpy.typing as npt
 from openmm import app, System, NonbondedForce
 from openmm import unit as omm_unit
-from openff.units import unit
+from openff.units import unit, Quantity
 from openfe import SolventComponent
 
 
@@ -223,7 +223,7 @@ def get_alchemical_waters(
     topology: app.Topology,
     positions: npt.NDArray,
     charge_difference: int,
-    distance_cutoff: unit.Quantity = 0.8 * unit.nanometer,
+    distance_cutoff: Quantity = 0.8 * unit.nanometer,
 ) -> list[int]:
     """
     Pick a list of waters to be used for alchemical charge correction.
@@ -237,7 +237,7 @@ def get_alchemical_waters(
     charge_difference : int
       The charge difference between the two end states
       calculated as stateA_formal_charge - stateB_formal_charge.
-    distance_cutoff : unit.Quantity
+    distance_cutoff : openff.units.Quantity
       The minimum distance away from the solutes from which an alchemical
       water can be chosen.
 

--- a/openfe/protocols/openmm_rfe/equil_rfe_methods.py
+++ b/openfe/protocols/openmm_rfe/equil_rfe_methods.py
@@ -258,7 +258,7 @@ class RelativeHybridTopologyProtocolResult(gufe.ProtocolResult):
 
     @staticmethod
     def compute_mean_estimate(dGs:list[Quantity]) -> Quantity:
-        u = dGs[0].u 
+        u = dGs[0].u
         # convert all values to units of the first value, then take average of magnitude
         # this would avoid a screwy case where each value was in different units
         vals = np.asarray([dG.to(u).m for dG in dGs])

--- a/openfe/protocols/openmm_rfe/equil_rfe_methods.py
+++ b/openfe/protocols/openmm_rfe/equil_rfe_methods.py
@@ -257,13 +257,13 @@ class RelativeHybridTopologyProtocolResult(gufe.ProtocolResult):
             raise NotImplementedError("Can't stitch together results yet")
 
     @staticmethod
-    def compute_mean_estimate(dGs:list[Quantity]):
-        u = dGs[0].u  # type: ignore
+    def compute_mean_estimate(dGs:list[Quantity]) -> Quantity:
+        u = dGs[0].u 
         # convert all values to units of the first value, then take average of magnitude
         # this would avoid a screwy case where each value was in different units
-        vals = [dG.to(u).m for dG in dGs]
+        vals = np.asarray([dG.to(u).m for dG in dGs])
 
-        return np.average(vals) * u  # type: ignore
+        return np.average(vals) * u
 
     def get_estimate(self) -> Quantity:
         """Average free energy difference of this transformation
@@ -279,13 +279,13 @@ class RelativeHybridTopologyProtocolResult(gufe.ProtocolResult):
         return self.compute_mean_estimate(dGs)
 
     @staticmethod
-    def compute_uncertainty(dGs:list[Quantity]):
-        u = dGs[0].u  # type: ignore
+    def compute_uncertainty(dGs:list[Quantity]) -> Quantity:
+        u = dGs[0].u
         # convert all values to units of the first value, then take average of magnitude
         # this would avoid a screwy case where each value was in different units
-        vals = [dG.to(u).m for dG in dGs]
+        vals = np.asarray([dG.to(u).m for dG in dGs])
 
-        return np.std(vals) * u  # type: ignore
+        return np.std(vals) * u
 
     def get_uncertainty(self) -> Quantity:
         """The uncertainty/error in the dG value: The std of the estimates of

--- a/openfe/protocols/openmm_rfe/equil_rfe_methods.py
+++ b/openfe/protocols/openmm_rfe/equil_rfe_methods.py
@@ -263,7 +263,7 @@ class RelativeHybridTopologyProtocolResult(gufe.ProtocolResult):
         # this would avoid a screwy case where each value was in different units
         vals = [dG.to(u).m for dG in dGs]
 
-        return np.average(vals) * u
+        return np.average(vals) * u  # type: ignore
 
     def get_estimate(self) -> Quantity:
         """Average free energy difference of this transformation
@@ -285,7 +285,7 @@ class RelativeHybridTopologyProtocolResult(gufe.ProtocolResult):
         # this would avoid a screwy case where each value was in different units
         vals = [dG.to(u).m for dG in dGs]
 
-        return np.std(vals) * u
+        return np.std(vals) * u  # type: ignore
 
     def get_uncertainty(self) -> Quantity:
         """The uncertainty/error in the dG value: The std of the estimates of

--- a/openfe/protocols/openmm_rfe/equil_rfe_methods.py
+++ b/openfe/protocols/openmm_rfe/equil_rfe_methods.py
@@ -258,7 +258,7 @@ class RelativeHybridTopologyProtocolResult(gufe.ProtocolResult):
 
     @staticmethod
     def compute_mean_estimate(dGs:list[Quantity]):
-        u = dGs[0].u
+        u = dGs[0].u  # type: ignore
         # convert all values to units of the first value, then take average of magnitude
         # this would avoid a screwy case where each value was in different units
         vals = [dG.to(u).m for dG in dGs]
@@ -280,7 +280,7 @@ class RelativeHybridTopologyProtocolResult(gufe.ProtocolResult):
 
     @staticmethod
     def compute_uncertainty(dGs:list[Quantity]):
-        u = dGs[0].u
+        u = dGs[0].u  # type: ignore
         # convert all values to units of the first value, then take average of magnitude
         # this would avoid a screwy case where each value was in different units
         vals = [dG.to(u).m for dG in dGs]

--- a/openfe/protocols/openmm_rfe/equil_rfe_methods.py
+++ b/openfe/protocols/openmm_rfe/equil_rfe_methods.py
@@ -31,7 +31,7 @@ from itertools import chain
 import matplotlib.pyplot as plt
 import numpy as np
 import numpy.typing as npt
-from openff.units import unit
+from openff.units import unit, Quantity
 from openff.units.openmm import to_openmm, from_openmm, ensure_quantity
 from openff.toolkit.topology import Molecule as OFFMolecule
 from openmmtools import multistate
@@ -257,7 +257,7 @@ class RelativeHybridTopologyProtocolResult(gufe.ProtocolResult):
             raise NotImplementedError("Can't stitch together results yet")
 
     @staticmethod
-    def compute_mean_estimate(dGs:list[unit.Quantity]):
+    def compute_mean_estimate(dGs:list[Quantity]):
         u = dGs[0].u
         # convert all values to units of the first value, then take average of magnitude
         # this would avoid a screwy case where each value was in different units
@@ -265,12 +265,12 @@ class RelativeHybridTopologyProtocolResult(gufe.ProtocolResult):
 
         return np.average(vals) * u
 
-    def get_estimate(self) -> unit.Quantity:
+    def get_estimate(self) -> Quantity:
         """Average free energy difference of this transformation
 
         Returns
         -------
-        dG : unit.Quantity
+        dG : openff.units.Quantity
           The free energy difference between the first and last states. This is
           a Quantity defined with units.
         """
@@ -279,7 +279,7 @@ class RelativeHybridTopologyProtocolResult(gufe.ProtocolResult):
         return self.compute_mean_estimate(dGs)
 
     @staticmethod
-    def compute_uncertainty(dGs:list[unit.Quantity]):
+    def compute_uncertainty(dGs:list[Quantity]):
         u = dGs[0].u
         # convert all values to units of the first value, then take average of magnitude
         # this would avoid a screwy case where each value was in different units
@@ -287,7 +287,7 @@ class RelativeHybridTopologyProtocolResult(gufe.ProtocolResult):
 
         return np.std(vals) * u
 
-    def get_uncertainty(self) -> unit.Quantity:
+    def get_uncertainty(self) -> Quantity:
         """The uncertainty/error in the dG value: The std of the estimates of
         each independent repeat
         """
@@ -296,13 +296,13 @@ class RelativeHybridTopologyProtocolResult(gufe.ProtocolResult):
         return self.compute_uncertainty(dGs)
 
 
-    def get_individual_estimates(self) -> list[tuple[unit.Quantity, unit.Quantity]]:
+    def get_individual_estimates(self) -> list[tuple[Quantity, Quantity]]:
         """Return a list of tuples containing the individual free energy
         estimates and associated MBAR errors for each repeat.
 
         Returns
         -------
-        dGs : list[tuple[unit.Quantity]]
+        dGs : list[tuple[openff.units.Quantity]]
           n_replicate simulation list of tuples containing the free energy
           estimates (first entry) and associated MBAR estimate errors
           (second entry).
@@ -312,7 +312,7 @@ class RelativeHybridTopologyProtocolResult(gufe.ProtocolResult):
                for pus in self.data.values()]
         return dGs
 
-    def get_forward_and_reverse_energy_analysis(self) -> list[Optional[dict[str, Union[npt.NDArray, unit.Quantity]]]]:
+    def get_forward_and_reverse_energy_analysis(self) -> list[Optional[dict[str, Union[npt.NDArray, Quantity]]]]:
         """
         Get a list of forward and reverse analysis of the free energies
         for each repeat using uncorrelated production samples.
@@ -333,7 +333,7 @@ class RelativeHybridTopologyProtocolResult(gufe.ProtocolResult):
 
         Returns
         -------
-        forward_reverse : list[Optional[dict[str, Union[npt.NDArray, unit.Quantity]]]]
+        forward_reverse : list[Optional[dict[str, Union[npt.NDArray, openff.units.Quantity]]]]
 
 
         Raises

--- a/openfe/protocols/openmm_utils/multistate_analysis.py
+++ b/openfe/protocols/openmm_utils/multistate_analysis.py
@@ -364,10 +364,10 @@ class MultistateEquilFEAnalysis:
 
         forward_reverse = {
             'fractions': np.array(fractions),
-            'forward_DGs': Quantity.from_list(forward_DGs),
-            'forward_dDGs': Quantity.from_list(forward_dDGs),
-            'reverse_DGs': Quantity.from_list(reverse_DGs),
-            'reverse_dDGs': Quantity.from_list(reverse_dDGs)
+            'forward_DGs': Quantity.from_list(forward_DGs),  # type: ignore
+            'forward_dDGs': Quantity.from_list(forward_dDGs),  # type: ignore
+            'reverse_DGs': Quantity.from_list(reverse_DGs),  # type: ignore
+            'reverse_dDGs': Quantity.from_list(reverse_dDGs)  # type: ignore
         }
         return forward_reverse
 

--- a/openfe/protocols/openmm_utils/multistate_analysis.py
+++ b/openfe/protocols/openmm_utils/multistate_analysis.py
@@ -9,7 +9,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 import numpy.typing as npt
 from openmmtools import multistate
-from openff.units import unit, ensure_quantity, Quantity
+from openff.units import unit, Quantity
+from openff.units.openmm import from_openmm
 from pymbar import MBAR
 from pymbar.utils import ParameterError
 from openfe.analysis import plotting
@@ -251,8 +252,8 @@ class MultistateEquilFEAnalysis:
         DG = DF_ij[0, -1] * analyzer.kT
         dDG = dDF_ij[0, -1] * analyzer.kT
 
-        return (ensure_quantity(DG, 'openff').to(return_units),
-                ensure_quantity(dDG, 'openff').to(return_units))
+        return (from_openmm(DG).to(return_units),
+                from_openmm(dDG, 'openff').to(return_units))
 
     def get_equil_free_energy(self) -> tuple[Quantity, Quantity]:
         """

--- a/openfe/protocols/openmm_utils/multistate_analysis.py
+++ b/openfe/protocols/openmm_utils/multistate_analysis.py
@@ -253,7 +253,7 @@ class MultistateEquilFEAnalysis:
         dDG = dDF_ij[0, -1] * analyzer.kT
 
         return (from_openmm(DG).to(return_units),
-                from_openmm(dDG, 'openff').to(return_units))
+                from_openmm(dDG).to(return_units))
 
     def get_equil_free_energy(self) -> tuple[Quantity, Quantity]:
         """

--- a/openfe/protocols/openmm_utils/multistate_analysis.py
+++ b/openfe/protocols/openmm_utils/multistate_analysis.py
@@ -9,7 +9,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import numpy.typing as npt
 from openmmtools import multistate
-from openff.units import unit, ensure_quantity
+from openff.units import unit, ensure_quantity, Quantity
 from pymbar import MBAR
 from pymbar.utils import ParameterError
 from openfe.analysis import plotting
@@ -66,14 +66,14 @@ class MultistateEquilFEAnalysis:
     sampling_method : str
       The sampling method. Expected values are `repex`, `sams`,
       and `independent`.
-    result_units : unit.Quantity
+    result_units : openff.units.Quantity
       Units to report results in.
     forward_reverse_samples : int
       The number of samples to use in the forward and reverse analysis
       of the free energies. Default 10.
     """
     def __init__(self, reporter: multistate.MultiStateReporter,
-                 sampling_method: str, result_units: unit.Quantity,
+                 sampling_method: str, result_units: Quantity,
                  forward_reverse_samples: int = 10):
         self.analyzer = multistate.MultiStateSamplerAnalyzer(reporter)
         self.units = result_units
@@ -192,8 +192,8 @@ class MultistateEquilFEAnalysis:
         u_ln: npt.NDArray,
         N_l: npt.NDArray,
         bootstraps: int = 1000,
-        return_units: unit.Quantity = unit.kilocalorie_per_mole,
-    ) -> tuple[unit.Quantity, unit.Quantity]:
+        return_units: Quantity = unit.kilocalorie_per_mole,
+    ) -> tuple[Quantity, Quantity]:
         """
         Helper method to create an MBAR object and extract free energies
         between end states.
@@ -211,14 +211,14 @@ class MultistateEquilFEAnalysis:
         bootstraps : int
           How many bootstrap samples will be computed. If 0, no bootstraps
           will be computed and analytical errors will be returned.
-        return_units : unit.Quantity
+        return_units : openff.units.Quantity
           The return units the results will be provided in.
 
         Returns
         -------
-        DG : unit.Quantity
+        DG : openff.units.Quantity
           The free energy difference between the end states.
-        dDG : unit.Quantity
+        dDG : openff.units.Quantity
           The MBAR bootstrap (1000 iterations) error estimate for the free energy difference.
 
         TODO
@@ -254,16 +254,16 @@ class MultistateEquilFEAnalysis:
         return (ensure_quantity(DG, 'openff').to(return_units),
                 ensure_quantity(dDG, 'openff').to(return_units))
 
-    def get_equil_free_energy(self) -> tuple[unit.Quantity, unit.Quantity]:
+    def get_equil_free_energy(self) -> tuple[Quantity, Quantity]:
         """
         Extract unbiased and uncorrelated estimates of the free energy
         and the associated error from a MultiStateSamplerAnalyzer object.
 
         Returns
         -------
-        DG : unit.Quantity
+        DG : openff.units.Quantity
           The free energy difference between the end states.
-        dDG : unit.Quantity
+        dDG : openff.units.Quantity
           The MBAR error for the free energy difference estimate.
         """
         u_ln_decorr = self.analyzer._unbiased_decorrelated_u_ln
@@ -281,7 +281,7 @@ class MultistateEquilFEAnalysis:
 
     def get_forward_and_reverse_analysis(
         self, num_samples: int = 10
-    ) -> Optional[dict[str, Union[npt.NDArray, unit.Quantity]]]:
+    ) -> Optional[dict[str, Union[npt.NDArray, Quantity]]]:
         """
         Calculate free energies with a progressively larger
         fraction of the decorrelated timeseries data in both
@@ -294,7 +294,7 @@ class MultistateEquilFEAnalysis:
 
         Returns
         -------
-        forward_reverse : Optional[dict[str, Union[npt.NDArray, unit.Quantity]]]
+        forward_reverse : Optional[dict[str, Union[npt.NDArray, openff.units.Quantity]]]
           If this analysis fails, returns None; otherwise returns a dictionary
           containing;
             * ``fractions``: fractions of sample used to calculate free energies
@@ -363,10 +363,10 @@ class MultistateEquilFEAnalysis:
 
         forward_reverse = {
             'fractions': np.array(fractions),
-            'forward_DGs': unit.Quantity.from_list(forward_DGs),
-            'forward_dDGs': unit.Quantity.from_list(forward_dDGs),
-            'reverse_DGs': unit.Quantity.from_list(reverse_DGs),
-            'reverse_dDGs': unit.Quantity.from_list(reverse_dDGs)
+            'forward_DGs': Quantity.from_list(forward_DGs),
+            'forward_dDGs': Quantity.from_list(forward_dDGs),
+            'reverse_DGs': Quantity.from_list(reverse_DGs),
+            'reverse_dDGs': Quantity.from_list(reverse_dDGs)
         }
         return forward_reverse
 

--- a/openfe/protocols/openmm_utils/settings_validation.py
+++ b/openfe/protocols/openmm_utils/settings_validation.py
@@ -89,8 +89,8 @@ def get_simsteps(sim_length: Quantity,
       The number of simulation timesteps.
     """
 
-    sim_time = round(sim_length.to('attosecond').m)
-    ts = round(timestep.to('attosecond').m)
+    sim_time = round(sim_length.to('attosecond').m)  # type: ignore
+    ts = round(timestep.to('attosecond').m)  # type: ignore
 
     sim_steps, mod = divmod(sim_time, ts)
     if mod != 0:
@@ -126,8 +126,8 @@ def divmod_time(
     remainder : int
       The remainder of the input time and time_per_iteration division.
     """
-    time_ats = round(time.to(unit.attosecond).m)
-    tpi_ats = round(time_per_iteration.to(unit.attosecond).m)
+    time_ats = round(time.to(unit.attosecond).m)  # type: ignore
+    tpi_ats = round(time_per_iteration.to(unit.attosecond).m)  # type: ignore
 
     iterations, remainder = divmod(time_ats, tpi_ats)
 

--- a/openfe/protocols/openmm_utils/settings_validation.py
+++ b/openfe/protocols/openmm_utils/settings_validation.py
@@ -4,7 +4,7 @@
 Reusable utility methods to validate input settings to OpenMM-based alchemical
 Protocols.
 """
-from openff.units import unit
+from openff.units import unit, Quantity
 from typing import Optional
 from .omm_settings import (
     IntegratorSettings,
@@ -44,7 +44,7 @@ def validate_openmm_solvation_settings(
             raise ValueError(errmsg)
 
 
-def validate_timestep(hmass: float, timestep: unit.Quantity):
+def validate_timestep(hmass: float, timestep: Quantity):
     """
     Check that the input timestep is suitable for the given hydrogen
     mass.
@@ -53,7 +53,7 @@ def validate_timestep(hmass: float, timestep: unit.Quantity):
     ----------
     hmass : float
       The target hydrogen mass (assumed units of amu).
-    timestep : unit.Quantity
+    timestep : openff.units.Quantity
       The integration time step.
 
 
@@ -69,16 +69,16 @@ def validate_timestep(hmass: float, timestep: unit.Quantity):
             raise ValueError(errmsg)
 
 
-def get_simsteps(sim_length: unit.Quantity,
-                 timestep: unit.Quantity, mc_steps: int) -> int:
+def get_simsteps(sim_length: Quantity,
+                 timestep: Quantity, mc_steps: int) -> int:
     """
     Gets and validates the number of simulation steps.
 
     Parameters
     ----------
-    sim_length : unit.Quantity
+    sim_length : openff.units.Quantity
       Simulation length.
-    timestep : unit.Quantity
+    timestep : openff.units.Quantity
       Integration timestep.
     mc_steps : int
       Number of integration timesteps between MCMC moves.
@@ -106,17 +106,17 @@ def get_simsteps(sim_length: unit.Quantity,
 
 
 def divmod_time(
-    time: unit.Quantity,
-    time_per_iteration: unit.Quantity,
+    time: Quantity,
+    time_per_iteration: Quantity,
 ) -> tuple[int, int]:
     """
     Convert a set amount of time to a number of iterations.
 
     Parameters
     ---------
-    time: unit.Quantity
+    time: openff.units.Quantity
       The time to convert.
-    time_per_iteration : unit.Quantity
+    time_per_iteration : openff.units.Quantity
       The amount of time which each iteration takes.
 
     Returns
@@ -134,7 +134,7 @@ def divmod_time(
     return iterations, remainder
 
 
-def divmod_time_and_check(numerator: unit.Quantity, denominator: unit.Quantity,
+def divmod_time_and_check(numerator: Quantity, denominator: Quantity,
                           numerator_name: str, denominator_name: str) -> int:
     """Perform a division of time, failing if there is a remainder
 
@@ -142,7 +142,7 @@ def divmod_time_and_check(numerator: unit.Quantity, denominator: unit.Quantity,
 
     Parameters
     ----------
-    numerator, denominator : unit.Quantity
+    numerator, denominator : openff.units.Quantity
       the division to perform
     numerator_name, denominator_name : str
       used for the error generated if there is any remainder
@@ -170,8 +170,8 @@ def divmod_time_and_check(numerator: unit.Quantity, denominator: unit.Quantity,
 
 
 def convert_checkpoint_interval_to_iterations(
-    checkpoint_interval: unit.Quantity,
-    time_per_iteration: unit.Quantity,
+    checkpoint_interval: Quantity,
+    time_per_iteration: Quantity,
 ) -> int:
     """
     Get the number of iterations per checkpoint interval.
@@ -182,9 +182,9 @@ def convert_checkpoint_interval_to_iterations(
 
     Parameters
     ----------
-    checkpoint_interval : unit.Quantity
+    checkpoint_interval : openff.units.Quantity
       The amount of time per checkpoints written.
-    time_per_iteration : unit.Quantity
+    time_per_iteration : openff.units.Quantity
       The amount of time each MC iteration takes.
 
     Returns
@@ -280,9 +280,9 @@ def convert_target_error_from_kcal_per_mole_to_kT(
 
     Parameters
     ----------
-    temperature : unit.Quantity
+    temperature : openff.units.Quantity
       temperature in K
-    target_error : unit.Quantity
+    target_error : openff.units.Quantity
       error in kcal/mol
 
     Returns

--- a/openfe/setup/atom_mapping/perses_mapper.py
+++ b/openfe/setup/atom_mapping/perses_mapper.py
@@ -8,7 +8,7 @@ The MCS class from Perses shamelessly wrapped and used here to match our API.
 
 from openfe.utils import requires_package
 from gufe.vendor.openff.models.types import FloatQuantity
-from openff.units import unit
+from openff.units import unit, Quantity
 from openff.units.openmm import to_openmm
 
 from ...utils.silence_root_logging import silence_root_logging
@@ -56,7 +56,7 @@ class PersesAtomMapper(LigandAtomMapper):
     def __init__(self, allow_ring_breaking: bool = True,
                  preserve_chirality: bool = True,
                  use_positions: bool = True,
-                 coordinate_tolerance: unit.Quantity = 0.25 * unit.angstrom):
+                 coordinate_tolerance: Quantity = 0.25 * unit.angstrom):
         """
         Suggest atom mappings with the Perses atom mapper.
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
I _think_ we were pinned to `openff-units==0.2.0` and `pint<0.22` because we were waiting on this: https://github.com/OpenFreeEnergy/gufe/pull/533.

Trying an unpin now to see where we're at.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
