### PR TITLE
Fix test to check if we are printing `--allow-partial` when a user uses `--allow-partial`

### DIFF
--- a/openfecli/tests/commands/test_gather.py
+++ b/openfecli/tests/commands/test_gather.py
@@ -413,10 +413,10 @@ class TestRBFEGatherFailedEdges:
             assert "The results network is disconnected" in str(result.stderr)
 
 
-    def test_missing_leg_allow_partial_(self, results_paths_serial_missing_legs: str):
-        runner = CliRunner()
+    def test_allow_partial_msg_not_printed(self, results_paths_serial_missing_legs: str):
         # we *dont* want the suggestion to use --allow-partial if the user already used it!
-        with pytest.warns(match=r'[^using the \-\-allow\-partial]'):
-            args =  ["--report", "ddg", "--allow-partial"]
-            result = runner.invoke(gather, results_paths_serial_missing_legs + args + ['--tsv'])
-            assert_click_success(result)
+        runner = CliRunner()
+        args =  ["--report", "ddg", "--allow-partial"]
+        result = runner.invoke(gather, results_paths_serial_missing_legs + args + ['--tsv'])
+        assert_click_success(result)
+        assert "--allow-partial" not in result.output


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
