### PR TITLE
Fix inline comment in slow septop test

### DIFF
--- a/openfe/tests/protocols/openmm_septop/test_septop_slow.py
+++ b/openfe/tests/protocols/openmm_septop/test_septop_slow.py
@@ -290,8 +290,7 @@ def test_openmm_run_engine(
         }
     )
 
-    # Create DAG from protocol, get the vacuum and solvent units
-    # and eventually dry run the first solvent unit
+    # Create DAG from protocol
     dag = protocol.create(
         stateA=stateA,
         stateB=stateB,


### PR DESCRIPTION
Tiny one I didn't see during review.

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
