### PR TITLE
minimum pin for jupyter_client to fix deprecation warnings

### DIFF
--- a/devtools/installer/construct.yaml
+++ b/devtools/installer/construct.yaml
@@ -14,11 +14,12 @@ specs:
   - conda
   - jupyterlab
   - mamba
-  - notebook <7
+  - notebook <7  # TODO from https://github.com/OpenFreeEnergy/openfe/pull/498, is this still needed?
   - openfe=={{ environ["VERSION"] }}
   - pip
   - pytest
   - pytest-xdist
+  - jupyter_client >8.4.0
   # python needs to match https://github.com/googlecolab/backend-info/blob/main/os-info.txt
   # until colab pushes a fix
   - python 3.12.11


### PR DESCRIPTION
draft mode because it's TBD whether this will fix it.

---

currently seeing `jupyter_client/session.py:203: DeprecationWarning: datetime.datetime.utcnow()` in our demo notebook(s).

I’m seeing this deprecation warning because, although `jupyter_client` addressed the deprecation in v8.4.0 in 2023, our env in colab is using `jupyter_client v7.4.9`.

 I tried adding an ignore but it seems flaky, and I think it's our requirements pulling it in in the single file installer.

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
