### PR TITLE
gather: unify code structure between rbfe, septop, & abfe

### DIFF
--- a/openfecli/commands/gather_abfe.py
+++ b/openfecli/commands/gather_abfe.py
@@ -154,7 +154,7 @@ def _generate_dg(results_dict: dict[str, dict[str, list]], allow_partial: bool) 
     Parameters
     ----------
     results_dict : dict[str, dict[str, list]]
-        Dictionary of results created by ``extract_results_dict``.
+        Dictionary of results created by ``_get_legs_from_result_jsons``.
 
     Returns
     -------
@@ -189,7 +189,7 @@ def _generate_dg_raw(results_dict: dict[str, dict[str, list]], allow_partial: bo
     Parameters
     ----------
     results_dict : dict[str, dict[str, list]]
-        Dictionary of results created by ``extract_results_dict``.
+        Dictionary of results created by ``_get_legs_from_result_jsons``.
 
     Returns
     -------

--- a/openfecli/commands/gather_septop.py
+++ b/openfecli/commands/gather_septop.py
@@ -162,30 +162,6 @@ def _error_mbar(r):
     return np.sqrt(np.mean(complex_errors) ** 2 + np.mean(solvent_errors) ** 2)
 
 
-def extract_results_dict(
-    results_files: list[os.PathLike | str],
-) -> dict[str, dict[str, list]]:
-    """
-    Get a dictionary of SepTop results from a list of directories.
-
-    Parameters
-    ----------
-    results_files : list[ps.PathLike | str]
-        A list of directors with SepTop result files to process.
-
-    Returns
-    -------
-    sim_results : dict[str, dict[str, list]]
-        Simulation results, organized by the leg's ligand names and simulation type.
-    """
-    # find and filter result jsons
-    result_fns = _collect_result_jsons(results_files)
-    # pair legs of simulations together into dict of dicts
-    sim_results = _get_legs_from_result_jsons(result_fns)
-
-    return sim_results
-
-
 def _get_ddgs(
     results_dict: dict[str, dict[str, list]], allow_partial: bool = False
 ) -> pd.DataFrame:
@@ -194,7 +170,7 @@ def _get_ddgs(
     Parameters
     ----------
     results_dict : dict[str, dict[str, list]]
-        Dictionary of results created by ``extract_results_dict``.
+        Dictionary of results created by ``_get_legs_from_result_jsons``.
 
     Returns
     -------
@@ -239,7 +215,7 @@ def _generate_dg_mle(
     Parameters
     ----------
     results_dict : dict[str, dict[str, list]]
-        Dictionary of results created by ``extract_results_dict``.
+        Dictionary of results created by ``_get_legs_from_result_jsons``.
 
     Returns
     -------
@@ -284,7 +260,7 @@ def _generate_raw(
     Parameters
     ----------
     results_dict : dict[str, dict[str, list]]
-        Dictionary of results created by ``extract_results_dict``.
+        Dictionary of results created by ``_get_legs_from_result_jsons``.
 
     Returns
     -------


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
downstream of https://github.com/OpenFreeEnergy/openfe/pull/1697

this unifies behavior as much as possible without doing a big refactor yet.
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [x] All new code is appropriately documented (user-facing code _must_ have complete docstrings).
* [x] Added a ``news`` entry, or the changes are not user-facing.
* [x] Ran pre-commit by making a comment with `pre-commit.ci autofix` before requesting review.

Manual Tests: these are slow so don't need to be run every commit, only before merging and when relevant changes are made (generally at reviewer-discretion). 
* [ ] [GPU integration tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/gpu-integration-tests.yaml)
* [ ] [example notebook testing](https://github.com/OpenFreeEnergy/openfe/actions/workflows/test-example-notebooks.yaml)
* [ ] [packaging tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/test-feedstock-pkg-build.yaml): run this for any large feature PRs or PRs that add test data.


## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
