### PR TITLE
update docs to show default as element_change=True

### DIFF
--- a/openfecli/commands/plan_rbfe_network.py
+++ b/openfecli/commands/plan_rbfe_network.py
@@ -168,7 +168,7 @@ def plan_rbfe_network(
     By default, this tool makes the following choices:
 
     * Atom mappings performed by LOMAP, with settings max3d=1.0 and
-      element_change=False
+      element_change=True
     * Minimal spanning network as the network planner, with LOMAP default
       score as the weight function
     * Water as solvent, with NaCl counter ions at 0.15 M concentration.

--- a/openfecli/commands/plan_rbfe_network.py
+++ b/openfecli/commands/plan_rbfe_network.py
@@ -167,7 +167,7 @@ def plan_rbfe_network(
 
     By default, this tool makes the following choices:
 
-    * Atom mappings performed by LOMAP, with settings max3d=1.0 and
+    * Atom mappings performed by LOMAP, with settings max3d=1.0, threed=True, shift=False and
       element_change=True
     * Minimal spanning network as the network planner, with LOMAP default
       score as the weight function


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
The default is `element_change=True`, but the docs were not accurate.
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
