### PR TITLE
add git-blame-ignore-revs for large formatting PRs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -9,3 +9,4 @@ d7196d119e2f65d88e488afc665f2521e4f68042
 
 # https://github.com/OpenFreeEnergy/openfe/pull/1623 - ruff formatting part 4
 036869ae81670c6dcfa2532f125ee88c3f35936c
+


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

~Leaving this as draft, we can tack on the other formatting PRs that are in progress, then merge.~

 ruff formatting is complete, ready for this to be merged! 🎉 

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
