### PR TITLE
docs: handle common case where ExampleNotebooks already exists and is on a tag

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,9 +16,9 @@ from importlib.metadata import version
 from inspect import cleandoc
 from pathlib import Path
 
+import git
 import nbformat
 import nbsphinx
-from git import Repo
 from packaging.version import parse
 
 sys.path.insert(0, os.path.abspath("../"))
@@ -181,10 +181,14 @@ sass_out_dir = "_static/css"
 example_notebooks_path = Path("ExampleNotebooks")
 try:
     if example_notebooks_path.exists():
-        repo = Repo(example_notebooks_path)
-        repo.remote("origin").pull()
+        repo = git.Repo(example_notebooks_path)
+        try:
+            repo.remote("origin").pull()
+        except git.exc.GitCommandError:
+            # cannot pull if on a tag
+            pass
     else:
-        repo = Repo.clone_from(
+        repo = git.Repo.clone_from(
             "https://github.com/OpenFreeEnergy/ExampleNotebooks.git",
             branch="2025.10.2",
             to_path=example_notebooks_path,


### PR DESCRIPTION
root cause of these failures: https://github.com/OpenFreeEnergy/ExampleNotebooks/actions/workflows/openfe-doc-build.yaml

now that we clone from a specific release, this is more common and causes docs builds to fail with that warning.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] All new code is appropriately documented (user-facing code _must_ have complete docstrings).
* [ ] Added a ``news`` entry, or the changes are not user-facing.
* [ ] Ran pre-commit by making a comment with `pre-commit.ci autofix` before requesting review.

Manual Tests: these are slow so don't need to be run every commit, only before merging and when relevant changes are made (generally at reviewer-discretion). 
* [ ] [GPU integration tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/gpu-integration-tests.yaml)
* [ ] [example notebook testing](https://github.com/OpenFreeEnergy/openfe/actions/workflows/test-example-notebooks.yaml)
* [ ] [packaging tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/test-feedstock-pkg-build.yaml): run this for any large feature PRs or PRs that add test data.


## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
