### PR TITLE
expose KartografAtomMapper alongside other AtomMappers

### DIFF
--- a/docs/reference/api/atom_mappers.rst
+++ b/docs/reference/api/atom_mappers.rst
@@ -21,6 +21,7 @@ Tools for mapping atoms in one molecule to those in another. Used to generate ef
     :nosignatures:
     :toctree: generated/
 
+    KartografAtomMapper
     LomapAtomMapper
     PersesAtomMapper
 

--- a/openfe/__init__.py
+++ b/openfe/__init__.py
@@ -71,6 +71,7 @@ from gufe.protocols import (
 
 from . import analysis, orchestration, setup, utils
 from .setup import (
+    KartografAtomMapper,
     LigandAtomMapper,
     LigandNetwork,
     LomapAtomMapper,


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
raised by @hannahbaumann.

fixes:
`KartografAtomMapper` is not currently shown in our docs, and it's also not available at the top level of `openfe`, only under `openfe.setup`.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] All new code is appropriately documented (user-facing code _must_ have complete docstrings).
* [ ] Added a ``news`` entry, or the changes are not user-facing.
* [ ] Ran pre-commit by making a comment with `pre-commit.ci autofix` before requesting review.

Manual Tests: these are slow so don't need to be run every commit, only before merging and when relevant changes are made (generally at reviewer-discretion). 
* [ ] [GPU integration tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/gpu-integration-tests.yaml)
* [ ] [example notebook testing](https://github.com/OpenFreeEnergy/openfe/actions/workflows/test-example-notebooks.yaml)
* [ ] [packaging tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/test-feedstock-pkg-build.yaml): run this for any large feature PRs or PRs that add test data.


## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
