### PR TITLE
refactor: clean up test data handling

### DIFF
--- a/src/openfe/tests/conftest.py
+++ b/src/openfe/tests/conftest.py
@@ -12,6 +12,7 @@ import mdtraj
 import numpy as np
 import openmm
 import pandas as pd
+import pooch
 import pytest
 from gufe import AtomMapper, LigandAtomMapping, ProteinComponent, SmallMoleculeComponent
 from openff.toolkit import ForceField
@@ -25,6 +26,8 @@ from openfe.protocols.openmm_rfe import RelativeHybridTopologyProtocol
 from openfe.protocols.openmm_rfe._rfe_utils.relative import HybridTopologyFactory
 from openfe.protocols.openmm_utils.serialization import deserialize
 from openfe.tests.protocols.openmm_rfe.helpers import make_htf
+
+POOCH_CACHE = pooch.os_cache("openfe")
 
 
 class SlowTests:

--- a/src/openfe/tests/protocols/conftest.py
+++ b/src/openfe/tests/protocols/conftest.py
@@ -1,9 +1,11 @@
 # This code is part of OpenFE and is licensed under the MIT license.
 # For details, see https://github.com/OpenFreeEnergy/openfe
 import gzip
+import pathlib
 from importlib import resources
 from typing import Optional
 
+import MDAnalysis as mda
 import openmm
 import pooch
 import pytest
@@ -15,6 +17,8 @@ from rdkit import Chem
 from rdkit.Geometry import Point3D
 
 import openfe
+
+from ..conftest import POOCH_CACHE
 
 
 @pytest.fixture
@@ -280,8 +284,30 @@ def septop_json() -> str:
         return f.read().decode()  # type: ignore
 
 
