### PR TITLE
Always use atoms in both helices and beta sheets in the DSSP filter

### DIFF
--- a/openfe/protocols/restraint_utils/geometry/utils.py
+++ b/openfe/protocols/restraint_utils/geometry/utils.py
@@ -705,11 +705,8 @@ def stable_secondary_structure_selection(
                 num_residues = len(group) - (2 * trim_structure_ends)
                 structure_residue_counts[group[0][0]] += num_residues
 
-    # If we have fewer alpha-helix residues than beta-sheet residues
-    # then we allow picking from beta-sheets too.
-    allowed_structures = ["H"]
-    if structure_residue_counts["H"] < structure_residue_counts["E"]:
-        allowed_structures.append("E")
+    # Pick atoms in both helices and beta sheets
+    allowed_structures = ["H", "E"]
 
     allowed_residxs = []
     for structure in structures:

--- a/openfe/tests/protocols/restraints/test_geometry_boresch.py
+++ b/openfe/tests/protocols/restraints/test_geometry_boresch.py
@@ -232,14 +232,14 @@ def test_get_boresch_restraint_dssp(eg5_protein_ligand_universe, eg5_ligands):
     # we should get the same guest atoms
     assert restraint_geometry.guest_atoms == [5528, 5507, 5508]
     # different host atoms
-    assert restraint_geometry.host_atoms == [3058, 1895, 1933]
+    assert restraint_geometry.host_atoms == [3517, 3058, 3548]
     # check the measured values
-    assert 1.09084815 == pytest.approx(restraint_geometry.r_aA0.to("nanometer").m)
-    assert 0.93824134 == pytest.approx(restraint_geometry.theta_A0.to("radians").m)
-    assert 1.58227158 == pytest.approx(restraint_geometry.theta_B0.to("radians").m)
-    assert 2.09875582 == pytest.approx(restraint_geometry.phi_A0.to("radians").m)
-    assert -0.142658924 == pytest.approx(restraint_geometry.phi_B0.to("radians").m)
-    assert -1.5340895 == pytest.approx(restraint_geometry.phi_C0.to("radians").m)
+    assert 1.01590371 == pytest.approx(restraint_geometry.r_aA0.to("nanometer").m)
+    assert 0.84966606 == pytest.approx(restraint_geometry.theta_A0.to("radians").m)
+    assert 1.23561539 == pytest.approx(restraint_geometry.theta_B0.to("radians").m)
+    assert 2.56825286 == pytest.approx(restraint_geometry.phi_A0.to("radians").m)
+    assert -1.60162692 == pytest.approx(restraint_geometry.phi_B0.to("radians").m)
+    assert -0.02396901 == pytest.approx(restraint_geometry.phi_C0.to("radians").m)
 
 
 POOCH_CACHE = pooch.os_cache("openfe")


### PR DESCRIPTION
Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
