### PR TITLE
Fix import error from pr# 1640

### DIFF
--- a/openfe/tests/setup/atom_mapping/test_perses_scorers.py
+++ b/openfe/tests/setup/atom_mapping/test_perses_scorers.py
@@ -12,7 +12,6 @@ from openfe.setup import perses_scorers
 from ....utils.silence_root_logging import silence_root_logging
 
 
-
 USING_OLD_OFF = False
 
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

There was one mistake in #1640, this PR fixes that mistake.
We need to wait to import things from perses directly until after we check we have the package available.  

Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
