### PR TITLE
Remove duplicate `available_platforms` fixture from septop slow tests

### DIFF
--- a/openfe/tests/protocols/openmm_septop/test_septop_slow.py
+++ b/openfe/tests/protocols/openmm_septop/test_septop_slow.py
@@ -216,13 +216,6 @@ def test_lambda_energies(
                 assert_allclose(from_openmm(value), from_openmm(energy_13[key]))
 
 
-@pytest.fixture
-def available_platforms() -> set[str]:
-    return {
-        openmm.Platform.getPlatform(i).getName() for i in range(openmm.Platform.getNumPlatforms())
-    }
-
-
 @pytest.mark.integration
 @pytest.mark.flaky(reruns=3)  # pytest-rerunfailures; we can get bad minimisation
 @pytest.mark.parametrize("platform", ["CUDA"])


### PR DESCRIPTION
Removed the 'available_platforms' fixture from the test.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
