### PR TITLE
[WIP/DNM] Use `DummyContextCache` for SepTop for speedup of long range correction calculation

### DIFF
--- a/src/openfe/protocols/openmm_septop/base.py
+++ b/src/openfe/protocols/openmm_septop/base.py
@@ -985,6 +985,7 @@ class BaseSepTopRunUnit(gufe.ProtocolUnit):
         self,
         forcefield_settings: OpenMMSystemGeneratorFFSettings,
         engine_settings: OpenMMEngineSettings,
+        use_dummy: bool = True,
     ) -> tuple[openmmtools.cache.ContextCache, openmmtools.cache.ContextCache]:
         """
         Set the context caches based on the chosen platform
@@ -993,6 +994,8 @@ class BaseSepTopRunUnit(gufe.ProtocolUnit):
         ----------
         forcefield_settings: OpenMMSystemGeneratorFFSettings
         engine_settings : OpenMMEngineSettings
+        use_dummy: bool
+          Whether to use a dummy context cache
 
         Returns
         -------
@@ -1010,17 +1013,22 @@ class BaseSepTopRunUnit(gufe.ProtocolUnit):
             restrict_cpu_count=restrict_cpu,
         )
 
-        energy_context_cache = openmmtools.cache.ContextCache(
-            capacity=None,
-            time_to_live=None,
-            platform=platform,
-        )
+        if use_dummy:
+            energy_context_cache = openmmtools.cache.DummyContextCache(platform=platform)
+            sampler_context_cache = openmmtools.cache.DummyContextCache(platform=platform)
 
-        sampler_context_cache = openmmtools.cache.ContextCache(
-            capacity=None,
-            time_to_live=None,
-            platform=platform,
-        )
+        else:
+            energy_context_cache = openmmtools.cache.ContextCache(
+                capacity=None,
+                time_to_live=None,
+                platform=platform,
+            )
+
+            sampler_context_cache = openmmtools.cache.ContextCache(
+                capacity=None,
+                time_to_live=None,
+                platform=platform,
+            )
 
         return energy_context_cache, sampler_context_cache
 
@@ -1315,7 +1323,9 @@ class BaseSepTopRunUnit(gufe.ProtocolUnit):
         try:
             # 5. Get context caches
             energy_ctx_cache, sampler_ctx_cache = self._get_ctx_caches(
-                settings["forcefield_settings"], settings["engine_settings"]
+                settings["forcefield_settings"],
+                settings["engine_settings"],
+                use_dummy=True,
             )
 
             # 6. Get integrator


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] All new code is appropriately documented (user-facing code _must_ have complete docstrings).
* [ ] Added a ``news`` entry, or the changes are not user-facing.
* [ ] Ran pre-commit: you can run [pre-commit](https://pre-commit.com) locally or comment on this PR with `pre-commit.ci autofix`.

Manual Tests: these are slow so don't need to be run every commit, only before merging and when relevant changes are made (generally at reviewer-discretion). 
* [ ] [GPU integration tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/gpu-integration-tests.yaml)
* [ ] [example notebook testing](https://github.com/OpenFreeEnergy/openfe/actions/workflows/test-example-notebooks.yaml)
* [ ] [packaging tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/test-feedstock-pkg-build.yaml): run this for any large feature PRs or PRs that add test data.


## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
