### PR TITLE
WIP:tests should catch logging import error

### DIFF
--- a/src/openfecli/tests/test_cli.py
+++ b/src/openfecli/tests/test_cli.py
@@ -7,6 +7,8 @@ import pytest
 from openfecli.cli import OpenFECLI, main
 from openfecli.plugins import OFECommandPlugin
 
+from .utils import assert_click_success
+
 
 @click.command("null-command", short_help="Do nothing (testing)")
 def null_command():
@@ -65,7 +67,7 @@ class TestCLI:
         assert len(plugins) > 0
 
 
-@pytest.mark.parametrize("with_log", [True, False])
+@pytest.mark.parametrize("with_log", [False, True])
 def test_main_log(with_log):
     logged_text = "Running null command\n"
     logfile_text = "\n".join(
@@ -105,6 +107,7 @@ def test_main_log(with_log):
 
         with null_command_context(main):
             result = runner.invoke(main, invocation)
+            assert_click_success(result)
 
     found = result.stdout_bytes
     assert found.decode("utf-8") == expected


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
resolves https://github.com/OpenFreeEnergy/openfe/issues/1839
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] All new code is appropriately documented (user-facing code _must_ have complete docstrings).
* [ ] Added a ``news`` entry, or the changes are not user-facing.
* [ ] Ran pre-commit: you can run [pre-commit](https://pre-commit.com) locally or comment on this PR with `pre-commit.ci autofix`.

Manual Tests: these are slow so don't need to be run every commit, only before merging and when relevant changes are made (generally at reviewer-discretion). 
* [ ] [GPU integration tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/gpu-integration-tests.yaml)
* [ ] [example notebook testing](https://github.com/OpenFreeEnergy/openfe/actions/workflows/test-example-notebooks.yaml)
* [ ] [packaging tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/test-feedstock-pkg-build.yaml): run this for any large feature PRs or PRs that add test data.


## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
