### PR TITLE
Add slow markers on >60s restraint tests

### DIFF
--- a/openfe/tests/protocols/restraints/test_geometry_boresch.py
+++ b/openfe/tests/protocols/restraints/test_geometry_boresch.py
@@ -178,6 +178,7 @@ def test_boresch_no_host_anchor(eg5_protein_ligand_universe, eg5_ligands):
         )
 
 
+@pytest.mark.slow
 def test_get_boresch_restraint_single_frame(eg5_protein_ligand_universe, eg5_ligands):
     """
     Make sure we can find a boresh restraint using a single frame

--- a/openfe/tests/protocols/restraints/test_geometry_boresch_host.py
+++ b/openfe/tests/protocols/restraints/test_geometry_boresch_host.py
@@ -142,6 +142,7 @@ def test_evaluate_host2_good(eg5_protein_ligand_universe):
     )
 
 
+@pytest.mark.slow
 def test_find_host_anchor_none(eg5_protein_ligand_universe):
 
     host_anchor = find_host_anchor(


### PR DESCRIPTION


## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
