### PR TITLE
Breakdown rfe protocolunit

### DIFF
--- a/openfe/protocols/openmm_rfe/hybridtop_units.py
+++ b/openfe/protocols/openmm_rfe/hybridtop_units.py
@@ -491,7 +491,7 @@ class RelativeHybridTopologyProtocolUnit(gufe.ProtocolUnit):
         ----------
         stateA : ChemicalSystem
           ChemicalSystem defining end state A.
-        stateB : ChmiecalSysstem
+        stateB : ChemicalSystem
           ChemicalSystem defining end state B.
         mapping : LigandAtomMapping
           The mapping for alchemical components between state A and B.


### PR DESCRIPTION
Blocked by #1769 

This PR breaks the hybrid topology protocol into a series of method calls to make life easier.

Checklist
* [x] All new code is appropriately documented (user-facing code _must_ have complete docstrings).
* [N/A] Added a ``news`` entry, or the changes are not user-facing.
* [x] Ran pre-commit by making a comment with `pre-commit.ci autofix` before requesting review.

Manual Tests: these are slow so don't need to be run every commit, only before merging and when relevant changes are made (generally at reviewer-discretion). 
* [ ] [GPU integration tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/gpu-integration-tests.yaml)
* [ ] [example notebook testing](https://github.com/OpenFreeEnergy/openfe/actions/workflows/test-example-notebooks.yaml)
* [ ] [packaging tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/test-feedstock-pkg-build.yaml): run this for any large feature PRs or PRs that add test data.


## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
