### PR TITLE
deprecate perses functionality

### DIFF
--- a/news/deprecate_perses.rst
+++ b/news/deprecate_perses.rst
@@ -8,7 +8,8 @@
 
 **Deprecated:**
 
-* Perses functionality is deprecated, slated to be removed in ``openfe v2.0``. This includes ``PersesAtomMapper`` and ``default_perses_scorer``.
+* Perses atom mapper and scorer functionality is deprecated, slated to be removed in ``openfe v2.0``. 
+This includes ``PersesAtomMapper`` and ``default_perses_scorer``.
 
 **Removed:**
 

--- a/news/deprecate_perses.rst
+++ b/news/deprecate_perses.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* Perses functionality is deprecated, slated to be removed in ``openfe v2.0``. This includes ``PersesAtomMapper`` and ``default_perses_scorer``.
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/openfe/setup/atom_mapping/perses_mapper.py
+++ b/src/openfe/setup/atom_mapping/perses_mapper.py
@@ -6,6 +6,8 @@ The MCS class from Perses shamelessly wrapped and used here to match our API.
 
 """
 
+import warnings
+
 from gufe.settings.typing import AngstromQuantity
 from openff.units import Quantity, unit
 from openff.units.openmm import to_openmm
@@ -75,6 +77,10 @@ class PersesAtomMapper(LigandAtomMapper):
             can be mapped, default: 0.25*unit.angstrom
 
         """
+        warnings.warn(
+            "PersesAtomMapper is deprecated and is planned to be removed in openfe v2.0.",
+            DeprecationWarning,
+        )
         self.allow_ring_breaking = allow_ring_breaking
         self.preserve_chirality = preserve_chirality
         self.use_positions = use_positions

--- a/src/openfe/setup/atom_mapping/perses_mapper.py
+++ b/src/openfe/setup/atom_mapping/perses_mapper.py
@@ -78,7 +78,7 @@ class PersesAtomMapper(LigandAtomMapper):
 
         """
         warnings.warn(
-            "PersesAtomMapper is deprecated and is planned to be removed in openfe v2.0.",
+            "PersesAtomMapper is deprecated and is planned to be removed in openfe v2.0. If you have questions related to this, please open an issue at https://github.com/OpenFreeEnergy/openfe/issues.",
             DeprecationWarning,
         )
         self.allow_ring_breaking = allow_ring_breaking

--- a/src/openfe/setup/atom_mapping/perses_scorers.py
+++ b/src/openfe/setup/atom_mapping/perses_scorers.py
@@ -1,6 +1,7 @@
 # This code is part of OpenFE and is licensed under the MIT license.
 # For details, see https://github.com/OpenFreeEnergy/openfe
 
+import warnings
 from typing import Callable
 
 from openfe.utils import requires_package
@@ -67,6 +68,11 @@ def default_perses_scorer(
     -------
         float
     """
