### PR TITLE
use isolated folder for conda cron ci

### DIFF
--- a/.github/workflows/conda_cron.yaml
+++ b/.github/workflows/conda_cron.yaml
@@ -30,9 +30,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          path: openfe_repo
 
       - name: Get Latest Version
         id: latest-version
+        working_directory: openfe_repo
         run: |
           LATEST_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
           # slice off the v, ie v0.7.2 -> 0.7.2


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
resolves https://github.com/OpenFreeEnergy/openfe/issues/1445

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
