### PR TITLE
update partial charge tests now that a production NAGL model is available

### DIFF
--- a/openfe/protocols/openmm_utils/charge_generation.py
+++ b/openfe/protocols/openmm_utils/charge_generation.py
@@ -142,12 +142,11 @@ def assign_offmol_nagl_charges(
         prod_models = get_models_by_type(
             model_type='am1bcc', production_only=True
         )
-        # Currently there are no production models so expect an IndexError
         try:
             nagl_model = prod_models[-1]
         except IndexError:
-            errmsg = ("No production am1bcc NAGL models are current available "
-                      "please manually select a candidate release model")
+            errmsg = ("No production am1bcc NAGL models were found, "
+                      "please manually select a candidate release model.")
             raise ValueError(errmsg)
 
     model_path = validate_nagl_model_path(nagl_model)

--- a/openfe/tests/protocols/test_openmmutils.py
+++ b/openfe/tests/protocols/test_openmmutils.py
@@ -793,15 +793,28 @@ class TestOFFPartialCharge:
         # but the charges should have
         assert not np.allclose(charges, lig.partial_charges)
 
-    @pytest.mark.skipif(not HAS_NAGL, reason='NAGL is not available')
-    def test_no_production_nagl(self, uncharged_mol):
+    @pytest.mark.skipif(not HAS_NAGL, reason="NAGL is not available")
+    def test_latest_production_nagl(self, uncharged_mol):
+        """We expect to find a NAGL model and be able to generate partial charges with it."""
+        charge_generation.assign_offmol_partial_charges(
+            uncharged_mol,
+            overwrite=False,
+            method="nagl",
+            toolkit_backend="rdkit",
+            generate_n_conformers=None,
+            nagl_model=None,
+        )
+        assert uncharged_mol.partial_charges.units == "elementary_charge"
 
-        with pytest.raises(ValueError, match='No production am1bcc NAGL'):
+    @pytest.mark.skipif(not HAS_NAGL, reason="NAGL is not available")
+    def test_no_production_nagl(self, uncharged_mol):
+        """Cleanly handle the case where a NAGL model isn't found."""
+        with mock.patch("openff.nagl_models.get_models_by_type", return_value=None):
             charge_generation.assign_offmol_partial_charges(
                 uncharged_mol,
                 overwrite=False,
-                method='nagl',
-                toolkit_backend='rdkit',
+                method="nagl",
+                toolkit_backend="rdkit",
                 generate_n_conformers=None,
                 nagl_model=None,
             )


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
I'm assuming we still want to have a helpful error message in case a production NAGL model isn't found - or we can omit that check if we trust that an upstream openff error message will make sense to an openfe user.
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