+    warnings.warn(
+        "default_perses_scorer is deprecated and is planned to be removed in openfe v2.0.",
+        DeprecationWarning,
+    )
+
     score = AtomMapper(use_positions=use_positions).score_mapping(
         AtomMapping(
             old_mol=mapping.componentA.to_openff(),

--- a/src/openfe/setup/atom_mapping/perses_scorers.py
+++ b/src/openfe/setup/atom_mapping/perses_scorers.py
@@ -69,7 +69,7 @@ def default_perses_scorer(
         float
     """
     warnings.warn(
-        "default_perses_scorer is deprecated and is planned to be removed in openfe v2.0.",
+        "default_perses_scorer is deprecated and is planned to be removed in openfe v2.0. If you have questions related to this, please open an issue at https://github.com/OpenFreeEnergy/openfe/issues",
         DeprecationWarning,
     )
 

--- a/src/openfe/tests/setup/atom_mapping/test_perses_atommapper.py
+++ b/src/openfe/tests/setup/atom_mapping/test_perses_atommapper.py
@@ -13,8 +13,8 @@ def test_simple(atom_mapping_basic_test_files):
     # basic sanity check on the LigandAtomMapper
     mol1 = atom_mapping_basic_test_files["methylcyclohexane"]
     mol2 = atom_mapping_basic_test_files["toluene"]
-
-    mapper = PersesAtomMapper()
+    with pytest.warns(DeprecationWarning, match="PersesAtomMapper"):
+        mapper = PersesAtomMapper()
 
     mapping_gen = mapper.suggest_mappings(mol1, mol2)
 
@@ -31,8 +31,8 @@ def test_generator_length(atom_mapping_basic_test_files):
     # generator stops correctly
     mol1 = atom_mapping_basic_test_files["methylcyclohexane"]
     mol2 = atom_mapping_basic_test_files["toluene"]
-
-    mapper = PersesAtomMapper()
+    with pytest.warns(DeprecationWarning, match="PersesAtomMapper"):
+        mapper = PersesAtomMapper()
 
     mapping_gen = mapper.suggest_mappings(mol1, mol2)
 
@@ -45,7 +45,8 @@ def test_generator_length(atom_mapping_basic_test_files):
 @skip_if_missing("perses")
 def test_empty_atommappings(mol_pair_to_shock_perses_mapper):
     mol1, mol2 = mol_pair_to_shock_perses_mapper
-    mapper = PersesAtomMapper()
+    with pytest.warns(DeprecationWarning, match="PersesAtomMapper"):
+        mapper = PersesAtomMapper()
 
     mapping_gen = mapper.suggest_mappings(mol1, mol2)
 
@@ -59,11 +60,12 @@ def test_empty_atommappings(mol_pair_to_shock_perses_mapper):
 @skip_if_missing("openeye")
 @skip_if_missing("perses")
 def test_dict_round_trip():
-    # use some none defaults
-    mapper1 = PersesAtomMapper(
-        allow_ring_breaking=False,
-        preserve_chirality=False,
-        coordinate_tolerance=0.01 * unit.nanometer,
-    )
-    mapper2 = PersesAtomMapper.from_dict(mapper1.to_dict())
+    with pytest.warns(DeprecationWarning, match="PersesAtomMapper"):
+        # use some none defaults
+        mapper1 = PersesAtomMapper(
+            allow_ring_breaking=False,
+            preserve_chirality=False,
+            coordinate_tolerance=0.01 * unit.nanometer,
+        )
+        mapper2 = PersesAtomMapper.from_dict(mapper1.to_dict())
     assert mapper2.to_dict() == mapper1.to_dict()

--- a/src/openfe/tests/setup/atom_mapping/test_perses_scorers.py
+++ b/src/openfe/tests/setup/atom_mapping/test_perses_scorers.py
@@ -18,7 +18,8 @@ USING_OLD_OFF = False
 @pytest.mark.xfail(not USING_OLD_OFF, reason="perses #1108")
 def test_perses_normalization_not_using_positions(gufe_atom_mapping_matrix):
     # now run the openfe equivalent with the same ligand atom _mappings
-    scorer = perses_scorers.default_perses_scorer
+    with pytest.raises(DeprecationWarning, match="default_perses_scorer"):
+        scorer = perses_scorers.default_perses_scorer
     molecule_row = np.max(list(gufe_atom_mapping_matrix.keys())) + 1
     norm_scores = np.zeros([molecule_row, molecule_row])
 
@@ -41,7 +42,8 @@ def test_perses_normalization_not_using_positions(gufe_atom_mapping_matrix):
 @skip_if_missing("perses")
 @pytest.mark.xfail(not USING_OLD_OFF, reason="perses #1108")
 def test_perses_not_implemented_position_using(gufe_atom_mapping_matrix):
-    scorer = perses_scorers.default_perses_scorer
+    with pytest.raises(DeprecationWarning, match="default_perses_scorer"):
+        scorer = perses_scorers.default_perses_scorer
 
     first_key = list(gufe_atom_mapping_matrix.keys())[0]
     match_re = "normalizing using positions is not currently implemented"
@@ -76,7 +78,8 @@ def test_perses_regression(gufe_atom_mapping_matrix):
     assert matrix.shape == (8, 8)
 
     # now run the openfe equivalent with the same ligand atom _mappings
-    scorer = perses_scorers.default_perses_scorer
+    with pytest.raises(DeprecationWarning, match="default_perses_scorer"):
+        scorer = perses_scorers.default_perses_scorer
     scores = np.zeros_like(matrix)
     for (i, j), ligand_atom_mapping in gufe_atom_mapping_matrix.items():
         score = scorer(

--- a/src/openfe/tests/setup/atom_mapping/test_perses_scorers.py
+++ b/src/openfe/tests/setup/atom_mapping/test_perses_scorers.py
@@ -18,7 +18,7 @@ USING_OLD_OFF = False
 @pytest.mark.xfail(not USING_OLD_OFF, reason="perses #1108")
 def test_perses_normalization_not_using_positions(gufe_atom_mapping_matrix):
     # now run the openfe equivalent with the same ligand atom _mappings
-    with pytest.raises(DeprecationWarning, match="default_perses_scorer"):
+    with pytest.warns(DeprecationWarning, match="default_perses_scorer"):
         scorer = perses_scorers.default_perses_scorer
     molecule_row = np.max(list(gufe_atom_mapping_matrix.keys())) + 1
     norm_scores = np.zeros([molecule_row, molecule_row])
@@ -42,7 +42,7 @@ def test_perses_normalization_not_using_positions(gufe_atom_mapping_matrix):
 @skip_if_missing("perses")
 @pytest.mark.xfail(not USING_OLD_OFF, reason="perses #1108")
 def test_perses_not_implemented_position_using(gufe_atom_mapping_matrix):
-    with pytest.raises(DeprecationWarning, match="default_perses_scorer"):
+    with pytest.warns(DeprecationWarning, match="default_perses_scorer"):
         scorer = perses_scorers.default_perses_scorer
 
     first_key = list(gufe_atom_mapping_matrix.keys())[0]
@@ -78,7 +78,7 @@ def test_perses_regression(gufe_atom_mapping_matrix):
     assert matrix.shape == (8, 8)
 
     # now run the openfe equivalent with the same ligand atom _mappings
-    with pytest.raises(DeprecationWarning, match="default_perses_scorer"):
+    with pytest.warns(DeprecationWarning, match="default_perses_scorer"):
         scorer = perses_scorers.default_perses_scorer
     scores = np.zeros_like(matrix)
     for (i, j), ligand_atom_mapping in gufe_atom_mapping_matrix.items():


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
to be dropped in 2.0
replaces https://github.com/OpenFreeEnergy/openfe/pull/1637
closes https://github.com/OpenFreeEnergy/openfe/issues/1854
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [x] All new code is appropriately documented (user-facing code _must_ have complete docstrings).
* [x] Added a ``news`` entry, or the changes are not user-facing.
* [x] Ran pre-commit: you can run [pre-commit](https://pre-commit.com) locally or comment on this PR with `pre-commit.ci autofix`.

Manual Tests: these are slow so don't need to be run every commit, only before merging and when relevant changes are made (generally at reviewer-discretion). 
* [ ] [GPU integration tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/gpu-integration-tests.yaml)
* [ ] [example notebook testing](https://github.com/OpenFreeEnergy/openfe/actions/workflows/test-example-notebooks.yaml)
* [ ] [packaging tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/test-feedstock-pkg-build.yaml): run this for any large feature PRs or PRs that add test data.


## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
