### PR TITLE
add cuda pin to conda lock generation

### DIFF
--- a/.github/workflows/gen-lock-file.yaml
+++ b/.github/workflows/gen-lock-file.yaml
@@ -48,6 +48,7 @@ jobs:
         dependencies:
           - openfe==${{ steps.latest-version.outputs.VERSION }}
           - python=3.12
+          - cuda<12.9
         EOF
 
     - name: Generate lock files


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
