### PR TITLE
add workflow_dispatch event trigger for cleaning up cache by branch

### DIFF
--- a/.github/workflows/clean_cache.yaml
+++ b/.github/workflows/clean_cache.yaml
@@ -1,6 +1,7 @@
 # from https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#force-deleting-cache-entries
 name: cleanup caches by a branch
 on:
+  workflow_dispatch:
   pull_request:
     types:
       - closed


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
I'd like to have this for when we know we need to clear a cache to address test failures on a specific PR.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] Added a ``news`` entry

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
