### PR TITLE
remove openmm exclusion from docs

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -6,7 +6,6 @@ Installation
 We try to follow `SPEC0 <https://scientific-python.org/specs/spec-0000/>`_ as far as minimum supported dependencies, with the following caveats:
 
 - Python 3.10, 3.11, 3.12 - **we do not yet support Python 3.13**
-- OpenMM 8.0, 8.1.1, 8.1.2 - **we do not yet support OpenMM v8.2.0**
 
 When you install ``openfe`` through any of the methods described below, you
 will install both the core library and the command line interface (CLI).

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -6,6 +6,7 @@ Installation
 We try to follow `SPEC0 <https://scientific-python.org/specs/spec-0000/>`_ as far as minimum supported dependencies, with the following caveats:
 
 - Python 3.10, 3.11, 3.12 - **we do not yet support Python 3.13**
+- OpenMM 8.0, 8.1.1, 8.1.2, 8.2.0 - **we do not yet support OpenMM v8.3.0**
 
 When you install ``openfe`` through any of the methods described below, you
 will install both the core library and the command line interface (CLI).


### PR DESCRIPTION
resolves https://github.com/OpenFreeEnergy/openfe/issues/1406

@mikemhenry opinion on rereleasing 1.5.0 so that this shows up on `stable`?  