### PR TITLE
switch pymbar warning to info and only raise if already set

### DIFF
--- a/openfe/__init__.py
+++ b/openfe/__init__.py
@@ -8,9 +8,9 @@ import os
 
 logger = logging.getLogger(__name__)
 
-if "PYMBAR_DISABLE_JAX" not in os.environ:
-    logger.warn(
-        "PYMBAR_DISABLE_JAX not set, setting to TRUE, see https://docs.openfree.energy/en/latest/guide/troubleshooting.html#pymbar-disable-jax for more details"
+if "PYMBAR_DISABLE_JAX" in os.environ:
+    logger.info(
+        f"PYMBAR_DISABLE_JAX set to {os.environ.get('PYMBAR_DISABLE_JAX')}. See https://docs.openfree.energy/en/latest/guide/troubleshooting.html#pymbar-disable-jax for more details"
     )
 
 # setdefault will only set PYMBAR_DISABLE_JAX if it is unset


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
@mikemhenry was right, it's too noisy! We don't want a warning raised just by calling `import openfe` in standard usage.

We should just have an INFO if `PYMBAR_DISABLE_JAX` is *already* set.

Open to @mikemhenry's edits on making this clearer.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] All new code is appropriately documented (user-facing code _must_ have complete docstrings).
* [ ] Added a ``news`` entry, or the changes are not user-facing.
* [ ] Ran pre-commit by making a comment with `pre-commit.ci autofix` before requesting review.

Manual Tests: these are slow so don't need to be run every commit, only before merging and when relevant changes are made (generally at reviewer-discretion). 
* [ ] [GPU integration tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/gpu-integration-tests.yaml)
* [ ] [example notebook testing](https://github.com/OpenFreeEnergy/openfe/actions/workflows/test-example-notebooks.yaml)
* [ ] [packaging tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/test-feedstock-pkg-build.yaml): run this for any large feature PRs or PRs that add test data.


## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
