### PR TITLE
don't run CI for rtd changes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,7 @@ on:
    # See here for more details: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-excluding-paths
     paths-ignore:
       - "docs/*"
+      - ".readthedocs.yaml"
   push:
     branches:
       - main

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,11 +9,11 @@ sphinx:
    configuration: docs/conf.py
    fail_on_warning: true
 
-conda:
-  environment: docs/environment.yaml
+# conda:
+#   environment: docs/environment.yaml
 
-python:
-  # Install our python package before building the docs
-  install:
-    - method: pip
-      path: .
+# python:
+#   # Install our python package before building the docs
+#   install:
+#     - method: pip
+#       path: .

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,11 +9,11 @@ sphinx:
    configuration: docs/conf.py
    fail_on_warning: true
 
-# conda:
-#   environment: docs/environment.yaml
+conda:
+  environment: docs/environment.yaml
 
-# python:
-#   # Install our python package before building the docs
-#   install:
-#     - method: pip
-#       path: .
+python:
+  # Install our python package before building the docs
+  install:
+    - method: pip
+      path: .


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
I'm doing some debugging of the RTD build and the CI is running since `.readthedocs.yml` isn't in `docs/`

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
