### PR TITLE
fix scope mismatch with zenodo data

### DIFF
--- a/src/openfe/tests/protocols/conftest.py
+++ b/src/openfe/tests/protocols/conftest.py
@@ -311,17 +311,14 @@ zenodo_restraint_data = pooch.create(
 )
 
 
+# session scope for downstream reuse
 @pytest.fixture(scope="session")
-def t4_lysozyme_trajectory_universe():
+def t4_lysozyme_trajectory_dir():
     zenodo_restraint_data.fetch("t4_lysozyme_trajectory.zip", processor=pooch.Unzip())
     cache_dir = pathlib.Path(
         POOCH_CACHE / "t4_lysozyme_trajectory.zip.unzip/t4_lysozyme_trajectory"
     )
-    universe = mda.Universe(
-        str(cache_dir / "t4_toluene_complex.pdb"),
-        str(cache_dir / "t4_toluene_complex.xtc"),
-    )
-    return universe
+    return cache_dir
 
 
 RFE_OUTPUT = pooch.create(

--- a/src/openfe/tests/protocols/conftest.py
+++ b/src/openfe/tests/protocols/conftest.py
@@ -311,7 +311,7 @@ zenodo_restraint_data = pooch.create(
 )
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def t4_lysozyme_trajectory_universe():
     zenodo_restraint_data.fetch("t4_lysozyme_trajectory.zip", processor=pooch.Unzip())
     cache_dir = pathlib.Path(

--- a/src/openfe/tests/protocols/restraints/test_geometry_boresch_host.py
+++ b/src/openfe/tests/protocols/restraints/test_geometry_boresch_host.py
@@ -332,8 +332,12 @@ class TestFindAnchorBondedTrajectory(TestFindAnchorMulti):
     ref_h1h2_distance = 1.55881
 
     @pytest.fixture(scope="class")
-    def universe(self, t4_lysozyme_trajectory_universe):
-        universe = t4_lysozyme_trajectory_universe
+    def universe(self, t4_lysozyme_trajectory_dir):
+        cache_dir = t4_lysozyme_trajectory_dir
+        universe = mda.Universe(
+            str(cache_dir / "t4_toluene_complex.pdb"),
+            str(cache_dir / "t4_toluene_complex.xtc"),
+        )
         # guess bonds for the protein atoms
         universe.select_atoms("protein").guess_bonds()
         return universe

--- a/src/openfe/tests/protocols/restraints/test_geometry_utils.py
+++ b/src/openfe/tests/protocols/restraints/test_geometry_utils.py
@@ -400,6 +400,16 @@ def test_atomgroup_has_bonds(eg5_protein_pdb):
     assert _atomgroup_has_bonds(ag)
 
 
+@pytest.fixture()
+def t4_lysozyme_trajectory_universe(t4_lysozyme_trajectory_dir):
+    cache_dir = t4_lysozyme_trajectory_dir
+    universe = mda.Universe(
+        str(cache_dir / "t4_toluene_complex.pdb"),
+        str(cache_dir / "t4_toluene_complex.xtc"),
+    )
+    return universe
+
+
 @pytest.mark.skipif(
     not os.path.exists(POOCH_CACHE) and not HAS_INTERNET,
     reason="Internet seems to be unavailable and test data is not cached locally.",


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->


<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [x] All new code is appropriately documented (user-facing code _must_ have complete docstrings).
* [x] Added a ``news`` entry, or the changes are not user-facing.
* [x] Ran pre-commit: you can run [pre-commit](https://pre-commit.com) locally or comment on this PR with `pre-commit.ci autofix`.

Manual Tests: these are slow so don't need to be run every commit, only before merging and when relevant changes are made (generally at reviewer-discretion). 

- long tests running here: https://github.com/OpenFreeEnergy/openfe/actions/runs/21653750952

- https://github.com/OpenFreeEnergy/openfe/actions/runs/21690126562


* [ ] [GPU integration tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/gpu-integration-tests.yaml)
* [ ] [example notebook testing](https://github.com/OpenFreeEnergy/openfe/actions/workflows/test-example-notebooks.yaml)
* [ ] [packaging tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/test-feedstock-pkg-build.yaml): run this for any large feature PRs or PRs that add test data.


## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
