### PR TITLE
Safely close reporter and clear GPU contexts to avoid UnboundLocalErrors

### DIFF
--- a/news/issue-1845.rst
+++ b/news/issue-1845.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed a bug in Protocol termination for the HybridTop and AFE Protocols
+  which would unecessary declare an UnboundLocalError.
+
+**Security:**
+
+* <news item>

--- a/news/issue-1845.rst
+++ b/news/issue-1845.rst
@@ -17,7 +17,7 @@
 **Fixed:**
 
 * Fixed a bug in Protocol termination for the HybridTop and AFE Protocols
-  which would unecessary declare an UnboundLocalError.
+  which would unnecessarily declare an ``UnboundLocalError``.
 
 **Security:**
 

--- a/src/openfe/protocols/openmm_afe/base_afe_units.py
+++ b/src/openfe/protocols/openmm_afe/base_afe_units.py
@@ -1319,24 +1319,29 @@ class BaseAbsoluteMultiStateSimulationUnit(gufe.ProtocolUnit, AbsoluteUnitMixin)
             )
 
         finally:
-            # close reporter when you're done to prevent file handle clashes
-            reporter.close()
+            # Have to wrap this in a try/except, because we might
+            # be in a situation where the reporter or sampler weren't created
+            try:
+                # Order is reporter, contexts, integrator, sampler
+                reporter.close()  # close to prevent file handle clashes
 
-            # clear GPU context
-            # Note: use cache.empty() when openmmtools #690 is resolved
-            for context in list(sampler.energy_context_cache._lru._data.keys()):
-                del sampler.energy_context_cache._lru._data[context]
-            for context in list(sampler.sampler_context_cache._lru._data.keys()):
-                del sampler.sampler_context_cache._lru._data[context]
-            # cautiously clear out the global context cache too
-            for context in list(openmmtools.cache.global_context_cache._lru._data.keys()):
-                del openmmtools.cache.global_context_cache._lru._data[context]
+                # clear GPU context
+                # Note: use cache.empty() when openmmtools #690 is resolved
+                for context in list(sampler.energy_context_cache._lru._data.keys()):
+                    del sampler.energy_context_cache._lru._data[context]
+                for context in list(sampler.sampler_context_cache._lru._data.keys()):
+                    del sampler.sampler_context_cache._lru._data[context]
+                # cautiously clear out the global context cache too
+                for context in list(openmmtools.cache.global_context_cache._lru._data.keys()):
+                    del openmmtools.cache.global_context_cache._lru._data[context]
 
-            del sampler.sampler_context_cache, sampler.energy_context_cache
+                del sampler.sampler_context_cache, sampler.energy_context_cache
 
-            # Keep these around in a dry run so we can inspect things
-            if not dry:
-                del integrator, sampler
+                # Keep these around in a dry run so we can inspect things
+                if not dry:
+                    del integrator, sampler
+            except UnboundLocalError:
+                pass
 
         if not dry:
             nc = self.shared_basepath / settings["output_settings"].output_filename

--- a/src/openfe/protocols/openmm_afe/base_afe_units.py
+++ b/src/openfe/protocols/openmm_afe/base_afe_units.py
@@ -1322,7 +1322,7 @@ class BaseAbsoluteMultiStateSimulationUnit(gufe.ProtocolUnit, AbsoluteUnitMixin)
             # Have to wrap this in a try/except, because we might
             # be in a situation where the reporter or sampler weren't created
             try:
-                # Order is reporter, contexts, integrator, sampler
+                # Order is reporter, contexts, sampler, integrator
                 reporter.close()  # close to prevent file handle clashes
 
                 # clear GPU context
@@ -1339,6 +1339,8 @@ class BaseAbsoluteMultiStateSimulationUnit(gufe.ProtocolUnit, AbsoluteUnitMixin)
 
                 # Keep these around in a dry run so we can inspect things
                 if not dry:
+                    # At this point we know the sampler exists, so we del the integrator
+                    # first since it's associated with the sampler
                     del integrator, sampler
             except UnboundLocalError:
                 pass


### PR DESCRIPTION
Fixes #1845

Added try/except block to safely close things in case there's an unbound variable.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [x] All new code is appropriately documented (user-facing code _must_ have complete docstrings).
* [x] Added a ``news`` entry, or the changes are not user-facing.
* [x] Ran pre-commit: you can run [pre-commit](https://pre-commit.com) locally or comment on this PR with `pre-commit.ci autofix`.

Manual Tests: these are slow so don't need to be run every commit, only before merging and when relevant changes are made (generally at reviewer-discretion). 
* [x] [GPU integration tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/gpu-integration-tests.yaml)
* [ ] [example notebook testing](https://github.com/OpenFreeEnergy/openfe/actions/workflows/test-example-notebooks.yaml)
* [ ] [packaging tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/test-feedstock-pkg-build.yaml): run this for any large feature PRs or PRs that add test data.


## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
