### PR TITLE
turn off zenodo retry

### DIFF
--- a/openfe/tests/protocols/restraints/test_geometry_boresch.py
+++ b/openfe/tests/protocols/restraints/test_geometry_boresch.py
@@ -242,7 +242,7 @@ zenodo_restraint_data = pooch.create(
     registry={
         "industry_benchmark_systems.zip": "sha256:2bb5eee36e29b718b96bf6e9350e0b9957a592f6c289f77330cbb6f4311a07bd"
     },
-    retry_if_failed=5,
+    retry_if_failed=0,
 )
 
 

--- a/openfe/tests/protocols/restraints/test_geometry_boresch.py
+++ b/openfe/tests/protocols/restraints/test_geometry_boresch.py
@@ -242,7 +242,6 @@ zenodo_restraint_data = pooch.create(
     registry={
         "industry_benchmark_systems.zip": "sha256:2bb5eee36e29b718b96bf6e9350e0b9957a592f6c289f77330cbb6f4311a07bd"
     },
-    retry_if_failed=0,
 )
 
 

--- a/openfe/tests/protocols/restraints/test_geometry_boresch_host.py
+++ b/openfe/tests/protocols/restraints/test_geometry_boresch_host.py
@@ -34,7 +34,7 @@ zenodo_restraint_data = pooch.create(
     registry={
         "t4_lysozyme_trajectory.zip": "sha256:e985d055db25b5468491e169948f641833a5fbb67a23dbb0a00b57fb7c0e59c8"
     },
-    retry_if_failed=5,
+    retry_if_failed=0,
 )
 
 

--- a/openfe/tests/protocols/restraints/test_geometry_boresch_host.py
+++ b/openfe/tests/protocols/restraints/test_geometry_boresch_host.py
@@ -34,7 +34,6 @@ zenodo_restraint_data = pooch.create(
     registry={
         "t4_lysozyme_trajectory.zip": "sha256:e985d055db25b5468491e169948f641833a5fbb67a23dbb0a00b57fb7c0e59c8"
     },
-    retry_if_failed=0,
 )
 
 

--- a/openfe/tests/protocols/restraints/test_geometry_utils.py
+++ b/openfe/tests/protocols/restraints/test_geometry_utils.py
@@ -56,7 +56,6 @@ zenodo_restraint_data = pooch.create(
     registry={
         "t4_lysozyme_trajectory.zip": "sha256:e985d055db25b5468491e169948f641833a5fbb67a23dbb0a00b57fb7c0e59c8"
     },
-    retry_if_failed=0,
 )
 
 

--- a/openfe/tests/protocols/restraints/test_geometry_utils.py
+++ b/openfe/tests/protocols/restraints/test_geometry_utils.py
@@ -56,7 +56,7 @@ zenodo_restraint_data = pooch.create(
     registry={
         "t4_lysozyme_trajectory.zip": "sha256:e985d055db25b5468491e169948f641833a5fbb67a23dbb0a00b57fb7c0e59c8"
     },
-    retry_if_failed=5,
+    retry_if_failed=0,
 )
 
 

--- a/openfe/tests/protocols/restraints/test_omm_restraints.py
+++ b/openfe/tests/protocols/restraints/test_omm_restraints.py
@@ -105,7 +105,7 @@ zenodo_restraint_data = pooch.create(
     registry={
         "industry_benchmark_systems.zip": "sha256:2bb5eee36e29b718b96bf6e9350e0b9957a592f6c289f77330cbb6f4311a07bd"
     },
-    retry_if_failed=5,
+    retry_if_failed=0,
 )
 
 

--- a/openfe/tests/protocols/restraints/test_omm_restraints.py
+++ b/openfe/tests/protocols/restraints/test_omm_restraints.py
@@ -105,7 +105,6 @@ zenodo_restraint_data = pooch.create(
     registry={
         "industry_benchmark_systems.zip": "sha256:2bb5eee36e29b718b96bf6e9350e0b9957a592f6c289f77330cbb6f4311a07bd"
     },
-    retry_if_failed=0,
 )
 
 

--- a/openfe/tests/protocols/test_openmmutils.py
+++ b/openfe/tests/protocols/test_openmmutils.py
@@ -1044,7 +1044,7 @@ RFE_OUTPUT = pooch.create(
         "simulation.nc": "md5:bc4e842b47de17704d804ae345b91599",
         "simulation_real_time_analysis.yaml": "md5:68a7d81462c42353a91bbbe5e64fd418",
     },
