### PR TITLE
Removing unnecessary limit on resids

### DIFF
--- a/news/no-resids-limit-from-topology.rst
+++ b/news/no-resids-limit-from-topology.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Remove unnecessary limit on residues ids (``resids``) when getting mappings from topology in ``topology_helpers.py`` utility module.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/openfe/protocols/openmm_rfe/_rfe_utils/topologyhelpers.py
+++ b/openfe/protocols/openmm_rfe/_rfe_utils/topologyhelpers.py
@@ -390,10 +390,6 @@ def _get_indices(topology, resids):
     residue_name : str
         Name of the residue to get the indices for.
     """
-    # TODO: remove, this shouldn't be necessary anymore
-    if len(resids) > 1:
-        raise ValueError("multiple residues were found")
-
     # create list of openmm residues
     top_res = [r for r in topology.residues() if r.index in resids]
 

--- a/openfe/protocols/openmm_rfe/_rfe_utils/topologyhelpers.py
+++ b/openfe/protocols/openmm_rfe/_rfe_utils/topologyhelpers.py
@@ -387,8 +387,9 @@ def _get_indices(topology, resids):
     ----------
     topology : openmm.app.Topology
         Topology to search from.
-    residue_name : str
-        Name of the residue to get the indices for.
+    resids : npt.NDArrayLike
+        An array of residue indices which match the residues we want to get
+        atom indices for.
     """
     # create list of openmm residues
     top_res = [r for r in topology.residues() if r.index in resids]


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

This change would allow not having an unnecessary limit on the `resids` when getting mappings from a topology. This is needed for current implementation of the protein mutation protocol.

Checklist
* [x] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