+zenodo_restraint_data = pooch.create(
+    path=POOCH_CACHE,
+    base_url="doi:10.5281/zenodo.15212342",
+    registry={
+        "t4_lysozyme_trajectory.zip": "sha256:e985d055db25b5468491e169948f641833a5fbb67a23dbb0a00b57fb7c0e59c8"
+    },
+)
+
+
+@pytest.fixture
+def t4_lysozyme_trajectory_universe():
+    zenodo_restraint_data.fetch("t4_lysozyme_trajectory.zip", processor=pooch.Unzip())
+    cache_dir = pathlib.Path(
+        POOCH_CACHE / "t4_lysozyme_trajectory.zip.unzip/t4_lysozyme_trajectory"
+    )
+    universe = mda.Universe(
+        str(cache_dir / "t4_toluene_complex.pdb"),
+        str(cache_dir / "t4_toluene_complex.xtc"),
+    )
+    return universe
+
+
 RFE_OUTPUT = pooch.create(
-    path=pooch.os_cache("openfe_analysis"),
+    path=POOCH_CACHE,
     base_url="doi:10.6084/m9.figshare.24101655",
     registry={
         "checkpoint.nc": "5af398cb14340fddf7492114998b244424b6c3f4514b2e07e4bd411484c08464",

--- a/src/openfe/tests/protocols/conftest.py
+++ b/src/openfe/tests/protocols/conftest.py
@@ -293,6 +293,15 @@ zenodo_industry_benchmarks_data = pooch.create(
 )
 
 
+@pytest.fixture
+def industry_benchmark_files():
+    zenodo_industry_benchmarks_data.fetch("industry_benchmark_systems.zip", processor=pooch.Unzip())
+    cache_dir = pathlib.Path(
+        POOCH_CACHE / "industry_benchmark_systems.zip.unzip/industry_benchmark_systems"
+    )
+    return cache_dir
+
+
 zenodo_restraint_data = pooch.create(
     path=POOCH_CACHE,
     base_url="doi:10.5281/zenodo.15212342",

--- a/src/openfe/tests/protocols/conftest.py
+++ b/src/openfe/tests/protocols/conftest.py
@@ -284,6 +284,15 @@ def septop_json() -> str:
         return f.read().decode()  # type: ignore
 
 
+zenodo_industry_benchmarks_data = pooch.create(
+    path=POOCH_CACHE,
+    base_url="doi:10.5281/zenodo.15212342",
+    registry={
+        "industry_benchmark_systems.zip": "sha256:2bb5eee36e29b718b96bf6e9350e0b9957a592f6c289f77330cbb6f4311a07bd"
+    },
+)
+
+
 zenodo_restraint_data = pooch.create(
     path=POOCH_CACHE,
     base_url="doi:10.5281/zenodo.15212342",

--- a/src/openfe/tests/protocols/conftest.py
+++ b/src/openfe/tests/protocols/conftest.py
@@ -310,11 +310,7 @@ RFE_OUTPUT = pooch.create(
     path=POOCH_CACHE,
     base_url="doi:10.6084/m9.figshare.24101655",
     registry={
-        "checkpoint.nc": "5af398cb14340fddf7492114998b244424b6c3f4514b2e07e4bd411484c08464",
-        "db.json": "b671f9eb4daf9853f3e1645f9fd7c18150fd2a9bf17c18f23c5cf0c9fd5ca5b3",
-        "hybrid_system.pdb": "07203679cb14b840b36e4320484df2360f45e323faadb02d6eacac244fddd517",
         "simulation.nc": "92361a0864d4359a75399470135f56642b72c605069a4c33dbc4be6f91f28b31",
-        "simulation_real_time_analysis.yaml": "65706002f371fafba96037f29b054fd7e050e442915205df88567f48f5e5e1cf",
     },
 )
 

--- a/src/openfe/tests/protocols/restraints/test_geometry_boresch.py
+++ b/src/openfe/tests/protocols/restraints/test_geometry_boresch.py
@@ -15,6 +15,7 @@ from openfe.protocols.restraint_utils.geometry.boresch.geometry import (
 )
 
 from ...conftest import HAS_INTERNET, POOCH_CACHE
+from ..conftest import zenodo_industry_benchmarks_data
 
 
 @pytest.fixture()
@@ -235,18 +236,9 @@ def test_get_boresch_restraint_dssp(eg5_protein_ligand_universe, eg5_ligands):
     assert -0.02396901 == pytest.approx(restraint_geometry.phi_C0.to("radians").m)
 
 
-zenodo_restraint_data = pooch.create(
-    path=POOCH_CACHE,
-    base_url="doi:10.5281/zenodo.15212342",
-    registry={
-        "industry_benchmark_systems.zip": "sha256:2bb5eee36e29b718b96bf6e9350e0b9957a592f6c289f77330cbb6f4311a07bd"
-    },
-)
-
-
 @pytest.fixture
 def industry_benchmark_files():
-    zenodo_restraint_data.fetch("industry_benchmark_systems.zip", processor=pooch.Unzip())
+    zenodo_industry_benchmarks_data.fetch("industry_benchmark_systems.zip", processor=pooch.Unzip())
     cache_dir = pathlib.Path(
         POOCH_CACHE / "industry_benchmark_systems.zip.unzip/industry_benchmark_systems"
     )

--- a/src/openfe/tests/protocols/restraints/test_geometry_boresch.py
+++ b/src/openfe/tests/protocols/restraints/test_geometry_boresch.py
@@ -15,7 +15,6 @@ from openfe.protocols.restraint_utils.geometry.boresch.geometry import (
 )
 
 from ...conftest import HAS_INTERNET, POOCH_CACHE
-from ..conftest import zenodo_industry_benchmarks_data
 
 
 @pytest.fixture()
@@ -234,15 +233,6 @@ def test_get_boresch_restraint_dssp(eg5_protein_ligand_universe, eg5_ligands):
     assert 2.56825286 == pytest.approx(restraint_geometry.phi_A0.to("radians").m)
     assert -1.60162692 == pytest.approx(restraint_geometry.phi_B0.to("radians").m)
     assert -0.02396901 == pytest.approx(restraint_geometry.phi_C0.to("radians").m)
-
-
-@pytest.fixture
-def industry_benchmark_files():
-    zenodo_industry_benchmarks_data.fetch("industry_benchmark_systems.zip", processor=pooch.Unzip())
-    cache_dir = pathlib.Path(
-        POOCH_CACHE / "industry_benchmark_systems.zip.unzip/industry_benchmark_systems"
-    )
-    return cache_dir
 
 
 @pytest.mark.skipif(

--- a/src/openfe/tests/protocols/restraints/test_geometry_boresch.py
+++ b/src/openfe/tests/protocols/restraints/test_geometry_boresch.py
@@ -14,7 +14,7 @@ from openfe.protocols.restraint_utils.geometry.boresch.geometry import (
     find_boresch_restraint,
 )
 
-from ...conftest import HAS_INTERNET
+from ...conftest import HAS_INTERNET, POOCH_CACHE
 
 
 @pytest.fixture()
@@ -235,7 +235,6 @@ def test_get_boresch_restraint_dssp(eg5_protein_ligand_universe, eg5_ligands):
     assert -0.02396901 == pytest.approx(restraint_geometry.phi_C0.to("radians").m)
 
 
-POOCH_CACHE = pooch.os_cache("openfe")
 zenodo_restraint_data = pooch.create(
     path=POOCH_CACHE,
     base_url="doi:10.5281/zenodo.15212342",
@@ -249,7 +248,7 @@ zenodo_restraint_data = pooch.create(
 def industry_benchmark_files():
     zenodo_restraint_data.fetch("industry_benchmark_systems.zip", processor=pooch.Unzip())
     cache_dir = pathlib.Path(
-        pooch.os_cache("openfe") / "industry_benchmark_systems.zip.unzip/industry_benchmark_systems"
+        POOCH_CACHE / "industry_benchmark_systems.zip.unzip/industry_benchmark_systems"
     )
     return cache_dir
 

--- a/src/openfe/tests/protocols/restraints/test_geometry_boresch_host.py
+++ b/src/openfe/tests/protocols/restraints/test_geometry_boresch_host.py
@@ -2,7 +2,6 @@
 # For details, see https://github.com/OpenFreeEnergy/openfe
 
 import os
-import pathlib
 
 import MDAnalysis as mda
 import numpy as np
@@ -25,9 +24,8 @@ from openfe.protocols.restraint_utils.geometry.utils import (
     is_collinear,
 )
 
-from ...conftest import HAS_INTERNET
+from ...conftest import HAS_INTERNET, POOCH_CACHE
 
-POOCH_CACHE = pooch.os_cache("openfe")
 zenodo_restraint_data = pooch.create(
     path=POOCH_CACHE,
     base_url="doi:10.5281/zenodo.15212342",
@@ -35,21 +33,6 @@ zenodo_restraint_data = pooch.create(
         "t4_lysozyme_trajectory.zip": "sha256:e985d055db25b5468491e169948f641833a5fbb67a23dbb0a00b57fb7c0e59c8"
     },
 )
-
-
-@pytest.fixture(scope="module")
-def t4_lysozyme_trajectory_universe():
-    zenodo_restraint_data.fetch("t4_lysozyme_trajectory.zip", processor=pooch.Unzip())
-    cache_dir = pathlib.Path(
-        pooch.os_cache("openfe") / "t4_lysozyme_trajectory.zip.unzip/t4_lysozyme_trajectory"
-    )
-    universe = mda.Universe(
-        str(cache_dir / "t4_toluene_complex.pdb"),
-        str(cache_dir / "t4_toluene_complex.xtc"),
-    )
-    # guess bonds for the protein atoms
-    universe.select_atoms("protein").guess_bonds()
-    return universe
 
 
 @pytest.fixture
@@ -358,7 +341,10 @@ class TestFindAnchorBondedTrajectory(TestFindAnchorMulti):
 
     @pytest.fixture(scope="class")
     def universe(self, t4_lysozyme_trajectory_universe):
-        return t4_lysozyme_trajectory_universe
+        universe = t4_lysozyme_trajectory_universe
+        # guess bonds for the protein atoms
+        universe.select_atoms("protein").guess_bonds()
+        return universe
 
     @pytest.fixture(scope="class")
     def host_anchor(self, universe):

--- a/src/openfe/tests/protocols/restraints/test_geometry_boresch_host.py
+++ b/src/openfe/tests/protocols/restraints/test_geometry_boresch_host.py
@@ -26,14 +26,6 @@ from openfe.protocols.restraint_utils.geometry.utils import (
 
 from ...conftest import HAS_INTERNET, POOCH_CACHE
 
-zenodo_restraint_data = pooch.create(
-    path=POOCH_CACHE,
-    base_url="doi:10.5281/zenodo.15212342",
-    registry={
-        "t4_lysozyme_trajectory.zip": "sha256:e985d055db25b5468491e169948f641833a5fbb67a23dbb0a00b57fb7c0e59c8"
-    },
-)
-
 
 @pytest.fixture
 def eg5_protein_ligand_universe(eg5_protein_pdb, eg5_ligands):

--- a/src/openfe/tests/protocols/restraints/test_geometry_utils.py
+++ b/src/openfe/tests/protocols/restraints/test_geometry_utils.py
@@ -3,12 +3,10 @@
 
 import itertools
 import os
-import pathlib
 from importlib import resources
 
 import MDAnalysis as mda
 import numpy as np
-import pooch
 import pytest
 from openff.units import unit
 from rdkit import Chem
@@ -32,7 +30,7 @@ from openfe.protocols.restraint_utils.geometry.utils import (
     stable_secondary_structure_selection,
 )
 
-from ...conftest import HAS_INTERNET
+from ...conftest import HAS_INTERNET, POOCH_CACHE
 
 
 @pytest.fixture(scope="module")
@@ -47,29 +45,6 @@ def eg5_protein_ligand_universe(eg5_protein_pdb, eg5_ligands):
     # add the residue name of the ligand
     lig.add_TopologyAttr("resname", ["LIG"])
     return mda.Merge(protein.atoms, lig.atoms)
-
-
-POOCH_CACHE = pooch.os_cache("openfe")
-zenodo_restraint_data = pooch.create(
-    path=POOCH_CACHE,
-    base_url="doi:10.5281/zenodo.15212342",
-    registry={
-        "t4_lysozyme_trajectory.zip": "sha256:e985d055db25b5468491e169948f641833a5fbb67a23dbb0a00b57fb7c0e59c8"
-    },
-)
-
-
-@pytest.fixture
-def t4_lysozyme_trajectory_universe():
-    zenodo_restraint_data.fetch("t4_lysozyme_trajectory.zip", processor=pooch.Unzip())
-    cache_dir = pathlib.Path(
-        pooch.os_cache("openfe") / "t4_lysozyme_trajectory.zip.unzip/t4_lysozyme_trajectory"
-    )
-    universe = mda.Universe(
-        str(cache_dir / "t4_toluene_complex.pdb"),
-        str(cache_dir / "t4_toluene_complex.xtc"),
-    )
-    return universe
 
 
 @pytest.fixture

--- a/src/openfe/tests/protocols/restraints/test_omm_restraints.py
+++ b/src/openfe/tests/protocols/restraints/test_omm_restraints.py
@@ -28,7 +28,7 @@ from openfe.protocols.restraint_utils.settings import (
     FlatBottomRestraintSettings,
 )
 
-from ...conftest import HAS_INTERNET
+from ...conftest import HAS_INTERNET, POOCH_CACHE
 
 
 def test_parameter_state_default():
@@ -98,7 +98,6 @@ def test_verify_geometry():
         restraint._verify_geometry(geometry)
 
 
-POOCH_CACHE = pooch.os_cache("openfe")
 zenodo_restraint_data = pooch.create(
     path=POOCH_CACHE,
     base_url="doi:10.5281/zenodo.15212342",
@@ -112,7 +111,7 @@ zenodo_restraint_data = pooch.create(
 def tyk2_protein_ligand_system():
     zenodo_restraint_data.fetch("industry_benchmark_systems.zip", processor=pooch.Unzip())
     cache_dir = pathlib.Path(
-        pooch.os_cache("openfe") / "industry_benchmark_systems.zip.unzip/industry_benchmark_systems"
+        POOCH_CACHE / "industry_benchmark_systems.zip.unzip/industry_benchmark_systems"
     )
     with open(str(cache_dir / "jacs_set" / "tyk2" / "protein_ligand_system.xml")) as xml:
         return openmm.XmlSerializer.deserialize(xml.read())
@@ -122,7 +121,7 @@ def tyk2_protein_ligand_system():
 def tyk2_rdkit_ligand():
     zenodo_restraint_data.fetch("industry_benchmark_systems.zip", processor=pooch.Unzip())
     cache_dir = pathlib.Path(
-        pooch.os_cache("openfe") / "industry_benchmark_systems.zip.unzip/industry_benchmark_systems"
+        POOCH_CACHE / "industry_benchmark_systems.zip.unzip/industry_benchmark_systems"
     )
     ligand = SmallMoleculeComponent.from_sdf_file(
         str(cache_dir / "jacs_set" / "tyk2" / "test_ligand.sdf")

--- a/src/openfe/tests/protocols/restraints/test_omm_restraints.py
+++ b/src/openfe/tests/protocols/restraints/test_omm_restraints.py
@@ -29,6 +29,7 @@ from openfe.protocols.restraint_utils.settings import (
 )
 
 from ...conftest import HAS_INTERNET, POOCH_CACHE
+from ..conftest import zenodo_industry_benchmarks_data
 
 
 def test_parameter_state_default():
@@ -98,18 +99,9 @@ def test_verify_geometry():
         restraint._verify_geometry(geometry)
 
 
-zenodo_restraint_data = pooch.create(
-    path=POOCH_CACHE,
-    base_url="doi:10.5281/zenodo.15212342",
-    registry={
-        "industry_benchmark_systems.zip": "sha256:2bb5eee36e29b718b96bf6e9350e0b9957a592f6c289f77330cbb6f4311a07bd"
-    },
-)
-
-
 @pytest.fixture
 def tyk2_protein_ligand_system():
-    zenodo_restraint_data.fetch("industry_benchmark_systems.zip", processor=pooch.Unzip())
+    zenodo_industry_benchmarks_data.fetch("industry_benchmark_systems.zip", processor=pooch.Unzip())
     cache_dir = pathlib.Path(
         POOCH_CACHE / "industry_benchmark_systems.zip.unzip/industry_benchmark_systems"
     )
@@ -119,7 +111,7 @@ def tyk2_protein_ligand_system():
 
 @pytest.fixture
 def tyk2_rdkit_ligand():
-    zenodo_restraint_data.fetch("industry_benchmark_systems.zip", processor=pooch.Unzip())
+    zenodo_industry_benchmarks_data.fetch("industry_benchmark_systems.zip", processor=pooch.Unzip())
     cache_dir = pathlib.Path(
         POOCH_CACHE / "industry_benchmark_systems.zip.unzip/industry_benchmark_systems"
     )

--- a/src/openfe/tests/protocols/restraints/test_omm_restraints.py
+++ b/src/openfe/tests/protocols/restraints/test_omm_restraints.py
@@ -2,10 +2,8 @@
 # For details, see https://github.com/OpenFreeEnergy/openfe
 
 import os
-import pathlib
 
 import openmm
-import pooch
 import pytest
 from gufe import SmallMoleculeComponent
 from openff.units import unit
@@ -29,7 +27,6 @@ from openfe.protocols.restraint_utils.settings import (
 )
 
 from ...conftest import HAS_INTERNET, POOCH_CACHE
-from ..conftest import zenodo_industry_benchmarks_data
 
 
 def test_parameter_state_default():
@@ -100,23 +97,17 @@ def test_verify_geometry():
 
 
 @pytest.fixture
-def tyk2_protein_ligand_system():
-    zenodo_industry_benchmarks_data.fetch("industry_benchmark_systems.zip", processor=pooch.Unzip())
-    cache_dir = pathlib.Path(
-        POOCH_CACHE / "industry_benchmark_systems.zip.unzip/industry_benchmark_systems"
-    )
-    with open(str(cache_dir / "jacs_set" / "tyk2" / "protein_ligand_system.xml")) as xml:
+def tyk2_protein_ligand_system(industry_benchmark_files):
+    with open(
+        str(industry_benchmark_files / "jacs_set" / "tyk2" / "protein_ligand_system.xml")
+    ) as xml:
         return openmm.XmlSerializer.deserialize(xml.read())
 
 
 @pytest.fixture
-def tyk2_rdkit_ligand():
-    zenodo_industry_benchmarks_data.fetch("industry_benchmark_systems.zip", processor=pooch.Unzip())
-    cache_dir = pathlib.Path(
-        POOCH_CACHE / "industry_benchmark_systems.zip.unzip/industry_benchmark_systems"
-    )
+def tyk2_rdkit_ligand(industry_benchmark_files):
     ligand = SmallMoleculeComponent.from_sdf_file(
-        str(cache_dir / "jacs_set" / "tyk2" / "test_ligand.sdf")
+        str(industry_benchmark_files / "jacs_set" / "tyk2" / "test_ligand.sdf")
     )
     return ligand.to_rdkit()
 

--- a/src/openfe/tests/protocols/test_openmmutils.py
+++ b/src/openfe/tests/protocols/test_openmmutils.py
@@ -1033,24 +1033,6 @@ class TestOFFPartialCharge:
             )
 
 
-RFE_OUTPUT = pooch.create(
-    path=POOCH_CACHE,
-    base_url="doi:10.5281/zenodo.15375081",
-    registry={
-        "checkpoint.nc": "md5:3cfd70a4cbe463403d6ec7cca84fc31a",
-        "db.json": "md5:33c8c1a0b629a52dcc291beff59fabc6",
-        "hybrid_system.pdb": "md5:44a1e78294360037acf419b95be18fb3",
-        "simulation.nc": "md5:bc4e842b47de17704d804ae345b91599",
-        "simulation_real_time_analysis.yaml": "md5:68a7d81462c42353a91bbbe5e64fd418",
-    },
-)
-
-
-@pytest.fixture
-def simulation_nc():
-    return RFE_OUTPUT.fetch("simulation.nc")
-
-
 @pytest.mark.slow
 @pytest.mark.skipif(
     not os.path.exists(POOCH_CACHE) and not HAS_INTERNET,

--- a/src/openfe/tests/protocols/test_openmmutils.py
+++ b/src/openfe/tests/protocols/test_openmmutils.py
@@ -40,7 +40,7 @@ from openfe.protocols.openmm_utils.charge_generation import (
     HAS_NAGL,
     HAS_OPENEYE,
 )
-from openfe.tests.conftest import HAS_INTERNET
+from openfe.tests.conftest import HAS_INTERNET, POOCH_CACHE
 
 
 @pytest.mark.parametrize(
@@ -1033,7 +1033,6 @@ class TestOFFPartialCharge:
             )
 
 
-POOCH_CACHE = pooch.os_cache("openfe")
 RFE_OUTPUT = pooch.create(
     path=POOCH_CACHE,
     base_url="doi:10.5281/zenodo.15375081",


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
consolidated all pooch creation and fetching instances, removed code duplication.

pre-work for https://github.com/OpenFreeEnergy/openfe/pull/1814

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [x] All new code is appropriately documented (user-facing code _must_ have complete docstrings).
* [x] Added a ``news`` entry, or the changes are not user-facing.
* [x] Ran pre-commit: you can run [pre-commit](https://pre-commit.com) locally or comment on this PR with `pre-commit.ci autofix`.

Manual Tests: these are slow so don't need to be run every commit, only before merging and when relevant changes are made (generally at reviewer-discretion). 
* [ ] [GPU integration tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/gpu-integration-tests.yaml)
* [ ] [example notebook testing](https://github.com/OpenFreeEnergy/openfe/actions/workflows/test-example-notebooks.yaml)
* [ ] [packaging tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/test-feedstock-pkg-build.yaml): run this for any large feature PRs or PRs that add test data.


## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
