### PR TITLE
temporary pin to pre-pydantic v2 gufe commit

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -51,4 +51,4 @@ dependencies:
   # Control blas/openmp threads
   - threadpoolctl
   - pip:
-    - git+https://github.com/OpenFreeEnergy/gufe@main
+    - git+https://github.com/OpenFreeEnergy/gufe@0e4d69a137c750136b3b2473bf6da9a34c28cb60


### PR DESCRIPTION
keep CI green until https://github.com/OpenFreeEnergy/openfe/pull/1431 is merged.

Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