-    retry_if_failed=5,
+    retry_if_failed=0,
 )
 
 

--- a/openfe/tests/protocols/test_openmmutils.py
+++ b/openfe/tests/protocols/test_openmmutils.py
@@ -1044,7 +1044,6 @@ RFE_OUTPUT = pooch.create(
         "simulation.nc": "md5:bc4e842b47de17704d804ae345b91599",
         "simulation_real_time_analysis.yaml": "md5:68a7d81462c42353a91bbbe5e64fd418",
     },
-    retry_if_failed=0,
 )
 
 

--- a/openfecli/tests/commands/test_gather.py
+++ b/openfecli/tests/commands/test_gather.py
@@ -29,13 +29,13 @@ ZENODO_RBFE_DATA = pooch.create(
         "rbfe_results_serial_repeats.tar.gz": "md5:2355ecc80e03242a4c7fcbf20cb45487",
         "rbfe_results_parallel_repeats.tar.gz": "md5:ff7313e14eb6f2940c6ffd50f2192181",
     },
-    retry_if_failed=5,
+    retry_if_failed=0,
 )
 ZENODO_CMET_DATA = pooch.create(
     path=POOCH_CACHE,
     base_url="doi:10.5281/zenodo.15200083",
     registry={"cmet_results.tar.gz": "md5:a4ca67a907f744c696b09660dc1eb8ec"},
-    retry_if_failed=5,
+    retry_if_failed=0,
 )
 
 
@@ -451,7 +451,7 @@ ZENODO_SEPTOP_DATA = pooch.create(
     path=POOCH_CACHE,
     base_url="doi:10.5281/zenodo.17435569",
     registry={"septop_results.zip": "md5:2cfa18da59a20228f5c75a1de6ec879e"},
-    retry_if_failed=2,
+    retry_if_failed=0,
 )
 
 

--- a/openfecli/tests/commands/test_gather.py
+++ b/openfecli/tests/commands/test_gather.py
@@ -29,13 +29,11 @@ ZENODO_RBFE_DATA = pooch.create(
         "rbfe_results_serial_repeats.tar.gz": "md5:2355ecc80e03242a4c7fcbf20cb45487",
         "rbfe_results_parallel_repeats.tar.gz": "md5:ff7313e14eb6f2940c6ffd50f2192181",
     },
-    retry_if_failed=0,
 )
 ZENODO_CMET_DATA = pooch.create(
     path=POOCH_CACHE,
     base_url="doi:10.5281/zenodo.15200083",
     registry={"cmet_results.tar.gz": "md5:a4ca67a907f744c696b09660dc1eb8ec"},
-    retry_if_failed=0,
 )
 
 
@@ -451,7 +449,6 @@ ZENODO_SEPTOP_DATA = pooch.create(
     path=POOCH_CACHE,
     base_url="doi:10.5281/zenodo.17435569",
     registry={"septop_results.zip": "md5:2cfa18da59a20228f5c75a1de6ec879e"},
-    retry_if_failed=0,
 )
 
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
related to https://github.com/fatiando/pooch/issues/502#issuecomment-3694759556

and 

https://blog.zenodo.org/2025/11/25/2025-11-14-search-api-updates/

Zenodo is (fairly) adding rate-limiting, so we should not be doing such persistent retries.

long-term solution is our plan to migrate to cloudflare or similar, but for now this is the least we can do.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] All new code is appropriately documented (user-facing code _must_ have complete docstrings).
* [ ] Added a ``news`` entry, or the changes are not user-facing.
* [ ] Ran pre-commit: you can run [pre-commit](https://pre-commit.com) locally or comment on this PR with `pre-commit.ci autofix`.

Manual Tests: these are slow so don't need to be run every commit, only before merging and when relevant changes are made (generally at reviewer-discretion). 
* [ ] [GPU integration tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/gpu-integration-tests.yaml)
* [ ] [example notebook testing](https://github.com/OpenFreeEnergy/openfe/actions/workflows/test-example-notebooks.yaml)
* [ ] [packaging tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/test-feedstock-pkg-build.yaml): run this for any large feature PRs or PRs that add test data.


## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
