### PR TITLE
fix pandas applymap deprecation warning

### DIFF
--- a/openfecli/commands/gather.py
+++ b/openfecli/commands/gather.py
@@ -153,7 +153,7 @@ def format_df_with_precision(
     """
 
     # find all entries in both columns that contain strings:
-    df_is_string = df[[est_col_name, unc_col_name]].applymap(lambda x: isinstance(x, str))
+    df_is_string = df[[est_col_name, unc_col_name]].map(lambda x: isinstance(x, str))
 
     # if either the estimate or uncertainty entries are strings, dont format
     no_strings_mask = ~(df_is_string[est_col_name] | df_is_string[unc_col_name])


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [x] All new code is appropriately documented (user-facing code _must_ have complete docstrings).
* [x] Added a ``news`` entry, or the changes are not user-facing.
* [x] Ran pre-commit by making a comment with `pre-commit.ci autofix` before requesting review.

Manual Tests: these are slow so don't need to be run every commit, only before merging and when relevant changes are made (generally at reviewer-discretion). 
* [ ] [GPU integration tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/gpu-integration-tests.yaml)
* [ ] [example notebook testing](https://github.com/OpenFreeEnergy/openfe/actions/workflows/test-example-notebooks.yaml)
* [ ] [packaging tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/test-feedstock-pkg-build.yaml): run this for any large feature PRs or PRs that add test data.


## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
