### PR TITLE
rename gufe.settings.types -> gufe.settings.typing

### DIFF
--- a/openfe/protocols/openmm_md/plain_md_methods.py
+++ b/openfe/protocols/openmm_md/plain_md_methods.py
@@ -31,7 +31,7 @@ from gufe import (
     ChemicalSystem,
     SmallMoleculeComponent,
 )
-from gufe.settings.types import KelvinQuantity
+from gufe.settings.typing import KelvinQuantity
 from openfe.protocols.openmm_utils.omm_settings import (
     BasePartialChargeSettings,
     FemtosecondQuantity

--- a/openfe/protocols/openmm_rfe/equil_rfe_settings.py
+++ b/openfe/protocols/openmm_rfe/equil_rfe_settings.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from typing import Literal
 from openff.units import unit
 
-from gufe.settings.types import NanometerQuantity
+from gufe.settings.typing import NanometerQuantity
 from gufe.settings import (
     Settings,
     SettingsBaseModel,

--- a/openfe/protocols/openmm_septop/equil_septop_settings.py
+++ b/openfe/protocols/openmm_septop/equil_septop_settings.py
@@ -29,7 +29,7 @@ from openfe.protocols.openmm_utils.omm_settings import (
     OpenMMSolvationSettings,
 )
 from openfe.protocols.restraint_utils.settings import BaseRestraintSettings
-from gufe.settings.types import PicosecondQuantity
+from gufe.settings.typing import PicosecondQuantity
 
 from openff.units import unit as offunit
 from pydantic import field_validator

--- a/openfe/protocols/openmm_utils/omm_settings.py
+++ b/openfe/protocols/openmm_utils/omm_settings.py
@@ -18,7 +18,7 @@ from gufe.settings import (
     ThermoSettings as ThermoSettings,
 )
 
-from gufe.settings.types import (
+from gufe.settings.typing import (
     NanometerQuantity,
     NanometerArrayQuantity,
     PicosecondQuantity,

--- a/openfe/protocols/restraint_utils/geometry/boresch/geometry.py
+++ b/openfe/protocols/restraint_utils/geometry/boresch/geometry.py
@@ -10,7 +10,7 @@ TODO
 from typing import Annotated, Literal, Optional, TypeAlias
 
 import MDAnalysis as mda
-from gufe.settings.types import NanometerQuantity, GufeQuantity, specify_quantity_units
+from gufe.settings.typing import NanometerQuantity, GufeQuantity, specify_quantity_units
 from MDAnalysis.lib.distances import calc_angles, calc_bonds, calc_dihedrals
 from openfe.protocols.restraint_utils.geometry.base import HostGuestRestraintGeometry
 from openff.units import Quantity, unit

--- a/openfe/protocols/restraint_utils/geometry/flatbottom.py
+++ b/openfe/protocols/restraint_utils/geometry/flatbottom.py
@@ -11,7 +11,7 @@ from typing import Optional
 
 import MDAnalysis as mda
 import numpy as np
-from gufe.settings.types import NanometerQuantity
+from gufe.settings.typing import NanometerQuantity
 from MDAnalysis.analysis.base import AnalysisBase
 from MDAnalysis.lib.distances import calc_bonds
 from openff.units import Quantity, unit

--- a/openfe/protocols/restraint_utils/settings.py
+++ b/openfe/protocols/restraint_utils/settings.py
@@ -11,7 +11,7 @@ TODO
 from typing import Annotated, Literal, Optional, TypeAlias
 
 from gufe.settings import SettingsBaseModel
-from gufe.settings.types import NanometerQuantity, GufeQuantity, specify_quantity_units
+from gufe.settings.typing import NanometerQuantity, GufeQuantity, specify_quantity_units
 from openff.units import unit
 from pydantic import ConfigDict, field_validator
 

--- a/openfe/setup/atom_mapping/perses_mapper.py
+++ b/openfe/setup/atom_mapping/perses_mapper.py
@@ -7,7 +7,7 @@ The MCS class from Perses shamelessly wrapped and used here to match our API.
 """
 
 from openfe.utils import requires_package
-from gufe.settings.types import AngstromQuantity
+from gufe.settings.typing import AngstromQuantity
 from openff.units import unit, Quantity
 from openff.units.openmm import to_openmm
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
because of rename in gufe.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [x] ~Added a ``news`` entry~ not needed

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
