### PR TITLE
run CI workflows for feat/ branches

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,7 @@ on:
   push:
     branches:
       - main
+      - 'feat/**'
   schedule:
     - cron: "0 4 * * *"
   workflow_dispatch:

--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -3,9 +3,11 @@ on:
   pull_request:
     branches:
       - main
+      - 'feat/**'
   push:
     branches:
       - main
+      - 'feat/**'
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"


### PR DESCRIPTION
In conversation with @ethanholz, we discussed running CI for branches that start with `feat/`, so that we can use CI for feature branches that might have many smaller PRs going into them.

Also, I'm proposing that we don't auto-run CI for PRs in draft-mode to save the rainforest.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
