### PR TITLE
ci: run slow tests separately

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -138,6 +138,8 @@ jobs:
 
       - name: "Run slow tests"
         if: github.event_name != 'pull_request'
+        env:
+          OFE_SLOW_TESTS: "true"
         run: |
           pytest -n auto -v --cov=openfe --cov=openfecli --cov-report=xml --durations=10 -m slow
   

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -130,14 +130,17 @@ jobs:
           # the key is pooch-${{ matrix.os }}-1 change it to pooch-${{ matrix.os }}-2
           key: pooch-${{ matrix.os }}-1
 
-      - name: "Run tests"
+      - name: "Run fast tests"
         env:
-          # Set the OFE_SLOW_TESTS to True if running a Cron job
-          OFE_SLOW_TESTS: ${{ fromJSON('{"false":"false","true":"true"}')[github.event_name != 'pull_request'] }}
-          DUECREDIT_ENABLE: 'yes'
+          OFE_SLOW_TESTS: "false"
         run: |
           pytest -n auto -v --cov=openfe --cov=openfecli --cov-report=xml --durations=10
 
+      - name: "Run slow tests"
+        if: github.event_name != 'pull_request'
+        run: |
+          pytest -n auto -v --cov=openfe --cov=openfecli --cov-report=xml --durations=10 -m slow
+  
       - name: codecov-pr
         if: ${{ github.repository == 'OpenFreeEnergy/openfe'
                 && github.event_name == 'pull_request' }}


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
we only run slow tests when code is pushed to main, but it's not clear from our current test set up that that is a difference between PR CI and scheduled or manual CI.
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] All new code is appropriately documented (user-facing code _must_ have complete docstrings).
* [ ] Added a ``news`` entry, or the changes are not user-facing.
* [ ] Ran pre-commit: you can run [pre-commit](https://pre-commit.com) locally or comment on this PR with `pre-commit.ci autofix`.

Manual Tests: these are slow so don't need to be run every commit, only before merging and when relevant changes are made (generally at reviewer-discretion). 
* [ ] [GPU integration tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/gpu-integration-tests.yaml)
* [ ] [example notebook testing](https://github.com/OpenFreeEnergy/openfe/actions/workflows/test-example-notebooks.yaml)
* [ ] [packaging tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/test-feedstock-pkg-build.yaml): run this for any large feature PRs or PRs that add test data.


## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
