### PR TITLE
pin openmm to <8.3

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ dependencies:
   - cinnabar ~=0.5.0
   - click >=8.2.0
   - coverage
-  - dask>=2025  # for debugging
+  - dask>=2025  # temporary fix for https://github.com/openforcefield/openff-units/issues/140
   - duecredit<0.10
   - kartograf>=1.2.0
   - konnektor~=0.2.0


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
pinning the development environment.yaml until we verify that https://github.com/openmm/openmm/pull/5069 is fixed.

because this is GPU-related, I see the tests fail locally but it doesn't affect our PR CPU tests.
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
