### PR TITLE
tests: migrate from using deprecated `tmpdir` to preferred `tmp_path`

### DIFF
--- a/src/openfe/tests/conftest.py
+++ b/src/openfe/tests/conftest.py
@@ -161,9 +161,9 @@ def other_mapping():
 
 
 @pytest.fixture()
-def lomap_basic_test_files_dir(tmpdir_factory):
+def lomap_basic_test_files_dir(tmp_path_factory):
     # for lomap, which wants the files in a directory
-    lomap_files = tmpdir_factory.mktemp("lomap_files")
+    lomap_files = tmp_path_factory.mktemp("lomap_files")
     lomap_basic = "openfe.tests.data.lomap_basic"
 
     for f in resources.contents(lomap_basic):
@@ -171,7 +171,7 @@ def lomap_basic_test_files_dir(tmpdir_factory):
             continue
         stuff = resources.read_binary(lomap_basic, f)
 
-        with open(str(lomap_files.join(f)), "wb") as fout:
+        with open(lomap_files / f, "wb") as fout:
             fout.write(stuff)
 
     yield str(lomap_files)

--- a/src/openfe/tests/protocols/openmm_abfe/test_abfe_energies.py
+++ b/src/openfe/tests/protocols/openmm_abfe/test_abfe_energies.py
@@ -117,7 +117,7 @@ class TestT4EnergiesRegression:
         return system
 
     @pytest.fixture()
-    def t4_validation_data(self, benzene_modifications, T4_protein_component, tmpdir):
+    def t4_validation_data(self, benzene_modifications, T4_protein_component, tmp_path):
         s = openmm_afe.AbsoluteBindingProtocol.default_settings()
         s.protocol_repeats = 1
         s.engine_settings.compute_platform = "cpu"
@@ -149,9 +149,10 @@ class TestT4EnergiesRegression:
 
         complex_units = [u for u in dag.protocol_units if isinstance(u, ABFEComplexSetupUnit)]
 
-        with tmpdir.as_cwd():
-            results = complex_units[0].run(dry=True)
-            return results
+        results = complex_units[0].run(
+            dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path
+        )
+        return results
 
     @staticmethod
     def get_energy_components(

--- a/src/openfe/tests/protocols/openmm_abfe/test_abfe_protocol.py
+++ b/src/openfe/tests/protocols/openmm_abfe/test_abfe_protocol.py
@@ -386,100 +386,112 @@ class TestT4LysozymeDryRun:
             positions=positions,
         )
 
-    def test_complex_dry_run(self, complex_setup_units, complex_sim_units, settings, tmpdir):
-        with tmpdir.as_cwd():
-            setup_results = complex_setup_units[0].run(dry=True, verbose=True)
-            sim_results = complex_sim_units[0].run(
-                system=setup_results["alchem_system"],
-                positions=setup_results["debug_positions"],
-                selection_indices=setup_results["selection_indices"],
-                box_vectors=setup_results["box_vectors"],
-                alchemical_restraints=True,
-                dry=True,
-            )
+    def test_complex_dry_run(self, complex_setup_units, complex_sim_units, settings, tmp_path):
+        setup_results = complex_setup_units[0].run(
+            dry=True,
+            verbose=True,
+            scratch_basepath=tmp_path,
+            shared_basepath=tmp_path,
+        )
+        sim_results = complex_sim_units[0].run(
+            system=setup_results["alchem_system"],
+            positions=setup_results["debug_positions"],
+            selection_indices=setup_results["selection_indices"],
+            box_vectors=setup_results["box_vectors"],
+            alchemical_restraints=True,
+            dry=True,
+            scratch_basepath=tmp_path,
+            shared_basepath=tmp_path,
+        )
 
-            # Check the sampler
-            self._verify_sampler(sim_results["sampler"], complexed=True, settings=settings)
+        # Check the sampler
+        self._verify_sampler(sim_results["sampler"], complexed=True, settings=settings)
 
-            # Check the alchemical system
-            self._assert_expected_alchemical_forces(
-                setup_results["alchem_system"], complexed=True, settings=settings
-            )
-            self._test_dodecahedron_vectors(setup_results["alchem_system"])
+        # Check the alchemical system
+        self._assert_expected_alchemical_forces(
+            setup_results["alchem_system"], complexed=True, settings=settings
+        )
+        self._test_dodecahedron_vectors(setup_results["alchem_system"])
 
-            # Check the alchemical indices
-            expected_indices = [i + self.num_complex_atoms for i in range(self.num_solvent_atoms)]
-            assert expected_indices == setup_results["alchem_indices"]
+        # Check the alchemical indices
+        expected_indices = [i + self.num_complex_atoms for i in range(self.num_solvent_atoms)]
+        assert expected_indices == setup_results["alchem_indices"]
 
-            # Check the non-alchemical system
-            self._assert_expected_nonalchemical_forces(setup_results["standard_system"], settings)
-            self._test_dodecahedron_vectors(setup_results["standard_system"])
-            # Check the box vectors haven't changed (they shouldn't have because we didn't do MD)
-            assert_allclose(
-                from_openmm(setup_results["alchem_system"].getDefaultPeriodicBoxVectors()),
-                from_openmm(setup_results["standard_system"].getDefaultPeriodicBoxVectors()),
-            )
+        # Check the non-alchemical system
+        self._assert_expected_nonalchemical_forces(setup_results["standard_system"], settings)
+        self._test_dodecahedron_vectors(setup_results["standard_system"])
+        # Check the box vectors haven't changed (they shouldn't have because we didn't do MD)
+        assert_allclose(
+            from_openmm(setup_results["alchem_system"].getDefaultPeriodicBoxVectors()),
+            from_openmm(setup_results["standard_system"].getDefaultPeriodicBoxVectors()),
+        )
 
-            # Check the PDB
-            pdb = mdt.load_pdb(setup_results["pdb_structure"])
-            assert pdb.n_atoms == self.num_all_not_water
+        # Check the PDB
+        pdb = mdt.load_pdb(setup_results["pdb_structure"])
+        assert pdb.n_atoms == self.num_all_not_water
 
-            # Check energies
-            alchem_region = AlchemicalRegion(alchemical_atoms=setup_results["alchem_indices"])
-            self._test_energies(
-                reference_system=setup_results["standard_system"],
-                alchemical_system=setup_results["alchem_system"],
-                alchemical_regions=alchem_region,
-                positions=setup_results["debug_positions"],
-            )
+        # Check energies
+        alchem_region = AlchemicalRegion(alchemical_atoms=setup_results["alchem_indices"])
+        self._test_energies(
+            reference_system=setup_results["standard_system"],
+            alchemical_system=setup_results["alchem_system"],
+            alchemical_regions=alchem_region,
+            positions=setup_results["debug_positions"],
+        )
 
-    def test_solvent_dry_run(self, solvent_setup_units, solvent_sim_units, settings, tmpdir):
-        with tmpdir.as_cwd():
-            setup_results = solvent_setup_units[0].run(dry=True, verbose=True)
-            sim_results = solvent_sim_units[0].run(
-                system=setup_results["alchem_system"],
-                positions=setup_results["debug_positions"],
-                selection_indices=setup_results["selection_indices"],
-                box_vectors=setup_results["box_vectors"],
-                alchemical_restraints=False,
-                dry=True,
-            )
+    def test_solvent_dry_run(self, solvent_setup_units, solvent_sim_units, settings, tmp_path):
+        setup_results = solvent_setup_units[0].run(
+            dry=True,
+            verbose=True,
+            scratch_basepath=tmp_path,
+            shared_basepath=tmp_path,
+        )
+        sim_results = solvent_sim_units[0].run(
+            system=setup_results["alchem_system"],
+            positions=setup_results["debug_positions"],
+            selection_indices=setup_results["selection_indices"],
+            box_vectors=setup_results["box_vectors"],
+            alchemical_restraints=False,
+            dry=True,
+            scratch_basepath=tmp_path,
+            shared_basepath=tmp_path,
+        )
 
-            # Check the sampler
-            self._verify_sampler(sim_results["sampler"], complexed=False, settings=settings)
+        # Check the sampler
+        self._verify_sampler(sim_results["sampler"], complexed=False, settings=settings)
 
-            # Check the alchemical system
-            self._assert_expected_alchemical_forces(
-                setup_results["alchem_system"], complexed=False, settings=settings
-            )
-            self._test_cubic_vectors(setup_results["alchem_system"])
+        # Check the alchemical system
+        self._assert_expected_alchemical_forces(
+            setup_results["alchem_system"], complexed=False, settings=settings
+        )
+        self._test_cubic_vectors(setup_results["alchem_system"])
 
-            # Check the alchemical indices
-            expected_indices = [i for i in range(self.num_solvent_atoms)]
-            assert expected_indices == setup_results["alchem_indices"]
+        # Check the alchemical indices
+        expected_indices = [i for i in range(self.num_solvent_atoms)]
+        assert expected_indices == setup_results["alchem_indices"]
 
-            # Check the non-alchemical system
-            self._assert_expected_nonalchemical_forces(setup_results["standard_system"], settings)
-            self._test_cubic_vectors(setup_results["standard_system"])
-            # Check the box vectors haven't changed (they shouldn't have because we didn't do MD)
-            assert_allclose(
-                from_openmm(setup_results["alchem_system"].getDefaultPeriodicBoxVectors()),
-                from_openmm(setup_results["standard_system"].getDefaultPeriodicBoxVectors()),
-            )
+        # Check the non-alchemical system
+        self._assert_expected_nonalchemical_forces(setup_results["standard_system"], settings)
+        self._test_cubic_vectors(setup_results["standard_system"])
+        # Check the box vectors haven't changed (they shouldn't have because we didn't do MD)
+        assert_allclose(
+            from_openmm(setup_results["alchem_system"].getDefaultPeriodicBoxVectors()),
+            from_openmm(setup_results["standard_system"].getDefaultPeriodicBoxVectors()),
+        )
 
-            # Check the PDB
-            pdb = mdt.load_pdb(setup_results["pdb_structure"])
-            assert pdb.n_atoms == self.num_solvent_atoms
+        # Check the PDB
+        pdb = mdt.load_pdb(setup_results["pdb_structure"])
+        assert pdb.n_atoms == self.num_solvent_atoms
 
-            # Check energies
-            alchem_region = AlchemicalRegion(alchemical_atoms=setup_results["alchem_indices"])
+        # Check energies
+        alchem_region = AlchemicalRegion(alchemical_atoms=setup_results["alchem_indices"])
 
-            self._test_energies(
-                reference_system=setup_results["standard_system"],
-                alchemical_system=setup_results["alchem_system"],
-                alchemical_regions=alchem_region,
-                positions=setup_results["debug_positions"],
-            )
+        self._test_energies(
+            reference_system=setup_results["standard_system"],
+            alchemical_system=setup_results["alchem_system"],
+            alchemical_regions=alchem_region,
+            positions=setup_results["debug_positions"],
+        )
 
 
 @pytest.mark.slow
@@ -511,7 +523,7 @@ class TestT4LysozymeTIP4PExtraSettingsDryRun(TestT4LysozymeDryRun):
         return s
 
 
-def test_user_charges(benzene_modifications, T4_protein_component, tmpdir):
+def test_user_charges(benzene_modifications, T4_protein_component, tmp_path):
     s = openmm_afe.AbsoluteBindingProtocol.default_settings()
     s.protocol_repeats = 1
     s.engine_settings.compute_platform = "cpu"
@@ -558,24 +570,27 @@ def test_user_charges(benzene_modifications, T4_protein_component, tmpdir):
 
     complex_setup_units = _get_units(dag.protocol_units, UNIT_TYPES["complex"]["setup"])
 
-    with tmpdir.as_cwd():
-        results = complex_setup_units[0].run(dry=True)
+    results = complex_setup_units[0].run(
+        dry=True,
+        scratch_basepath=tmp_path,
+        shared_basepath=tmp_path,
+    )
 
-        system_nbf = [
-            f for f in results["standard_system"].getForces() if isinstance(f, NonbondedForce)
-        ][0]
-        alchem_system_nbf = [
-            f
-            for f in results["alchem_system"].getForces()
-            if isinstance(f, NonbondedForce)
-        ][0]  # fmt: skip
+    system_nbf = [
+        f for f in results["standard_system"].getForces() if isinstance(f, NonbondedForce)
+    ][0]
+    alchem_system_nbf = [
+        f
+        for f in results["alchem_system"].getForces()
+        if isinstance(f, NonbondedForce)
+    ][0]  # fmt: skip
 
-        for i in range(12):
-            # add 2613 to account for the protein
-            index = i + 2613
+    for i in range(12):
+        # add 2613 to account for the protein
+        index = i + 2613
 
-            c, s, e = system_nbf.getParticleParameters(index)
-            assert pytest.approx(prop_chgs[i]) == c.value_in_unit(ommunit.elementary_charge)
+        c, s, e = system_nbf.getParticleParameters(index)
+        assert pytest.approx(prop_chgs[i]) == c.value_in_unit(ommunit.elementary_charge)
 
-            offsets = alchem_system_nbf.getParticleParameterOffset(i)
-            assert pytest.approx(prop_chgs[i]) == offsets[2]
+        offsets = alchem_system_nbf.getParticleParameterOffset(i)
+        assert pytest.approx(prop_chgs[i]) == offsets[2]

--- a/src/openfe/tests/protocols/openmm_abfe/test_abfe_protocol_results.py
+++ b/src/openfe/tests/protocols/openmm_abfe/test_abfe_protocol_results.py
@@ -83,12 +83,12 @@ def patcher():
         yield
 
 
-def test_gather(benzene_complex_dag, patcher, tmpdir):
+def test_gather(benzene_complex_dag, patcher, tmp_path):
     # check that .gather behaves as expected
     dagres = gufe.protocols.execute_DAG(
         benzene_complex_dag,
-        shared_basedir=tmpdir,
-        scratch_basedir=tmpdir,
+        shared_basedir=tmp_path,
+        scratch_basedir=tmp_path,
         keep_shared=True,
     )
 
@@ -101,7 +101,7 @@ def test_gather(benzene_complex_dag, patcher, tmpdir):
     assert isinstance(res, openmm_afe.AbsoluteBindingProtocolResult)
 
 
-def test_unit_tagging(benzene_complex_dag, patcher, tmpdir):
+def test_unit_tagging(benzene_complex_dag, patcher, tmp_path):
     # test that executing the units includes correct gen and repeat info
 
     dag_units = benzene_complex_dag.protocol_units
@@ -117,19 +117,19 @@ def test_unit_tagging(benzene_complex_dag, patcher, tmpdir):
 
         for u in setup_units:
             rid = u.inputs["repeat_id"]
-            setup_results[rid] = u.execute(context=gufe.Context(tmpdir, tmpdir))
+            setup_results[rid] = u.execute(context=gufe.Context(tmp_path, tmp_path))
 
         for u in sim_units:
             rid = u.inputs["repeat_id"]
             sim_results[rid] = u.execute(
-                context=gufe.Context(tmpdir, tmpdir),
+                context=gufe.Context(tmp_path, tmp_path),
                 setup_results=setup_results[rid],
             )
 
         for u in a_units:
             rid = u.inputs["repeat_id"]
             analysis_results[rid] = u.execute(
-                context=gufe.Context(tmpdir, tmpdir),
+                context=gufe.Context(tmp_path, tmp_path),
                 setup_results=setup_results[rid],
                 simulation_results=sim_results[rid],
             )

--- a/src/openfe/tests/protocols/openmm_abfe/test_abfe_slow.py
+++ b/src/openfe/tests/protocols/openmm_abfe/test_abfe_slow.py
@@ -24,7 +24,7 @@ def test_openmm_run_engine(
     eg5_protein,
     eg5_ligands,
     eg5_cofactor,
-    tmpdir,
+    tmp_path,
 ):
     if platform not in available_platforms:
         pytest.skip(f"OpenMM Platform: {platform} not available")
@@ -92,7 +92,7 @@ def test_openmm_run_engine(
         mapping=None,
     )
 
-    cwd = pathlib.Path(str(tmpdir))
+    cwd = pathlib.Path(tmp_path)
     r = openfe.execute_DAG(dag, shared_basedir=cwd, scratch_basedir=cwd, keep_shared=True)
 
     assert r.ok()
@@ -104,7 +104,7 @@ def test_openmm_run_engine(
         # get the path to the simulation unit shared dict
         for pur in purs:
             if "Simulation" in pur.name:
-                sim_shared = tmpdir / f"shared_{pur.source_key}_attempt_0"
+                sim_shared = tmp_path / f"shared_{pur.source_key}_attempt_0"
                 assert sim_shared.exists()
                 assert pathlib.Path(sim_shared).is_dir()
 
@@ -113,7 +113,7 @@ def test_openmm_run_engine(
             if "Analysis" not in pur.name:
                 continue
 
-            unit_shared = tmpdir / f"shared_{pur.source_key}_attempt_0"
+            unit_shared = tmp_path / f"shared_{pur.source_key}_attempt_0"
             assert unit_shared.exists()
             assert pathlib.Path(unit_shared).is_dir()
 

--- a/src/openfe/tests/protocols/openmm_ahfe/test_ahfe_protocol.py
+++ b/src/openfe/tests/protocols/openmm_ahfe/test_ahfe_protocol.py
@@ -195,7 +195,7 @@ def _verify_alchemical_sterics_force_parameters(
 
 
 @pytest.mark.parametrize("method", ["repex", "sams", "independent", "InDePeNdENT"])
-def test_setup_dry_sim_vac_benzene(benzene_system, method, protocol_dry_settings, tmpdir):
+def test_setup_dry_sim_vac_benzene(benzene_system, method, protocol_dry_settings, tmp_path):
     protocol_dry_settings.vacuum_simulation_settings.sampler_method = method
 
     protocol = openmm_afe.AbsoluteSolvationProtocol(settings=protocol_dry_settings)
@@ -221,51 +221,52 @@ def test_setup_dry_sim_vac_benzene(benzene_system, method, protocol_dry_settings
     assert len(vac_setup_unit) == 1
     assert len(vac_sim_unit) == 1
 
-    with tmpdir.as_cwd():
-        setup_results = vac_setup_unit[0].run(dry=True)
-        sim_results = vac_sim_unit[0].run(
-            system=setup_results["alchem_system"],
-            positions=setup_results["debug_positions"],
-            selection_indices=setup_results["selection_indices"],
-            box_vectors=setup_results["box_vectors"],
-            alchemical_restraints=False,
-            dry=True,
-        )
+    setup_results = vac_setup_unit[0].run(
+        dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path
+    )
+    sim_results = vac_sim_unit[0].run(
+        system=setup_results["alchem_system"],
+        positions=setup_results["debug_positions"],
+        selection_indices=setup_results["selection_indices"],
+        box_vectors=setup_results["box_vectors"],
+        alchemical_restraints=False,
+        dry=True,
+    )
 
-        sampler = sim_results["sampler"]
-        assert isinstance(sampler, MultiStateSampler)
-        assert not sampler.is_periodic
-        assert sampler._thermodynamic_states[0].barostat is None
+    sampler = sim_results["sampler"]
+    assert isinstance(sampler, MultiStateSampler)
+    assert not sampler.is_periodic
+    assert sampler._thermodynamic_states[0].barostat is None
 
-        # standard system
-        system = setup_results["standard_system"]
-        assert system.getNumParticles() == 12
-        assert len(system.getForces()) == 4
-        _assert_num_forces(system, NonbondedForce, 1)
-        _assert_num_forces(system, HarmonicBondForce, 1)
-        _assert_num_forces(system, HarmonicAngleForce, 1)
-        _assert_num_forces(system, PeriodicTorsionForce, 1)
+    # standard system
+    system = setup_results["standard_system"]
+    assert system.getNumParticles() == 12
+    assert len(system.getForces()) == 4
+    _assert_num_forces(system, NonbondedForce, 1)
+    _assert_num_forces(system, HarmonicBondForce, 1)
+    _assert_num_forces(system, HarmonicAngleForce, 1)
+    _assert_num_forces(system, PeriodicTorsionForce, 1)
 
-        # alchemical system
-        alchem_system = setup_results["alchem_system"]
-        assert alchem_system.getNumParticles() == 12
-        assert len(alchem_system.getForces()) == 12
-        _assert_num_forces(alchem_system, NonbondedForce, 1)
-        _assert_num_forces(alchem_system, CustomNonbondedForce, 4)
-        _assert_num_forces(alchem_system, CustomBondForce, 4)
-        _assert_num_forces(alchem_system, HarmonicBondForce, 1)
-        _assert_num_forces(alchem_system, HarmonicAngleForce, 1)
-        _assert_num_forces(alchem_system, PeriodicTorsionForce, 1)
+    # alchemical system
+    alchem_system = setup_results["alchem_system"]
+    assert alchem_system.getNumParticles() == 12
+    assert len(alchem_system.getForces()) == 12
+    _assert_num_forces(alchem_system, NonbondedForce, 1)
+    _assert_num_forces(alchem_system, CustomNonbondedForce, 4)
+    _assert_num_forces(alchem_system, CustomBondForce, 4)
+    _assert_num_forces(alchem_system, HarmonicBondForce, 1)
+    _assert_num_forces(alchem_system, HarmonicAngleForce, 1)
+    _assert_num_forces(alchem_system, PeriodicTorsionForce, 1)
 
-        # Check some force contents
-        stericsf = [
-            f
-            for f in alchem_system.getForces()
-            if isinstance(f, CustomNonbondedForce) and "U_sterics" in f.getEnergyFunction()
-        ]
+    # Check some force contents
+    stericsf = [
+        f
+        for f in alchem_system.getForces()
+        if isinstance(f, CustomNonbondedForce) and "U_sterics" in f.getEnergyFunction()
+    ]
 
-        for force in stericsf:
-            _verify_alchemical_sterics_force_parameters(force)
+    for force in stericsf:
+        _verify_alchemical_sterics_force_parameters(force)
 
 
 @pytest.mark.parametrize(
@@ -276,7 +277,7 @@ def test_setup_dry_sim_vac_benzene(benzene_system, method, protocol_dry_settings
     ],
 )
 def test_alchemical_settings_setup_vacuum(
-    alpha, a, b, c, correction, benzene_system, protocol_dry_settings, tmpdir
+    alpha, a, b, c, correction, benzene_system, protocol_dry_settings, tmp_path
 ):
     """
     Test non default alchemical settings
@@ -309,36 +310,35 @@ def test_alchemical_settings_setup_vacuum(
     assert len(vac_setup_unit) == 1
     assert len(vac_sim_unit) == 1
 
-    with tmpdir.as_cwd():
-        results = vac_setup_unit[0].run(dry=True)
+    results = vac_setup_unit[0].run(dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path)
 
-        alchem_system = results["alchem_system"]
-        _assert_num_forces(alchem_system, NonbondedForce, 1)
-        _assert_num_forces(alchem_system, CustomNonbondedForce, 4)
-        _assert_num_forces(alchem_system, CustomBondForce, 4)
-        _assert_num_forces(alchem_system, HarmonicBondForce, 1)
-        _assert_num_forces(alchem_system, HarmonicAngleForce, 1)
-        _assert_num_forces(alchem_system, PeriodicTorsionForce, 1)
+    alchem_system = results["alchem_system"]
+    _assert_num_forces(alchem_system, NonbondedForce, 1)
+    _assert_num_forces(alchem_system, CustomNonbondedForce, 4)
+    _assert_num_forces(alchem_system, CustomBondForce, 4)
+    _assert_num_forces(alchem_system, HarmonicBondForce, 1)
+    _assert_num_forces(alchem_system, HarmonicAngleForce, 1)
+    _assert_num_forces(alchem_system, PeriodicTorsionForce, 1)
 
-        # Check some force contents
-        stericsf = [
-            f
-            for f in alchem_system.getForces()
-            if isinstance(f, CustomNonbondedForce) and "U_sterics" in f.getEnergyFunction()
-        ]
+    # Check some force contents
+    stericsf = [
+        f
+        for f in alchem_system.getForces()
+        if isinstance(f, CustomNonbondedForce) and "U_sterics" in f.getEnergyFunction()
+    ]
 
-        for force in stericsf:
-            _verify_alchemical_sterics_force_parameters(
-                force,
-                long_range=not correction,
-                alpha=alpha,
-                a=a,
-                b=b,
-                c=c,
-            )
+    for force in stericsf:
+        _verify_alchemical_sterics_force_parameters(
+            force,
+            long_range=not correction,
+            alpha=alpha,
+            a=a,
+            b=b,
+            c=c,
+        )
 
 
-def test_confgen_fail_AFE(benzene_system, protocol_dry_settings, tmpdir):
+def test_confgen_fail_AFE(benzene_system, protocol_dry_settings, tmp_path):
     # check system parametrisation works even if confgen fails
     protocol = openmm_afe.AbsoluteSolvationProtocol(settings=protocol_dry_settings)
 
@@ -356,14 +356,17 @@ def test_confgen_fail_AFE(benzene_system, protocol_dry_settings, tmpdir):
     prot_units = list(dag.protocol_units)
     vac_setup_unit = _get_units(prot_units, UNIT_TYPES["vacuum"]["setup"])
 
-    with tmpdir.as_cwd():
-        with mock.patch("rdkit.Chem.AllChem.EmbedMultipleConfs", return_value=0):
-            # If this worked, the system will have been built
-            system = vac_setup_unit[0].run(dry=True)["alchem_system"]
-            assert system
+    with mock.patch("rdkit.Chem.AllChem.EmbedMultipleConfs", return_value=0):
+        # If this worked, the system will have been built
+        system = vac_setup_unit[0].run(
+            dry=True,
+            scratch_basepath=tmp_path,
+            shared_basepath=tmp_path,
+        )["alchem_system"]
+        assert system
 
 
-def test_setup_solv_benzene(benzene_system, protocol_dry_settings, tmpdir):
+def test_setup_solv_benzene(benzene_system, protocol_dry_settings, tmp_path):
     protocol_dry_settings.solvent_output_settings.output_indices = "resname UNK"
 
     protocol = openmm_afe.AbsoluteSolvationProtocol(settings=protocol_dry_settings)
@@ -386,24 +389,27 @@ def test_setup_solv_benzene(benzene_system, protocol_dry_settings, tmpdir):
 
     assert len(sol_setup_unit) == len(sol_sim_unit) == 1
 
-    with tmpdir.as_cwd():
-        setup_results = sol_setup_unit[0].run(dry=True)
-        sim_results = sol_sim_unit[0].run(
-            system=setup_results["alchem_system"],
-            positions=setup_results["debug_positions"],
-            selection_indices=setup_results["selection_indices"],
-            box_vectors=setup_results["box_vectors"],
-            alchemical_restraints=False,
-            dry=True,
-        )
-        sol_sampler = sim_results["sampler"]
-        assert sol_sampler.is_periodic
+    setup_results = sol_setup_unit[0].run(
+        dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path
+    )
+    sim_results = sol_sim_unit[0].run(
+        system=setup_results["alchem_system"],
+        positions=setup_results["debug_positions"],
+        selection_indices=setup_results["selection_indices"],
+        box_vectors=setup_results["box_vectors"],
+        alchemical_restraints=False,
+        dry=True,
+        scratch_basepath=tmp_path,
+        shared_basepath=tmp_path,
+    )
+    sol_sampler = sim_results["sampler"]
+    assert sol_sampler.is_periodic
 
-        pdb = mdt.load_pdb(setup_results["pdb_structure"])
-        assert pdb.n_atoms == 12
+    pdb = mdt.load_pdb(setup_results["pdb_structure"])
+    assert pdb.n_atoms == 12
 
 
-def test_dry_run_vsite_fail(benzene_system, tmpdir, protocol_dry_settings):
+def test_dry_run_vsite_fail(benzene_system, tmp_path, protocol_dry_settings):
     protocol_dry_settings.vacuum_forcefield_settings.forcefields = [
         "amber/ff14SB.xml",  # ff14SB protein force field
         "amber/tip4pew_standard.xml",  # FF we are testing with the fun VS
@@ -435,20 +441,23 @@ def test_dry_run_vsite_fail(benzene_system, tmpdir, protocol_dry_settings):
     sol_setup_unit = _get_units(prot_units, UNIT_TYPES["solvent"]["setup"])
     sol_sim_unit = _get_units(prot_units, UNIT_TYPES["solvent"]["sim"])
 
-    with tmpdir.as_cwd():
-        setup_results = sol_setup_unit[0].run(dry=True)
-        with pytest.raises(ValueError, match="are unstable"):
-            sim_results = sol_sim_unit[0].run(
-                system=setup_results["alchem_system"],
-                positions=setup_results["debug_positions"],
-                selection_indices=setup_results["selection_indices"],
-                box_vectors=setup_results["box_vectors"],
-                alchemical_restraints=False,
-                dry=True,
-            )
+    setup_results = sol_setup_unit[0].run(
+        dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path
+    )
+    with pytest.raises(ValueError, match="are unstable"):
+        sim_results = sol_sim_unit[0].run(
+            system=setup_results["alchem_system"],
+            positions=setup_results["debug_positions"],
+            selection_indices=setup_results["selection_indices"],
+            box_vectors=setup_results["box_vectors"],
+            alchemical_restraints=False,
+            dry=True,
+            scratch_basepath=tmp_path,
+            shared_basepath=tmp_path,
+        )
 
 
-def test_setup_dry_sim_solv_benzene_tip4p(benzene_system, protocol_dry_settings, tmpdir):
+def test_setup_dry_sim_solv_benzene_tip4p(benzene_system, protocol_dry_settings, tmp_path):
     protocol_dry_settings.vacuum_forcefield_settings.forcefields = [
         "amber/ff14SB.xml",  # ff14SB protein force field
         "amber/tip4pew_standard.xml",  # FF we are testing with the fun VS
@@ -480,21 +489,24 @@ def test_setup_dry_sim_solv_benzene_tip4p(benzene_system, protocol_dry_settings,
     sol_setup_units = _get_units(prot_units, UNIT_TYPES["solvent"]["setup"])
     sol_sim_units = _get_units(prot_units, UNIT_TYPES["solvent"]["sim"])
 
-    with tmpdir.as_cwd():
-        setup_results = sol_setup_units[0].run(dry=True)
-        sim_results = sol_sim_units[0].run(
-            system=setup_results["alchem_system"],
-            positions=setup_results["debug_positions"],
-            selection_indices=setup_results["selection_indices"],
-            box_vectors=setup_results["box_vectors"],
-            alchemical_restraints=False,
-            dry=True,
-        )
-        sol_sampler = sim_results["sampler"]
-        assert sol_sampler.is_periodic
+    setup_results = sol_setup_units[0].run(
+        dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path
+    )
+    sim_results = sol_sim_units[0].run(
+        system=setup_results["alchem_system"],
+        positions=setup_results["debug_positions"],
+        selection_indices=setup_results["selection_indices"],
+        box_vectors=setup_results["box_vectors"],
+        alchemical_restraints=False,
+        dry=True,
+        scratch_basepath=tmp_path,
+        shared_basepath=tmp_path,
+    )
+    sol_sampler = sim_results["sampler"]
+    assert sol_sampler.is_periodic
 
 
-def test_dry_run_solv_benzene_noncubic(benzene_system, protocol_dry_settings, tmpdir):
+def test_dry_run_solv_benzene_noncubic(benzene_system, protocol_dry_settings, tmp_path):
     protocol_dry_settings.solvation_settings.solvent_padding = 1.5 * offunit.nanometer
     protocol_dry_settings.solvation_settings.box_shape = "dodecahedron"
 
@@ -515,25 +527,24 @@ def test_dry_run_solv_benzene_noncubic(benzene_system, protocol_dry_settings, tm
 
     sol_setup_units = _get_units(prot_units, UNIT_TYPES["solvent"]["setup"])
 
-    with tmpdir.as_cwd():
-        results = sol_setup_units[0].run(dry=True)
-        system = results["alchem_system"]
+    results = sol_setup_units[0].run(dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path)
+    system = results["alchem_system"]
 
-        vectors = system.getDefaultPeriodicBoxVectors()
-        width = float(from_openmm(vectors)[0][0].to("nanometer").m)
+    vectors = system.getDefaultPeriodicBoxVectors()
+    width = float(from_openmm(vectors)[0][0].to("nanometer").m)
 
-        # dodecahedron has the following shape:
-        # [width, 0, 0], [0, width, 0], [0.5, 0.5, 0.5 * sqrt(2)] * width
+    # dodecahedron has the following shape:
+    # [width, 0, 0], [0, width, 0], [0.5, 0.5, 0.5 * sqrt(2)] * width
 
-        expected_vectors = [
-            [width, 0, 0],
-            [0, width, 0],
-            [0.5 * width, 0.5 * width, 0.5 * sqrt(2) * width],
-        ] * offunit.nanometer
-        assert_allclose(expected_vectors, from_openmm(vectors))
+    expected_vectors = [
+        [width, 0, 0],
+        [0, width, 0],
+        [0.5 * width, 0.5 * width, 0.5 * sqrt(2) * width],
+    ] * offunit.nanometer
+    assert_allclose(expected_vectors, from_openmm(vectors))
 
 
-def test_dry_run_solv_user_charges_benzene(benzene_modifications, protocol_dry_settings, tmpdir):
+def test_dry_run_solv_user_charges_benzene(benzene_modifications, protocol_dry_settings, tmp_path):
     """
     Create a test system with fictitious user supplied charges and
     ensure that they are properly passed through to the constructed
@@ -578,36 +589,32 @@ def test_dry_run_solv_user_charges_benzene(benzene_modifications, protocol_dry_s
     sol_setup_units = _get_units(prot_units, UNIT_TYPES["solvent"]["setup"])
 
     # check sol_unit charges
-    with tmpdir.as_cwd():
-        results = sol_setup_units[0].run(dry=True)
-        system = results["alchem_system"]
-        nonbond = [f for f in system.getForces() if isinstance(f, NonbondedForce)]
+    results = sol_setup_units[0].run(dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path)
+    system = results["alchem_system"]
+    nonbond = [f for f in system.getForces() if isinstance(f, NonbondedForce)]
 
-        assert len(nonbond) == 1
+    assert len(nonbond) == 1
 
-        # loop through the 12 benzene atoms
-        # partial charge is stored in the offset
-        for i in range(12):
-            offsets = nonbond[0].getParticleParameterOffset(i)
-            c = ensure_quantity(offsets[2], "openff")
-            assert pytest.approx(c) == prop_chgs[i]
+    # loop through the 12 benzene atoms
+    # partial charge is stored in the offset
+    for i in range(12):
+        offsets = nonbond[0].getParticleParameterOffset(i)
+        c = ensure_quantity(offsets[2], "openff")
+        assert pytest.approx(c) == prop_chgs[i]
 
     # check vac_unit charges
-    with tmpdir.as_cwd():
-        results = vac_setup_units[0].run(dry=True)
-        system = results["alchem_system"]
-        nonbond = [f for f in system.getForces() if isinstance(f, CustomNonbondedForce)]
-        assert len(nonbond) == 4
+    results = vac_setup_units[0].run(dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path)
+    system = results["alchem_system"]
+    nonbond = [f for f in system.getForces() if isinstance(f, CustomNonbondedForce)]
+    assert len(nonbond) == 4
 
-        custom_elec = [
-            n for n in nonbond if n.getGlobalParameterName(0) == "lambda_electrostatics"
-        ][0]
+    custom_elec = [n for n in nonbond if n.getGlobalParameterName(0) == "lambda_electrostatics"][0]
 
-        # loop through the 12 benzene atoms
-        for i in range(12):
-            c, s = custom_elec.getParticleParameters(i)
-            c = ensure_quantity(c, "openff")
-            assert pytest.approx(c) == prop_chgs[i]
+    # loop through the 12 benzene atoms
+    for i in range(12):
+        c, s = custom_elec.getParticleParameters(i)
+        c = ensure_quantity(c, "openff")
+        assert pytest.approx(c) == prop_chgs[i]
 
 
 @pytest.mark.parametrize(
@@ -638,7 +645,7 @@ def test_dry_run_solv_user_charges_benzene(benzene_modifications, protocol_dry_s
     ],
 )
 def test_dry_run_charge_backends(
-    CN_molecule, tmpdir, method, backend, ref_key, protocol_dry_settings, am1bcc_ref_charges
+    CN_molecule, tmp_path, method, backend, ref_key, protocol_dry_settings, am1bcc_ref_charges
 ):
     """
     Check that partial charge generation with different backends
@@ -663,20 +670,17 @@ def test_dry_run_charge_backends(
     vac_setup_units = _get_units(prot_units, UNIT_TYPES["vacuum"]["setup"])
 
     # check vac_unit charges
-    with tmpdir.as_cwd():
-        results = vac_setup_units[0].run(dry=True)
-        system = results["alchem_system"]
-        nonbond = [f for f in system.getForces() if isinstance(f, CustomNonbondedForce)]
-        assert len(nonbond) == 4
+    results = vac_setup_units[0].run(dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path)
+    system = results["alchem_system"]
+    nonbond = [f for f in system.getForces() if isinstance(f, CustomNonbondedForce)]
+    assert len(nonbond) == 4
 
-        custom_elec = [
-            n for n in nonbond if n.getGlobalParameterName(0) == "lambda_electrostatics"
-        ][0]
+    custom_elec = [n for n in nonbond if n.getGlobalParameterName(0) == "lambda_electrostatics"][0]
 
-        charges = []
-        for i in range(system.getNumParticles()):
-            c, s = custom_elec.getParticleParameters(i)
-            charges.append(c)
+    charges = []
+    for i in range(system.getNumParticles()):
+        c, s = custom_elec.getParticleParameters(i)
+        charges.append(c)
 
     assert_allclose(
         am1bcc_ref_charges[ref_key],
@@ -710,7 +714,7 @@ def test_dry_run_vacuum_write_frequency(
     positions_write_frequency,
     velocities_write_frequency,
     protocol_dry_settings,
-    tmpdir,
+    tmp_path,
 ):
     protocol_dry_settings.solvent_output_settings.output_indices = "resname UNK"
     protocol_dry_settings.solvent_output_settings.positions_write_frequency = positions_write_frequency  # fmt: skip
@@ -741,23 +745,28 @@ def test_dry_run_vacuum_write_frequency(
         setup_units = _get_units(prot_units, UNIT_TYPES[phase]["setup"])
         sim_units = _get_units(prot_units, UNIT_TYPES[phase]["sim"])
 
-        with tmpdir.as_cwd():
-            setup_results = setup_units[0].run(dry=True)
-            sim_results = sim_units[0].run(
-                system=setup_results["alchem_system"],
-                positions=setup_results["debug_positions"],
-                selection_indices=setup_results["selection_indices"],
-                box_vectors=setup_results["box_vectors"],
-                alchemical_restraints=False,
-                dry=True,
-            )
-            sampler = sim_results["sampler"]
-            reporter = sampler._reporter
-            if positions_write_frequency:
-                assert reporter.position_interval == positions_write_frequency.m
-            else:
-                assert reporter.position_interval == 0
-            if velocities_write_frequency:
-                assert reporter.velocity_interval == velocities_write_frequency.m
-            else:
-                assert reporter.velocity_interval == 0
+        setup_results = setup_units[0].run(
+            dry=True,
+            scratch_basepath=tmp_path,
+            shared_basepath=tmp_path,
+        )
+        sim_results = sim_units[0].run(
+            system=setup_results["alchem_system"],
+            positions=setup_results["debug_positions"],
+            selection_indices=setup_results["selection_indices"],
+            box_vectors=setup_results["box_vectors"],
+            alchemical_restraints=False,
+            dry=True,
+            scratch_basepath=tmp_path,
+            shared_basepath=tmp_path,
+        )
+        sampler = sim_results["sampler"]
+        reporter = sampler._reporter
+        if positions_write_frequency:
+            assert reporter.position_interval == positions_write_frequency.m
+        else:
+            assert reporter.position_interval == 0
+        if velocities_write_frequency:
+            assert reporter.velocity_interval == velocities_write_frequency.m
+        else:
+            assert reporter.velocity_interval == 0

--- a/src/openfe/tests/protocols/openmm_ahfe/test_ahfe_protocol_results.py
+++ b/src/openfe/tests/protocols/openmm_ahfe/test_ahfe_protocol_results.py
@@ -103,12 +103,12 @@ def patcher():
         yield
 
 
-def test_gather(benzene_solvation_dag, patcher, tmpdir):
+def test_gather(benzene_solvation_dag, patcher, tmp_path):
     # check that .gather behaves as expected
     dagres = gufe.protocols.execute_DAG(
         benzene_solvation_dag,
-        shared_basedir=tmpdir,
-        scratch_basedir=tmpdir,
+        shared_basedir=tmp_path,
+        scratch_basedir=tmp_path,
         keep_shared=True,
     )
 
@@ -121,7 +121,7 @@ def test_gather(benzene_solvation_dag, patcher, tmpdir):
     assert isinstance(res, openmm_afe.AbsoluteSolvationProtocolResult)
 
 
-def test_unit_tagging(benzene_solvation_dag, patcher, tmpdir):
+def test_unit_tagging(benzene_solvation_dag, patcher, tmp_path):
     # test that executing the units includes correct gen and repeat info
 
     dag_units = benzene_solvation_dag.protocol_units
@@ -137,19 +137,19 @@ def test_unit_tagging(benzene_solvation_dag, patcher, tmpdir):
 
         for u in setup_units:
             rid = u.inputs["repeat_id"]
-            setup_results[rid] = u.execute(context=gufe.Context(tmpdir, tmpdir))
+            setup_results[rid] = u.execute(context=gufe.Context(tmp_path, tmp_path))
 
         for u in sim_units:
             rid = u.inputs["repeat_id"]
             sim_results[rid] = u.execute(
-                context=gufe.Context(tmpdir, tmpdir),
+                context=gufe.Context(tmp_path, tmp_path),
                 setup_results=setup_results[rid],
             )
 
         for u in a_units:
             rid = u.inputs["repeat_id"]
             analysis_results[rid] = u.execute(
-                context=gufe.Context(tmpdir, tmpdir),
+                context=gufe.Context(tmp_path, tmp_path),
                 setup_results=setup_results[rid],
                 simulation_results=sim_results[rid],
             )

--- a/src/openfe/tests/protocols/openmm_ahfe/test_ahfe_resume.py
+++ b/src/openfe/tests/protocols/openmm_ahfe/test_ahfe_resume.py
@@ -175,24 +175,23 @@ class TestCheckpointResuming:
         return positions
 
     @staticmethod
-    def _copy_simfiles(cwd: pathlib.Path, filepath):
-        shutil.copyfile(filepath, f"{cwd}/{filepath.name}")
+    def _copy_simfiles(tmp_path: pathlib.Path, filepath):
+        shutil.copyfile(filepath, f"{tmp_path}/{filepath.name}")
 
     @pytest.mark.integration
     def test_resume(
-        self, protocol_dag, ahfe_solv_trajectory_path, ahfe_solv_checkpoint_path, tmpdir
+        self, protocol_dag, ahfe_solv_trajectory_path, ahfe_solv_checkpoint_path, tmp_path
     ):
         """
         Attempt to resume a simulation unit with pre-existing checkpoint &
         trajectory files.
         """
-        cwd = pathlib.Path(str(tmpdir))
-        self._copy_simfiles(cwd, ahfe_solv_trajectory_path)
-        self._copy_simfiles(cwd, ahfe_solv_checkpoint_path)
+        self._copy_simfiles(tmp_path, ahfe_solv_trajectory_path)
+        self._copy_simfiles(tmp_path, ahfe_solv_checkpoint_path)
 
         # 1. Check that the trajectory / checkpoint contain what we expect
         reporter = MultiStateReporter(
-            f"{cwd}/solvent.nc",
+            f"{tmp_path}/solvent.nc",
             checkpoint_storage="solvent_checkpoint.nc",
         )
         sampler = ReplicaExchangeSampler.from_storage(reporter)
@@ -217,8 +216,8 @@ class TestCheckpointResuming:
         # Dry run the setup since it'll be easier to use the objects directly
         setup_results = setup_unit.run(
             dry=True,
-            scratch_basepath=cwd,
-            shared_basepath=cwd,
+            scratch_basepath=tmp_path,
+            shared_basepath=tmp_path,
         )
 
         # Now we run the simultion in resume mode
@@ -228,21 +227,21 @@ class TestCheckpointResuming:
             selection_indices=setup_results["selection_indices"],
             box_vectors=setup_results["box_vectors"],
             alchemical_restraints=False,
-            scratch_basepath=cwd,
-            shared_basepath=cwd,
+            scratch_basepath=tmp_path,
+            shared_basepath=tmp_path,
         )
 
         # Finally we analyze the results
         _ = analysis_unit.run(
             trajectory=sim_results["trajectory"],
             checkpoint=sim_results["checkpoint"],
-            scratch_basepath=cwd,
-            shared_basepath=cwd,
+            scratch_basepath=tmp_path,
+            shared_basepath=tmp_path,
         )
 
         # Analyze the trajectory / checkpoint again
         reporter = MultiStateReporter(
-            f"{cwd}/solvent.nc",
+            f"{tmp_path}/solvent.nc",
             checkpoint_storage="solvent_checkpoint.nc",
         )
 
@@ -264,12 +263,12 @@ class TestCheckpointResuming:
         del sampler
 
         # Check the free energy plots are there
-        mbar_overlap_file = cwd / "mbar_overlap_matrix.png"
+        mbar_overlap_file = tmp_path / "mbar_overlap_matrix.png"
         assert (mbar_overlap_file).exists()
 
     @pytest.mark.slow
     def test_resume_fail_particles(
-        self, protocol_dag, ahfe_solv_trajectory_path, ahfe_solv_checkpoint_path, tmpdir
+        self, protocol_dag, ahfe_solv_trajectory_path, ahfe_solv_checkpoint_path, tmp_path
     ):
         """
         Test that the run unit will fail with a system incompatible
@@ -277,17 +276,18 @@ class TestCheckpointResuming:
 
         Here we check that we don't have the same particles / mass.
         """
-        # define a temp directory path & copy files
-        cwd = pathlib.Path(str(tmpdir))
-        self._copy_simfiles(cwd, ahfe_solv_trajectory_path)
-        self._copy_simfiles(cwd, ahfe_solv_checkpoint_path)
+        # copy files
+        self._copy_simfiles(tmp_path, ahfe_solv_trajectory_path)
+        self._copy_simfiles(tmp_path, ahfe_solv_checkpoint_path)
 
         pus = list(protocol_dag.protocol_units)
         setup_unit = _get_units(pus, openmm_afe.AHFESolventSetupUnit)[0]
         sim_unit = _get_units(pus, openmm_afe.AHFESolventSimUnit)[0]
 
         # Dry run the setup since it'll be easier to use the objects directly
-        setup_results = setup_unit.run(dry=True, scratch_basepath=cwd, shared_basepath=cwd)
+        setup_results = setup_unit.run(
+            dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path
+        )
 
         # Create a fake system where we will add a particle
         fake_system = copy.deepcopy(setup_results["alchem_system"])
@@ -302,13 +302,13 @@ class TestCheckpointResuming:
                 selection_indices=setup_results["selection_indices"],
                 box_vectors=setup_results["box_vectors"],
                 alchemical_restraints=False,
-                scratch_basepath=cwd,
-                shared_basepath=cwd,
+                scratch_basepath=tmp_path,
+                shared_basepath=tmp_path,
             )
 
     @pytest.mark.slow
     def test_resume_fail_constraints(
-        self, protocol_dag, ahfe_solv_trajectory_path, ahfe_solv_checkpoint_path, tmpdir
+        self, protocol_dag, ahfe_solv_trajectory_path, ahfe_solv_checkpoint_path, tmp_path
     ):
         """
         Test that the run unit will fail with a system incompatible
@@ -316,17 +316,18 @@ class TestCheckpointResuming:
 
         Here we check that we don't have the same constraints.
         """
-        # define a temp directory path & copy files
-        cwd = pathlib.Path(str(tmpdir))
-        self._copy_simfiles(cwd, ahfe_solv_trajectory_path)
-        self._copy_simfiles(cwd, ahfe_solv_checkpoint_path)
+        # copy files
+        self._copy_simfiles(tmp_path, ahfe_solv_trajectory_path)
+        self._copy_simfiles(tmp_path, ahfe_solv_checkpoint_path)
 
         pus = list(protocol_dag.protocol_units)
         setup_unit = _get_units(pus, openmm_afe.AHFESolventSetupUnit)[0]
         sim_unit = _get_units(pus, openmm_afe.AHFESolventSimUnit)[0]
 
         # Dry run the setup since it'll be easier to use the objects directly
-        setup_results = setup_unit.run(dry=True, scratch_basepath=cwd, shared_basepath=cwd)
+        setup_results = setup_unit.run(
+            dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path
+        )
 
         # Create a fake system without constraints
         fake_system = copy.deepcopy(setup_results["alchem_system"])
@@ -343,13 +344,13 @@ class TestCheckpointResuming:
                 selection_indices=setup_results["selection_indices"],
                 box_vectors=setup_results["box_vectors"],
                 alchemical_restraints=False,
-                scratch_basepath=cwd,
-                shared_basepath=cwd,
+                scratch_basepath=tmp_path,
+                shared_basepath=tmp_path,
             )
 
     @pytest.mark.slow
     def test_resume_fail_forces(
-        self, protocol_dag, ahfe_solv_trajectory_path, ahfe_solv_checkpoint_path, tmpdir
+        self, protocol_dag, ahfe_solv_trajectory_path, ahfe_solv_checkpoint_path, tmp_path
     ):
         """
         Test that the run unit will fail with a system incompatible
@@ -357,17 +358,18 @@ class TestCheckpointResuming:
 
         Here we check we don't have the same forces.
         """
-        # define a temp directory path & copy files
-        cwd = pathlib.Path(str(tmpdir))
-        self._copy_simfiles(cwd, ahfe_solv_trajectory_path)
-        self._copy_simfiles(cwd, ahfe_solv_checkpoint_path)
+        # copy files
+        self._copy_simfiles(tmp_path, ahfe_solv_trajectory_path)
+        self._copy_simfiles(tmp_path, ahfe_solv_checkpoint_path)
 
         pus = list(protocol_dag.protocol_units)
         setup_unit = _get_units(pus, openmm_afe.AHFESolventSetupUnit)[0]
         sim_unit = _get_units(pus, openmm_afe.AHFESolventSimUnit)[0]
 
         # Dry run the setup since it'll be easier to use the objects directly
-        setup_results = setup_unit.run(dry=True, scratch_basepath=cwd, shared_basepath=cwd)
+        setup_results = setup_unit.run(
+            dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path
+        )
 
         # Create a fake system without the last force
         fake_system = copy.deepcopy(setup_results["alchem_system"])
@@ -382,14 +384,19 @@ class TestCheckpointResuming:
                 selection_indices=setup_results["selection_indices"],
                 box_vectors=setup_results["box_vectors"],
                 alchemical_restraints=False,
-                scratch_basepath=cwd,
-                shared_basepath=cwd,
+                scratch_basepath=tmp_path,
+                shared_basepath=tmp_path,
             )
 
     @pytest.mark.slow
     @pytest.mark.parametrize("forcetype", [openmm.NonbondedForce, openmm.MonteCarloBarostat])
     def test_resume_differ_forces(
-        self, forcetype, protocol_dag, ahfe_solv_trajectory_path, ahfe_solv_checkpoint_path, tmpdir
+        self,
+        forcetype,
+        protocol_dag,
+        ahfe_solv_trajectory_path,
+        ahfe_solv_checkpoint_path,
+        tmp_path,
     ):
         """
         Test that the run unit will fail with a system incompatible
@@ -397,17 +404,18 @@ class TestCheckpointResuming:
 
         Here we check we have a different force
         """
-        # define a temp directory path & copy files
-        cwd = pathlib.Path(str(tmpdir))
-        self._copy_simfiles(cwd, ahfe_solv_trajectory_path)
-        self._copy_simfiles(cwd, ahfe_solv_checkpoint_path)
+        # copy files
+        self._copy_simfiles(tmp_path, ahfe_solv_trajectory_path)
+        self._copy_simfiles(tmp_path, ahfe_solv_checkpoint_path)
 
         pus = list(protocol_dag.protocol_units)
         setup_unit = _get_units(pus, openmm_afe.AHFESolventSetupUnit)[0]
         sim_unit = _get_units(pus, openmm_afe.AHFESolventSimUnit)[0]
 
         # Dry run the setup since it'll be easier to use the objects directly
-        setup_results = setup_unit.run(dry=True, scratch_basepath=cwd, shared_basepath=cwd)
+        setup_results = setup_unit.run(
+            dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path
+        )
 
         # Create a fake system with the fake forcetype
         fake_system = copy.deepcopy(setup_results["alchem_system"])
@@ -438,40 +446,41 @@ class TestCheckpointResuming:
                 selection_indices=setup_results["selection_indices"],
                 box_vectors=setup_results["box_vectors"],
                 alchemical_restraints=False,
-                scratch_basepath=cwd,
-                shared_basepath=cwd,
+                scratch_basepath=tmp_path,
+                shared_basepath=tmp_path,
             )
 
     @pytest.mark.slow
     @pytest.mark.parametrize("bad_file", ["trajectory", "checkpoint"])
     def test_resume_bad_files(
-        self, protocol_dag, ahfe_solv_trajectory_path, ahfe_solv_checkpoint_path, bad_file, tmpdir
+        self, protocol_dag, ahfe_solv_trajectory_path, ahfe_solv_checkpoint_path, bad_file, tmp_path
     ):
         """
         Test what happens when you have a bad trajectory and/or checkpoint
         files.
         """
-        # define a temp directory path & copy files
-        cwd = pathlib.Path(str(tmpdir))
+        # copy files
 
         if bad_file == "trajectory":
-            with open(f"{cwd}/solvent.nc", "w") as f:
+            with open(f"{tmp_path}/solvent.nc", "w") as f:
                 f.write("foo")
         else:
-            self._copy_simfiles(cwd, ahfe_solv_trajectory_path)
+            self._copy_simfiles(tmp_path, ahfe_solv_trajectory_path)
 
         if bad_file == "checkpoint":
-            with open(f"{cwd}/solvent_checkpoint.nc", "w") as f:
+            with open(f"{tmp_path}/solvent_checkpoint.nc", "w") as f:
                 f.write("bar")
         else:
-            self._copy_simfiles(cwd, ahfe_solv_checkpoint_path)
+            self._copy_simfiles(tmp_path, ahfe_solv_checkpoint_path)
 
         pus = list(protocol_dag.protocol_units)
         setup_unit = _get_units(pus, openmm_afe.AHFESolventSetupUnit)[0]
         sim_unit = _get_units(pus, openmm_afe.AHFESolventSimUnit)[0]
 
         # Dry run the setup since it'll be easier to use the objects directly
-        setup_results = setup_unit.run(dry=True, scratch_basepath=cwd, shared_basepath=cwd)
+        setup_results = setup_unit.run(
+            dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path
+        )
 
         with pytest.raises(OSError, match="Unknown file format"):
             _ = sim_unit.run(
@@ -480,6 +489,6 @@ class TestCheckpointResuming:
                 selection_indices=setup_results["selection_indices"],
                 box_vectors=setup_results["box_vectors"],
                 alchemical_restraints=False,
-                scratch_basepath=cwd,
-                shared_basepath=cwd,
+                scratch_basepath=tmp_path,
+                shared_basepath=tmp_path,
             )

--- a/src/openfe/tests/protocols/openmm_ahfe/test_ahfe_resume.py
+++ b/src/openfe/tests/protocols/openmm_ahfe/test_ahfe_resume.py
@@ -175,10 +175,9 @@ class TestCheckpointResuming:
         return positions
 
     @staticmethod
-    def _copy_simfiles(tmp_path: pathlib.Path, filepath):
-        shutil.copyfile(filepath, f"{tmp_path}/{filepath.name}")
+    def _copy_simfiles(cwd: pathlib.Path, filepath):
+        shutil.copyfile(filepath, f"{cwd}/{filepath.name}")
 
-    @pytest.mark.integration
     def test_resume(
         self, protocol_dag, ahfe_solv_trajectory_path, ahfe_solv_checkpoint_path, tmp_path
     ):
@@ -191,7 +190,7 @@ class TestCheckpointResuming:
 
         # 1. Check that the trajectory / checkpoint contain what we expect
         reporter = MultiStateReporter(
-            f"{tmp_path}/solvent.nc",
+            tmp_path / "solvent.nc",
             checkpoint_storage="solvent_checkpoint.nc",
         )
         sampler = ReplicaExchangeSampler.from_storage(reporter)
@@ -241,7 +240,7 @@ class TestCheckpointResuming:
 
         # Analyze the trajectory / checkpoint again
         reporter = MultiStateReporter(
-            f"{tmp_path}/solvent.nc",
+            tmp_path / "solvent.nc",
             checkpoint_storage="solvent_checkpoint.nc",
         )
 
@@ -462,13 +461,13 @@ class TestCheckpointResuming:
         # copy files
 
         if bad_file == "trajectory":
-            with open(f"{tmp_path}/solvent.nc", "w") as f:
+            with open(tmp_path / "solvent.nc", "w") as f:
                 f.write("foo")
         else:
             self._copy_simfiles(tmp_path, ahfe_solv_trajectory_path)
 
         if bad_file == "checkpoint":
-            with open(f"{tmp_path}/solvent_checkpoint.nc", "w") as f:
+            with open(tmp_path / "solvent_checkpoint.nc", "w") as f:
                 f.write("bar")
         else:
             self._copy_simfiles(tmp_path, ahfe_solv_checkpoint_path)

--- a/src/openfe/tests/protocols/openmm_ahfe/test_ahfe_slow.py
+++ b/src/openfe/tests/protocols/openmm_ahfe/test_ahfe_slow.py
@@ -78,8 +78,7 @@ def test_openmm_run_engine(
         mapping=None,
     )
 
-    basedir = tmp_path
-    r = execute_DAG(dag, shared_basedir=basedir, scratch_basedir=basedir, keep_shared=True)
+    r = execute_DAG(dag, shared_basedir=tmp_path, scratch_basedir=tmp_path, keep_shared=True)
 
     assert r.ok()
 

--- a/src/openfe/tests/protocols/openmm_ahfe/test_ahfe_slow.py
+++ b/src/openfe/tests/protocols/openmm_ahfe/test_ahfe_slow.py
@@ -21,7 +21,7 @@ def test_openmm_run_engine(
     platform,
     get_available_openmm_platforms,
     benzene_modifications,
-    tmpdir,
+    tmp_path,
 ):
     if platform not in get_available_openmm_platforms:
         pytest.skip(f"OpenMM Platform: {platform} not available")
@@ -78,8 +78,8 @@ def test_openmm_run_engine(
         mapping=None,
     )
 
-    cwd = pathlib.Path(str(tmpdir))
-    r = execute_DAG(dag, shared_basedir=cwd, scratch_basedir=cwd, keep_shared=True)
+    basedir = tmp_path
+    r = execute_DAG(dag, shared_basedir=basedir, scratch_basedir=basedir, keep_shared=True)
 
     assert r.ok()
 
@@ -90,7 +90,7 @@ def test_openmm_run_engine(
         # get the path to the simulation unit shared dict
         for pur in purs:
             if "Simulation" in pur.name:
-                sim_shared = tmpdir / f"shared_{pur.source_key}_attempt_0"
+                sim_shared = tmp_path / f"shared_{pur.source_key}_attempt_0"
                 assert sim_shared.exists()
                 assert pathlib.Path(sim_shared).is_dir()
 
@@ -99,7 +99,7 @@ def test_openmm_run_engine(
             if "Analysis" not in pur.name:
                 continue
 
-            unit_shared = tmpdir / f"shared_{pur.source_key}_attempt_0"
+            unit_shared = tmp_path / f"shared_{pur.source_key}_attempt_0"
             assert unit_shared.exists()
             assert pathlib.Path(unit_shared).is_dir()
 

--- a/src/openfe/tests/protocols/openmm_md/test_plain_md_protocol.py
+++ b/src/openfe/tests/protocols/openmm_md/test_plain_md_protocol.py
@@ -101,7 +101,7 @@ def test_create_independent_repeat_ids(benzene_system):
     assert len(repeat_ids) == 6
 
 
-def test_dry_run_default_vacuum(benzene_vacuum_system, vac_settings, tmpdir):
+def test_dry_run_default_vacuum(benzene_vacuum_system, vac_settings, tmp_path):
     protocol = PlainMDProtocol(settings=vac_settings)
 
     # create DAG from protocol and take first (and only) work unit from within
@@ -111,24 +111,25 @@ def test_dry_run_default_vacuum(benzene_vacuum_system, vac_settings, tmpdir):
         mapping=None,
     )
     dag_unit = list(dag.protocol_units)[0]
+    result = dag_unit.run(
+        dry=True, verbose=True, scratch_basepath=tmp_path, shared_basepath=tmp_path
+    )
+    system = result["debug"]["system"]
+    assert not ThermodynamicState(
+        system,
+        temperature=to_openmm(protocol.settings.thermo_settings.temperature),
+    ).is_periodic
 
-    with tmpdir.as_cwd():
-        sim = dag_unit.run(dry=True, verbose=True)["debug"]["system"]
-        assert not ThermodynamicState(
-            sim,
+    assert (
+        ThermodynamicState(
+            system,
             temperature=to_openmm(protocol.settings.thermo_settings.temperature),
-        ).is_periodic
-
-        assert (
-            ThermodynamicState(
-                sim,
-                temperature=to_openmm(protocol.settings.thermo_settings.temperature),
-            ).barostat
-            is None
-        )
+        ).barostat
+        is None
+    )
 
 
-def test_dry_run_logger_output(benzene_vacuum_system, vac_settings, tmpdir, caplog):
+def test_dry_run_logger_output(benzene_vacuum_system, vac_settings, tmp_path, caplog):
     vac_settings.simulation_settings.equilibration_length_nvt = 1 * unit.picosecond
     vac_settings.simulation_settings.equilibration_length = 1 * unit.picosecond
     vac_settings.simulation_settings.production_length = 1 * unit.picosecond
@@ -145,18 +146,17 @@ def test_dry_run_logger_output(benzene_vacuum_system, vac_settings, tmpdir, capl
     )
     dag_unit = list(dag.protocol_units)[0]
 
-    with tmpdir.as_cwd():
-        caplog.set_level(logging.INFO)
-        dag_unit.run(dry=False, verbose=True)
+    caplog.set_level(logging.INFO)
+    dag_unit.run(dry=False, verbose=True, scratch_basepath=tmp_path, shared_basepath=tmp_path)
 
-        messages = [r.message for r in caplog.records]
-        assert "minimizing systems" in messages
-        assert "Running NVT equilibration" in messages
-        assert "Running NPT equilibration" in messages
-        assert "running production phase" in messages
+    messages = [r.message for r in caplog.records]
+    assert "minimizing systems" in messages
+    assert "Running NVT equilibration" in messages
+    assert "Running NPT equilibration" in messages
+    assert "running production phase" in messages
 
 
-def test_dry_run_ffcache_none_vacuum(benzene_vacuum_system, vac_settings, tmpdir):
+def test_dry_run_ffcache_none_vacuum(benzene_vacuum_system, vac_settings, tmp_path):
     vac_settings.output_settings.forcefield_cache = None
 
     protocol = PlainMDProtocol(
@@ -171,12 +171,10 @@ def test_dry_run_ffcache_none_vacuum(benzene_vacuum_system, vac_settings, tmpdir
         mapping=None,
     )
     dag_unit = list(dag.protocol_units)[0]
-
-    with tmpdir.as_cwd():
-        dag_unit.run(dry=True)["debug"]["system"]
+    dag_unit.run(dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path)["debug"]["system"]
 
 
-def test_dry_run_gaff_vacuum(benzene_vacuum_system, vac_settings, tmpdir):
+def test_dry_run_gaff_vacuum(benzene_vacuum_system, vac_settings, tmp_path):
     vac_settings.forcefield_settings.small_molecule_forcefield = "gaff-2.11"
 
     protocol = PlainMDProtocol(
@@ -190,12 +188,11 @@ def test_dry_run_gaff_vacuum(benzene_vacuum_system, vac_settings, tmpdir):
         mapping=None,
     )
     dag_unit = list(dag.protocol_units)[0]
-    with tmpdir.as_cwd():
-        system = dag_unit.run(dry=True)["debug"]["system"]
+    dag_unit.run(dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path)["debug"]["system"]
 
 
 @pytest.mark.skipif(not HAS_ESPALOMA, reason="espaloma is not available")
-def test_dry_run_espaloma_vacuum_user_charges(benzene_modifications, vac_settings, tmpdir):
+def test_dry_run_espaloma_vacuum_user_charges(benzene_modifications, vac_settings, tmp_path):
     vac_settings.forcefield_settings.small_molecule_forcefield = "espaloma-0.3.2"
 
     protocol = PlainMDProtocol(
@@ -216,16 +213,16 @@ def test_dry_run_espaloma_vacuum_user_charges(benzene_modifications, vac_setting
         mapping=None,
     )
     dag_unit = list(dag.protocol_units)[0]
-    with tmpdir.as_cwd():
-        system = dag_unit.run(dry=True)["debug"]["system"]
-        assert system.getNumParticles() == 12
-        # check the charges assigned
-        nb_force = [f for f in system.getForces() if isinstance(f, NonbondedForce)][0]
-        charges = []
-        for i in range(nb_force.getNumParticles()):
-            c, _, _ = nb_force.getParticleParameters(i)
-            charges.append(c.value_in_unit(omm_unit.elementary_charge))
-        assert_allclose(charges, expected_charges, rtol=1e-6)
+    result = dag_unit.run(dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path)
+    system = result["debug"]["system"]
+    assert system.getNumParticles() == 12
+    # check the charges assigned
+    nb_force = [f for f in system.getForces() if isinstance(f, NonbondedForce)][0]
+    charges = []
+    for i in range(nb_force.getNumParticles()):
+        c, _, _ = nb_force.getParticleParameters(i)
+        charges.append(c.value_in_unit(omm_unit.elementary_charge))
+    assert_allclose(charges, expected_charges, rtol=1e-6)
 
 
 @pytest.mark.parametrize(
@@ -256,7 +253,7 @@ def test_dry_run_espaloma_vacuum_user_charges(benzene_modifications, vac_setting
     ],
 )
 def test_dry_run_charge_backends(
-    CN_molecule, tmpdir, method, backend, ref_key, vac_settings, am1bcc_ref_charges
+    CN_molecule, tmp_path, method, backend, ref_key, vac_settings, am1bcc_ref_charges
 ):
     vac_settings.partial_charge_settings.partial_charge_method = method
     vac_settings.partial_charge_settings.off_toolkit_backend = backend
@@ -269,22 +266,22 @@ def test_dry_run_charge_backends(
     dag = protocol.create(stateA=csystem, stateB=csystem, mapping=None)
     md_unit = list(dag.protocol_units)[0]
 
-    with tmpdir.as_cwd():
-        system = md_unit.run(dry=True)["debug"]["system"]
+    result = md_unit.run(dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path)
+    system = result["debug"]["system"]
 
-        nonbond = [f for f in system.getForces() if isinstance(f, NonbondedForce)][0]
+    nonbond = [f for f in system.getForces() if isinstance(f, NonbondedForce)][0]
 
-        charges = []
-        for i in range(system.getNumParticles()):
-            c, s, e = nonbond.getParticleParameters(i)
-            charges.append(from_openmm(c))
+    charges = []
+    for i in range(system.getNumParticles()):
+        c, s, e = nonbond.getParticleParameters(i)
+        charges.append(from_openmm(c))
 
     charges = unit.Quantity.from_list(charges)
 
     assert_allclose(am1bcc_ref_charges[ref_key], charges, rtol=1e-4)
 
 
-def test_dry_many_molecules_solvent(benzene_many_solv_system, tmpdir):
+def test_dry_many_molecules_solvent(benzene_many_solv_system, tmp_path):
     """
     A basic test flushing "will it work if you pass multiple molecules"
     """
@@ -301,8 +298,7 @@ def test_dry_many_molecules_solvent(benzene_many_solv_system, tmpdir):
     )
     dag_unit = list(dag.protocol_units)[0]
 
-    with tmpdir.as_cwd():
-        system = dag_unit.run(dry=True)["debug"]["system"]
+    dag_unit.run(dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path)["debug"]["system"]
 
 
 BENZ = """\
@@ -371,7 +367,7 @@ $$$$
 """
 
 
-def test_dry_run_ligand_tip4p(benzene_system, tmpdir):
+def test_dry_run_ligand_tip4p(benzene_system, tmp_path):
     """
     Test that we can create a system with virtual sites in the
     environment (waters)
@@ -397,13 +393,13 @@ def test_dry_run_ligand_tip4p(benzene_system, tmpdir):
     )
     dag_unit = list(dag.protocol_units)[0]
 
-    with tmpdir.as_cwd():
-        system = dag_unit.run(dry=True)["debug"]["system"]
-        assert system
+    result = dag_unit.run(dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path)
+    system = result["debug"]["system"]
+    assert system
 
 
 @pytest.mark.slow
-def test_dry_run_complex(benzene_complex_system, tmpdir):
+def test_dry_run_complex(benzene_complex_system, tmp_path):
     # this will be very time consuming
     settings = PlainMDProtocol.default_settings()
     settings.engine_settings.compute_platform = None
@@ -416,29 +412,29 @@ def test_dry_run_complex(benzene_complex_system, tmpdir):
     )
     dag_unit = list(dag.protocol_units)[0]
 
-    with tmpdir.as_cwd():
-        sim = dag_unit.run(dry=True)["debug"]["system"]
-        assert ThermodynamicState(
+    result = dag_unit.run(dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path)
+    sim = result["debug"]["system"]
+    assert ThermodynamicState(
+        sim,
+        temperature=to_openmm(protocol.settings.thermo_settings.temperature),
+    ).is_periodic
+    assert isinstance(
+        ThermodynamicState(
             sim,
             temperature=to_openmm(protocol.settings.thermo_settings.temperature),
-        ).is_periodic
-        assert isinstance(
-            ThermodynamicState(
-                sim,
-                temperature=to_openmm(protocol.settings.thermo_settings.temperature),
-            ).barostat,
-            MonteCarloBarostat,
-        )
-        assert (
-            ThermodynamicState(
-                sim,
-                temperature=to_openmm(protocol.settings.thermo_settings.temperature),
-            ).pressure
-            == 1 * omm_unit.bar
-        )
+        ).barostat,
+        MonteCarloBarostat,
+    )
+    assert (
+        ThermodynamicState(
+            sim,
+            temperature=to_openmm(protocol.settings.thermo_settings.temperature),
+        ).pressure
+        == 1 * omm_unit.bar
+    )
 
 
-def test_hightimestep(benzene_vacuum_system, tmpdir):
+def test_hightimestep(benzene_vacuum_system, tmp_path):
     settings = PlainMDProtocol.default_settings()
     settings.forcefield_settings.hydrogen_mass = 1.0
     settings.forcefield_settings.nonbonded_method = "nocutoff"
@@ -453,9 +449,8 @@ def test_hightimestep(benzene_vacuum_system, tmpdir):
     dag_unit = list(dag.protocol_units)[0]
 
     errmsg = "too large for hydrogen mass"
-    with tmpdir.as_cwd():
-        with pytest.raises(ValueError, match=errmsg):
-            dag_unit.run(dry=True)
+    with pytest.raises(ValueError, match=errmsg):
+        dag_unit.run(dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path)
 
 
 def test_vaccuum_PME_error(benzene_vacuum_system):
@@ -484,7 +479,7 @@ def solvent_protocol_dag(benzene_system):
     )
 
 
-def test_unit_tagging(solvent_protocol_dag, tmpdir):
+def test_unit_tagging(solvent_protocol_dag, tmp_path):
     # test that executing the Units includes correct generation and repeat info
     dag_units = solvent_protocol_dag.protocol_units
     with mock.patch(
@@ -496,7 +491,7 @@ def test_unit_tagging(solvent_protocol_dag, tmpdir):
     ):
         results = []
         for u in dag_units:
-            ret = u.execute(context=gufe.Context(tmpdir, tmpdir))
+            ret = u.execute(context=gufe.Context(tmp_path, tmp_path))
             results.append(ret)
 
     repeats = set()
@@ -508,7 +503,7 @@ def test_unit_tagging(solvent_protocol_dag, tmpdir):
     assert len(repeats) == 3
 
 
-def test_gather(solvent_protocol_dag, tmpdir):
+def test_gather(solvent_protocol_dag, tmp_path):
     # check .gather behaves as expected
     with mock.patch(
         "openfe.protocols.openmm_md.plain_md_methods.PlainMDProtocolUnit.run",
@@ -519,8 +514,8 @@ def test_gather(solvent_protocol_dag, tmpdir):
     ):
         dagres = gufe.protocols.execute_DAG(
             solvent_protocol_dag,
-            shared_basedir=tmpdir,
-            scratch_basedir=tmpdir,
+            shared_basedir=tmp_path,
+            scratch_basedir=tmp_path,
             keep_shared=True,
         )
 

--- a/src/openfe/tests/protocols/openmm_md/test_plain_md_slow.py
+++ b/src/openfe/tests/protocols/openmm_md/test_plain_md_slow.py
@@ -37,12 +37,10 @@ def test_vacuum_sim(
         mapping=None,
     )
 
-    basedir = tmp_path
-
     r = execute_DAG(
         dag,
-        shared_basedir=basedir,
-        scratch_basedir=basedir,
+        shared_basedir=tmp_path,
+        scratch_basedir=tmp_path,
         keep_shared=True,
     )
 
@@ -106,12 +104,10 @@ def test_complex_solvent_sim_gpu(
         mapping=None,
     )
 
-    basedir = pathlib.Path(str(tmp_path))
-
     r = execute_DAG(
         dag,
-        shared_basedir=basedir,
-        scratch_basedir=basedir,
+        shared_basedir=tmp_path,
+        scratch_basedir=tmp_path,
         keep_shared=True,
     )
 

--- a/src/openfe/tests/protocols/openmm_md/test_plain_md_slow.py
+++ b/src/openfe/tests/protocols/openmm_md/test_plain_md_slow.py
@@ -15,7 +15,7 @@ def test_vacuum_sim(
     benzene_vacuum_system,
     platform,
     available_platforms,
-    tmpdir,
+    tmp_path,
 ):
     if platform not in available_platforms:
         pytest.skip(f"OpenMM Platform: {platform} is not available")
@@ -37,12 +37,12 @@ def test_vacuum_sim(
         mapping=None,
     )
 
-    workdir = pathlib.Path(str(tmpdir))
+    basedir = tmp_path
 
     r = execute_DAG(
         dag,
-        shared_basedir=workdir,
-        scratch_basedir=workdir,
+        shared_basedir=basedir,
+        scratch_basedir=basedir,
         keep_shared=True,
     )
 
@@ -51,7 +51,7 @@ def test_vacuum_sim(
     assert len(r.protocol_unit_results) == 1
 
     pur = r.protocol_unit_results[0]
-    unit_shared = tmpdir / f"shared_{pur.source_key}_attempt_0"
+    unit_shared = tmp_path / f"shared_{pur.source_key}_attempt_0"
     assert unit_shared.exists()
     assert pathlib.Path(unit_shared).is_dir()
 
@@ -85,7 +85,7 @@ def test_complex_solvent_sim_gpu(
     benzene_complex_system,
     platform,
     available_platforms,
-    tmpdir,
+    tmp_path,
 ):
     if platform not in available_platforms:
         pytest.skip(f"OpenMM Platform: {platform} is not available")
@@ -106,12 +106,12 @@ def test_complex_solvent_sim_gpu(
         mapping=None,
     )
 
-    workdir = pathlib.Path(str(tmpdir))
+    basedir = pathlib.Path(str(tmp_path))
 
     r = execute_DAG(
         dag,
-        shared_basedir=workdir,
-        scratch_basedir=workdir,
+        shared_basedir=basedir,
+        scratch_basedir=basedir,
         keep_shared=True,
     )
 
@@ -120,7 +120,7 @@ def test_complex_solvent_sim_gpu(
     assert len(r.protocol_unit_results) == 1
 
     pur = r.protocol_unit_results[0]
-    unit_shared = tmpdir / f"shared_{pur.source_key}_attempt_0"
+    unit_shared = tmp_path / f"shared_{pur.source_key}_attempt_0"
     assert unit_shared.exists()
     assert pathlib.Path(unit_shared).is_dir()
 

--- a/src/openfe/tests/protocols/openmm_rfe/test_hybrid_top_protocol.py
+++ b/src/openfe/tests/protocols/openmm_rfe/test_hybrid_top_protocol.py
@@ -268,7 +268,7 @@ def test_setup_dry_sim_default_vacuum(
     benzene_to_toluene_mapping,
     method,
     vac_settings,
-    tmpdir,
+    tmp_path,
     benzene_toluene_topology,
 ):
     vac_settings.simulation_settings.sampler_method = method
@@ -286,64 +286,67 @@ def test_setup_dry_sim_default_vacuum(
     dag_setup_unit = _get_units(dag.protocol_units, HybridTopologySetupUnit)[0]
     dag_sim_unit = _get_units(dag.protocol_units, HybridTopologyMultiStateSimulationUnit)[0]
 
-    with tmpdir.as_cwd():
-        # Manually run the units
-        setup_results = dag_setup_unit.run(dry=True)
+    # Manually run the units
+    setup_results = dag_setup_unit.run(
+        dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path
+    )
 
-        sim_results = dag_sim_unit.run(
-            system=setup_results["hybrid_system"],
-            positions=setup_results["hybrid_positions"],
-            selection_indices=setup_results["selection_indices"],
-            dry=True,
-        )
+    sim_results = dag_sim_unit.run(
+        system=setup_results["hybrid_system"],
+        positions=setup_results["hybrid_positions"],
+        selection_indices=setup_results["selection_indices"],
+        dry=True,
+        scratch_basepath=tmp_path,
+        shared_basepath=tmp_path,
+    )
 
-        sampler = sim_results["sampler"]
-        assert isinstance(sampler, MultiStateSampler)
-        assert not sampler.is_periodic
-        assert sampler._thermodynamic_states[0].barostat is None
+    sampler = sim_results["sampler"]
+    assert isinstance(sampler, MultiStateSampler)
+    assert not sampler.is_periodic
+    assert sampler._thermodynamic_states[0].barostat is None
 
-        # Check hybrid OMM and MDTtraj Topologies
-        htf = setup_results["hybrid_factory"]
-        # 16 atoms:
-        # 11 common atoms, 1 extra hydrogen in benzene, 4 extra in toluene
-        # 12 bonds in benzene + 4 extra toluene bonds
-        assert len(list(htf.hybrid_topology.atoms)) == 16
-        assert len(list(htf.omm_hybrid_topology.atoms())) == 16
-        assert len(list(htf.hybrid_topology.bonds)) == 16
-        assert len(list(htf.omm_hybrid_topology.bonds())) == 16
+    # Check hybrid OMM and MDTtraj Topologies
+    htf = setup_results["hybrid_factory"]
+    # 16 atoms:
+    # 11 common atoms, 1 extra hydrogen in benzene, 4 extra in toluene
+    # 12 bonds in benzene + 4 extra toluene bonds
+    assert len(list(htf.hybrid_topology.atoms)) == 16
+    assert len(list(htf.omm_hybrid_topology.atoms())) == 16
+    assert len(list(htf.hybrid_topology.bonds)) == 16
+    assert len(list(htf.omm_hybrid_topology.bonds())) == 16
 
-        # smoke test - can convert back the mdtraj topology
-        ret_top = mdt.Topology.to_openmm(htf.hybrid_topology)
-        assert len(list(ret_top.atoms())) == 16
-        assert len(list(ret_top.bonds())) == 16
+    # smoke test - can convert back the mdtraj topology
+    ret_top = mdt.Topology.to_openmm(htf.hybrid_topology)
+    assert len(list(ret_top.atoms())) == 16
+    assert len(list(ret_top.bonds())) == 16
 
-        # check that our PDB has the right number of atoms
-        pdb = mdt.load_pdb("hybrid_system.pdb")
-        assert pdb.n_atoms == 16
+    # check that our PDB has the right number of atoms
+    pdb = mdt.load_pdb(tmp_path / "hybrid_system.pdb")
+    assert pdb.n_atoms == 16
 
-        # regression test that we have the expected mdtraj topology
-        assert benzene_toluene_topology == htf.hybrid_topology
+    # regression test that we have the expected mdtraj topology
+    assert benzene_toluene_topology == htf.hybrid_topology
 
-        # check we can extract the correct positions for the end states
-        old_positions = htf.old_positions(htf.hybrid_positions)
-        # check the shape and positions match the input
-        assert old_positions.shape == (12, 3)
-        # compare with the input positions which are stored on the htf
-        assert_allclose(
-            old_positions.value_in_unit(omm_unit.angstrom),
-            htf._old_positions.value_in_unit(omm_unit.angstrom),
-        )
-        # same for toluene
-        new_positions = htf.new_positions(htf.hybrid_positions)
-        assert new_positions.shape == (15, 3)
-        assert_allclose(
-            new_positions.value_in_unit(omm_unit.angstrom),
-            htf._new_positions.value_in_unit(omm_unit.angstrom),
-        )
+    # check we can extract the correct positions for the end states
+    old_positions = htf.old_positions(htf.hybrid_positions)
+    # check the shape and positions match the input
+    assert old_positions.shape == (12, 3)
+    # compare with the input positions which are stored on the htf
+    assert_allclose(
+        old_positions.value_in_unit(omm_unit.angstrom),
+        htf._old_positions.value_in_unit(omm_unit.angstrom),
+    )
+    # same for toluene
+    new_positions = htf.new_positions(htf.hybrid_positions)
+    assert new_positions.shape == (15, 3)
+    assert_allclose(
+        new_positions.value_in_unit(omm_unit.angstrom),
+        htf._new_positions.value_in_unit(omm_unit.angstrom),
+    )
 
 
 def test_setup_gaff_vacuum(
-    benzene_vacuum_system, toluene_vacuum_system, benzene_to_toluene_mapping, vac_settings, tmpdir
+    benzene_vacuum_system, toluene_vacuum_system, benzene_to_toluene_mapping, vac_settings, tmp_path
 ):
     """
     Simple dry run of the setup unit to make sure that parameterisation
@@ -363,8 +366,7 @@ def test_setup_gaff_vacuum(
     )
     dag_setup_unit = _get_units(dag.protocol_units, HybridTopologySetupUnit)[0]
 
-    with tmpdir.as_cwd():
-        _ = dag_setup_unit.run(dry=True)
+    _ = dag_setup_unit.run(dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path)
 
 
 @pytest.mark.slow
@@ -373,7 +375,7 @@ def test_dry_many_molecules_solvent(
     toluene_many_solv_system,
     benzene_to_toluene_mapping,
     solv_settings,
-    tmpdir,
+    tmp_path,
 ):
     """
     A basic setup test flushing "will it work if you pass multiple molecules"
@@ -390,8 +392,7 @@ def test_dry_many_molecules_solvent(
     )
     dag_setup_unit = _get_units(dag.protocol_units, HybridTopologySetupUnit)[0]
 
-    with tmpdir.as_cwd():
-        _ = dag_setup_unit.run(dry=True)
+    _ = dag_setup_unit.run(dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path)
 
 
 BENZ = """\
@@ -460,7 +461,7 @@ $$$$
 """
 
 
-def test_setup_core_element_change(vac_settings, tmpdir):
+def test_setup_core_element_change(vac_settings, tmp_path):
     benz = openfe.SmallMoleculeComponent(Chem.MolFromMolBlock(BENZ, removeHs=False))
     pyr = openfe.SmallMoleculeComponent(Chem.MolFromMolBlock(PYRIDINE, removeHs=False))
 
@@ -478,24 +479,23 @@ def test_setup_core_element_change(vac_settings, tmpdir):
 
     dag_setup_unit = _get_units(dag.protocol_units, HybridTopologySetupUnit)[0]
 
-    with tmpdir.as_cwd():
-        results = dag_setup_unit.run(dry=True)
-        system = results["hybrid_system"]
-        assert system.getNumParticles() == 12
-        # Average mass between nitrogen and carbon
-        assert system.getParticleMass(1) == 12.0127235 * omm_unit.amu
+    results = dag_setup_unit.run(dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path)
+    system = results["hybrid_system"]
+    assert system.getNumParticles() == 12
+    # Average mass between nitrogen and carbon
+    assert system.getParticleMass(1) == 12.0127235 * omm_unit.amu
 
-        # Get out the CustomNonbondedForce
-        cnf = [f for f in system.getForces() if f.__class__.__name__ == "CustomNonbondedForce"][0]
-        # there should be no new unique atoms
-        assert cnf.getInteractionGroupParameters(6) == [(), ()]
-        # there should be one old unique atom (spare hydrogen from the benzene)
-        assert cnf.getInteractionGroupParameters(7) == [(7,), (7,)]
+    # Get out the CustomNonbondedForce
+    cnf = [f for f in system.getForces() if f.__class__.__name__ == "CustomNonbondedForce"][0]
+    # there should be no new unique atoms
+    assert cnf.getInteractionGroupParameters(6) == [(), ()]
+    # there should be one old unique atom (spare hydrogen from the benzene)
+    assert cnf.getInteractionGroupParameters(7) == [(7,), (7,)]
 
 
 @pytest.mark.parametrize("method", ["repex", "sams", "independent"])
 def test_dry_run_ligand(
-    benzene_system, toluene_system, benzene_to_toluene_mapping, method, solv_settings, tmpdir
+    benzene_system, toluene_system, benzene_to_toluene_mapping, method, solv_settings, tmp_path
 ):
     # this might be a bit time consuming
     solv_settings.simulation_settings.sampler_method = method
@@ -512,30 +512,33 @@ def test_dry_run_ligand(
     dag_setup_unit = _get_units(dag.protocol_units, HybridTopologySetupUnit)[0]
     dag_sim_unit = _get_units(dag.protocol_units, HybridTopologyMultiStateSimulationUnit)[0]
 
-    with tmpdir.as_cwd():
-        # Manually run the units
-        setup_results = dag_setup_unit.run(dry=True)
+    # Manually run the units
+    setup_results = dag_setup_unit.run(
+        dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path
+    )
 
-        sim_results = dag_sim_unit.run(
-            system=setup_results["hybrid_system"],
-            positions=setup_results["hybrid_positions"],
-            selection_indices=setup_results["selection_indices"],
-            dry=True,
-        )
+    sim_results = dag_sim_unit.run(
+        system=setup_results["hybrid_system"],
+        positions=setup_results["hybrid_positions"],
+        selection_indices=setup_results["selection_indices"],
+        dry=True,
+        scratch_basepath=tmp_path,
+        shared_basepath=tmp_path,
+    )
 
-        sampler = sim_results["sampler"]
-        assert isinstance(sampler, MultiStateSampler)
-        assert sampler.is_periodic
-        assert isinstance(sampler._thermodynamic_states[0].barostat, MonteCarloBarostat)
-        assert sampler._thermodynamic_states[1].pressure == 1 * omm_unit.bar
+    sampler = sim_results["sampler"]
+    assert isinstance(sampler, MultiStateSampler)
+    assert sampler.is_periodic
+    assert isinstance(sampler._thermodynamic_states[0].barostat, MonteCarloBarostat)
+    assert sampler._thermodynamic_states[1].pressure == 1 * omm_unit.bar
 
-        # Check we have the right number of atoms in the PDB
-        pdb = mdt.load_pdb("hybrid_system.pdb")
-        assert pdb.n_atoms == 16
+    # Check we have the right number of atoms in the PDB
+    pdb = mdt.load_pdb(tmp_path / "hybrid_system.pdb")
+    assert pdb.n_atoms == 16
 
 
 def test_confgen_mocked_fail(
-    benzene_system, toluene_system, benzene_to_toluene_mapping, solv_settings, tmpdir
+    benzene_system, toluene_system, benzene_to_toluene_mapping, solv_settings, tmp_path
 ):
     """
     Check that even if conformer generation fails, we can still perform a sim
@@ -547,11 +550,10 @@ def test_confgen_mocked_fail(
     )
     dag_unit = list(dag.protocol_units)[0]
 
-    with tmpdir.as_cwd():
-        with mock.patch("rdkit.Chem.AllChem.EmbedMultipleConfs", return_value=0):
-            sampler = dag_unit.run(dry=True)
+    with mock.patch("rdkit.Chem.AllChem.EmbedMultipleConfs", return_value=0):
+        sampler = dag_unit.run(dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path)
 
-            assert sampler
+        assert sampler
 
 
 @pytest.fixture(scope="session")
@@ -681,7 +683,7 @@ def test_tip4p_check_vsite_parameters(tip4p_hybrid_factory):
     ],
 )
 def test_setup_ligand_system_cutoff(
-    cutoff, benzene_system, toluene_system, benzene_to_toluene_mapping, solv_settings, tmpdir
+    cutoff, benzene_system, toluene_system, benzene_to_toluene_mapping, solv_settings, tmp_path
 ):
     """
     Test that the right nonbonded cutoff is propagated to the hybrid system.
@@ -701,18 +703,19 @@ def test_setup_ligand_system_cutoff(
 
     dag_setup_unit = [pu for pu in dag.protocol_units if isinstance(pu, HybridTopologySetupUnit)][0]
 
-    with tmpdir.as_cwd():
-        hs = dag_setup_unit.run(dry=True)["hybrid_system"]
+    hs = dag_setup_unit.run(dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path)[
+        "hybrid_system"
+    ]
 
-        nbfs = [
-            f
-            for f in hs.getForces()
-            if isinstance(f, CustomNonbondedForce) or isinstance(f, NonbondedForce)
-        ]
+    nbfs = [
+        f
+        for f in hs.getForces()
+        if isinstance(f, CustomNonbondedForce) or isinstance(f, NonbondedForce)
+    ]
 
-        for f in nbfs:
-            f_cutoff = from_openmm(f.getCutoffDistance())
-            assert f_cutoff == cutoff
+    for f in nbfs:
+        f_cutoff = from_openmm(f.getCutoffDistance())
+        assert f_cutoff == cutoff
 
 
 @pytest.mark.parametrize(
@@ -743,7 +746,7 @@ def test_setup_ligand_system_cutoff(
     ],
 )
 def test_setup_charge_backends(
-    CN_molecule, tmpdir, method, backend, ref_key, vac_settings, am1bcc_ref_charges
+    CN_molecule, tmp_path, method, backend, ref_key, vac_settings, am1bcc_ref_charges
 ):
     vac_settings.partial_charge_settings.partial_charge_method = method
     vac_settings.partial_charge_settings.off_toolkit_backend = backend
@@ -768,44 +771,43 @@ def test_setup_charge_backends(
 
     dag_setup_unit = [pu for pu in dag.protocol_units if isinstance(pu, HybridTopologySetupUnit)][0]
 
-    with tmpdir.as_cwd():
-        results = dag_setup_unit.run(dry=True)
-        htf = results["hybrid_factory"]
-        hybrid_system = results["hybrid_system"]
+    results = dag_setup_unit.run(dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path)
+    htf = results["hybrid_factory"]
+    hybrid_system = results["hybrid_system"]
 
-        # get the standard nonbonded force
-        nonbond = [f for f in hybrid_system.getForces() if isinstance(f, NonbondedForce)]
-        assert len(nonbond) == 1
+    # get the standard nonbonded force
+    nonbond = [f for f in hybrid_system.getForces() if isinstance(f, NonbondedForce)]
+    assert len(nonbond) == 1
 
-        # get the particle parameter offsets
-        c_offsets = {}
-        for i in range(nonbond[0].getNumParticleParameterOffsets()):
-            offset = nonbond[0].getParticleParameterOffset(i)
-            c_offsets[offset[1]] = ensure_quantity(offset[2], "openff")
+    # get the particle parameter offsets
+    c_offsets = {}
+    for i in range(nonbond[0].getNumParticleParameterOffsets()):
+        offset = nonbond[0].getParticleParameterOffset(i)
+        c_offsets[offset[1]] = ensure_quantity(offset[2], "openff")
 
-        # See the user charges test below for an idea of what we're doing here
-        # In this particular case we are solely checking that the old atoms
-        # match the reference charges in am1bcc_ref_charges
-        for i in range(hybrid_system.getNumParticles()):
-            c, s, e = nonbond[0].getParticleParameters(i)
-            # get the particle charge (c)
-            c = ensure_quantity(c, "openff")
-            # particle charge (c) is equal to molA particle charge
-            # offset (c_offsets) is equal to -(molA particle charge)
-            if i in htf._atom_classes["unique_old_atoms"]:
-                idx = htf._hybrid_to_old_map[i]
-                ref = am1bcc_ref_charges[ref_key][idx]
-                np.testing.assert_allclose(c, ref, rtol=1e-4)
-                np.testing.assert_allclose(c_offsets[i], -ref, rtol=1e-4)
-            # particle charge (c) is equal to molA particle charge
-            # offset (c_offsets) is equal to difference between molB and molA
-            elif i in htf._atom_classes["core_atoms"]:
-                old_i = htf._hybrid_to_old_map[i]
-                ref = am1bcc_ref_charges[ref_key][i]
-                np.testing.assert_allclose(c, ref, rtol=1e-4)
+    # See the user charges test below for an idea of what we're doing here
+    # In this particular case we are solely checking that the old atoms
+    # match the reference charges in am1bcc_ref_charges
+    for i in range(hybrid_system.getNumParticles()):
+        c, s, e = nonbond[0].getParticleParameters(i)
+        # get the particle charge (c)
+        c = ensure_quantity(c, "openff")
+        # particle charge (c) is equal to molA particle charge
+        # offset (c_offsets) is equal to -(molA particle charge)
+        if i in htf._atom_classes["unique_old_atoms"]:
+            idx = htf._hybrid_to_old_map[i]
+            ref = am1bcc_ref_charges[ref_key][idx]
+            np.testing.assert_allclose(c, ref, rtol=1e-4)
+            np.testing.assert_allclose(c_offsets[i], -ref, rtol=1e-4)
+        # particle charge (c) is equal to molA particle charge
+        # offset (c_offsets) is equal to difference between molB and molA
+        elif i in htf._atom_classes["core_atoms"]:
+            old_i = htf._hybrid_to_old_map[i]
+            ref = am1bcc_ref_charges[ref_key][i]
+            np.testing.assert_allclose(c, ref, rtol=1e-4)
 
 
-def test_setup_same_mol_different_charges(benzene_modifications, vac_settings, tmpdir):
+def test_setup_same_mol_different_charges(benzene_modifications, vac_settings, tmp_path):
     """
     Issue #1120 - make sure we can do an RFE of a system with different
     parameters but the same molecule.
@@ -838,39 +840,38 @@ def test_setup_same_mol_different_charges(benzene_modifications, vac_settings, t
     )
     dag_setup_unit = [pu for pu in dag.protocol_units if isinstance(pu, HybridTopologySetupUnit)][0]
 
-    with tmpdir.as_cwd():
-        results = dag_setup_unit.run(dry=True)
-        htf = results["hybrid_factory"]
-        hybrid_system = results["hybrid_system"]
+    results = dag_setup_unit.run(dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path)
+    htf = results["hybrid_factory"]
+    hybrid_system = results["hybrid_system"]
 
-        # get the standard nonbonded force
-        nonbond = [f for f in hybrid_system.getForces() if isinstance(f, NonbondedForce)]
+    # get the standard nonbonded force
+    nonbond = [f for f in hybrid_system.getForces() if isinstance(f, NonbondedForce)]
 
-        # get the particle parameters & offsets
-        for i in range(hybrid_system.getNumParticles()):
-            # All particles should be core atoms
-            assert i in htf._atom_classes["core_atoms"]
+    # get the particle parameters & offsets
+    for i in range(hybrid_system.getNumParticles()):
+        # All particles should be core atoms
+        assert i in htf._atom_classes["core_atoms"]
 
-            # offsets
-            offset = ensure_quantity(nonbond[0].getParticleParameterOffset(i)[2], "openff")
+        # offsets
+        offset = ensure_quantity(nonbond[0].getParticleParameterOffset(i)[2], "openff")
 
-            # parameters
-            c, s, e = nonbond[0].getParticleParameters(i)
-            c = ensure_quantity(c, "openff")
+        # parameters
+        c, s, e = nonbond[0].getParticleParameters(i)
+        c = ensure_quantity(c, "openff")
 
-            # check state A charge
-            assert pytest.approx(c) == stateA_charges[i]
+        # check state A charge
+        assert pytest.approx(c) == stateA_charges[i]
 
-            # check state B charge
-            c_diff = stateB_charges[i] - stateA_charges[i]
-            assert pytest.approx(offset) == c_diff
+        # check state B charge
+        c_diff = stateB_charges[i] - stateA_charges[i]
+        assert pytest.approx(offset) == c_diff
 
-            # check that the offset value is non-zero
-            assert abs(offset) > 0 * offset.units
+        # check that the offset value is non-zero
+        assert abs(offset) > 0 * offset.units
 
 
 @pytest.mark.flaky(reruns=3)  # bad minimisation can happen
-def test_setup_user_charges(benzene_modifications, vac_settings, tmpdir):
+def test_setup_user_charges(benzene_modifications, vac_settings, tmp_path):
     """
     Create a hybrid system with a set of fictitious user supplied charges
     and ensure that they are properly passed through to the constructed
@@ -926,73 +927,72 @@ def test_setup_user_charges(benzene_modifications, vac_settings, tmpdir):
     )
     dag_setup_unit = [pu for pu in dag.protocol_units if isinstance(pu, HybridTopologySetupUnit)][0]
 
-    with tmpdir.as_cwd():
-        results = dag_setup_unit.run(dry=True)
-        htf = results["hybrid_factory"]
-        hybrid_system = results["hybrid_system"]
+    results = dag_setup_unit.run(dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path)
+    htf = results["hybrid_factory"]
+    hybrid_system = results["hybrid_system"]
 
-        # get the standard nonbonded force
-        nonbond = [f for f in hybrid_system.getForces() if isinstance(f, NonbondedForce)]
-        assert len(nonbond) == 1
+    # get the standard nonbonded force
+    nonbond = [f for f in hybrid_system.getForces() if isinstance(f, NonbondedForce)]
+    assert len(nonbond) == 1
 
-        # get the particle parameter offsets
-        c_offsets = {}
-        for i in range(nonbond[0].getNumParticleParameterOffsets()):
-            offset = nonbond[0].getParticleParameterOffset(i)
-            c_offsets[offset[1]] = ensure_quantity(offset[2], "openff")
+    # get the particle parameter offsets
+    c_offsets = {}
+    for i in range(nonbond[0].getNumParticleParameterOffsets()):
+        offset = nonbond[0].getParticleParameterOffset(i)
+        c_offsets[offset[1]] = ensure_quantity(offset[2], "openff")
 
-        # Here is a bit of exposition on what we're doing
-        # HTF creates two sets of nonbonded forces, a standard one (for the
-        # PME) and a custom one (for sterics).
-        # Here we specifically check charges, so we only concentrate on the
-        # standard NonbondedForce.
-        # The way the NonbondedForce is constructed is as follows:
-        # - unique old atoms:
-        #  * The particle charge is set to the input molA particle charge
-        #  * The chargeScale offset is set to the negative value of the molA
-        #    particle charge (such that by scaling you effectively zero out
-        #    the charge.
-        # - unique new atoms:
-        #  * The particle charge is set to zero (doesn't exist in the starting
-        #    end state).
-        #  * The chargeScale offset is set to the value of the molB particle
-        #    charge (such that by scaling you effectively go from 0 to molB
-        #    charge).
-        # - core atoms:
-        #  * The particle charge is set to the input molA particle charge
-        #    (i.e. we start from a system that has molA charges).
-        #  * The particle charge offset is set to the difference between
-        #    the molB particle charge and the molA particle charge (i.e.
-        #    we scale by that difference to get to the value of the molB
-        #    particle charge).
-        for i in range(hybrid_system.getNumParticles()):
-            c, s, e = nonbond[0].getParticleParameters(i)
-            # get the particle charge (c)
-            c = ensure_quantity(c, "openff")
-            # particle charge (c) is equal to molA particle charge
-            # offset (c_offsets) is equal to -(molA particle charge)
-            if i in htf._atom_classes["unique_old_atoms"]:
-                idx = htf._hybrid_to_old_map[i]
-                np.testing.assert_allclose(c, benzene_rand_chg[idx])
-                np.testing.assert_allclose(c_offsets[i], -benzene_rand_chg[idx])
-            # particle charge (c) is equal to 0
-            # offset (c_offsets) is equal to molB particle charge
-            elif i in htf._atom_classes["unique_new_atoms"]:
-                idx = htf._hybrid_to_new_map[i]
-                np.testing.assert_allclose(c, 0 * unit.elementary_charge)
-                np.testing.assert_allclose(c_offsets[i], toluene_rand_chg[idx])
-            # particle charge (c) is equal to molA particle charge
-            # offset (c_offsets) is equal to difference between molB and molA
-            elif i in htf._atom_classes["core_atoms"]:
-                old_i = htf._hybrid_to_old_map[i]
-                new_i = htf._hybrid_to_new_map[i]
-                c_exp = toluene_rand_chg[new_i] - benzene_rand_chg[old_i]
-                np.testing.assert_allclose(c, benzene_rand_chg[old_i])
-                np.testing.assert_allclose(c_offsets[i], c_exp)
+    # Here is a bit of exposition on what we're doing
+    # HTF creates two sets of nonbonded forces, a standard one (for the
+    # PME) and a custom one (for sterics).
+    # Here we specifically check charges, so we only concentrate on the
+    # standard NonbondedForce.
+    # The way the NonbondedForce is constructed is as follows:
+    # - unique old atoms:
+    #  * The particle charge is set to the input molA particle charge
+    #  * The chargeScale offset is set to the negative value of the molA
+    #    particle charge (such that by scaling you effectively zero out
+    #    the charge.
+    # - unique new atoms:
+    #  * The particle charge is set to zero (doesn't exist in the starting
+    #    end state).
+    #  * The chargeScale offset is set to the value of the molB particle
+    #    charge (such that by scaling you effectively go from 0 to molB
+    #    charge).
+    # - core atoms:
+    #  * The particle charge is set to the input molA particle charge
+    #    (i.e. we start from a system that has molA charges).
+    #  * The particle charge offset is set to the difference between
+    #    the molB particle charge and the molA particle charge (i.e.
+    #    we scale by that difference to get to the value of the molB
+    #    particle charge).
+    for i in range(hybrid_system.getNumParticles()):
+        c, s, e = nonbond[0].getParticleParameters(i)
+        # get the particle charge (c)
+        c = ensure_quantity(c, "openff")
+        # particle charge (c) is equal to molA particle charge
+        # offset (c_offsets) is equal to -(molA particle charge)
+        if i in htf._atom_classes["unique_old_atoms"]:
+            idx = htf._hybrid_to_old_map[i]
+            np.testing.assert_allclose(c, benzene_rand_chg[idx])
+            np.testing.assert_allclose(c_offsets[i], -benzene_rand_chg[idx])
+        # particle charge (c) is equal to 0
+        # offset (c_offsets) is equal to molB particle charge
+        elif i in htf._atom_classes["unique_new_atoms"]:
+            idx = htf._hybrid_to_new_map[i]
+            np.testing.assert_allclose(c, 0 * unit.elementary_charge)
+            np.testing.assert_allclose(c_offsets[i], toluene_rand_chg[idx])
+        # particle charge (c) is equal to molA particle charge
+        # offset (c_offsets) is equal to difference between molB and molA
+        elif i in htf._atom_classes["core_atoms"]:
+            old_i = htf._hybrid_to_old_map[i]
+            new_i = htf._hybrid_to_new_map[i]
+            c_exp = toluene_rand_chg[new_i] - benzene_rand_chg[old_i]
+            np.testing.assert_allclose(c, benzene_rand_chg[old_i])
+            np.testing.assert_allclose(c_offsets[i], c_exp)
 
 
 def test_virtual_sites_no_reassign(
-    benzene_system, toluene_system, benzene_to_toluene_mapping, solv_settings, tmpdir
+    benzene_system, toluene_system, benzene_to_toluene_mapping, solv_settings, tmp_path
 ):
     """
     Because of some as-of-yet not fully identified issue, not reassigning
@@ -1020,21 +1020,24 @@ def test_virtual_sites_no_reassign(
     dag_setup_unit = _get_units(dag.protocol_units, HybridTopologySetupUnit)[0]
     dag_sim_unit = _get_units(dag.protocol_units, HybridTopologyMultiStateSimulationUnit)[0]
 
-    with tmpdir.as_cwd():
-        # Manually run the units
-        setup_results = dag_setup_unit.run(dry=True)
-        errmsg = "Simulations with virtual sites without velocity"
-        with pytest.raises(ValueError, match=errmsg):
-            sim_results = dag_sim_unit.run(
-                system=setup_results["hybrid_system"],
-                positions=setup_results["hybrid_positions"],
-                selection_indices=setup_results["selection_indices"],
-                dry=True,
-            )
+    # Manually run the units
+    setup_results = dag_setup_unit.run(
+        dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path
+    )
+    errmsg = "Simulations with virtual sites without velocity"
+    with pytest.raises(ValueError, match=errmsg):
+        _ = dag_sim_unit.run(
+            system=setup_results["hybrid_system"],
+            positions=setup_results["hybrid_positions"],
+            selection_indices=setup_results["selection_indices"],
+            dry=True,
+            scratch_basepath=tmp_path,
+            shared_basepath=tmp_path,
+        )
 
 
 def test_setup_dodecahdron_ligand_box(
-    benzene_system, toluene_system, benzene_to_toluene_mapping, solv_settings, tmpdir
+    benzene_system, toluene_system, benzene_to_toluene_mapping, solv_settings, tmp_path
 ):
     """
     Test that a hybrid system with a dodechadron is built properly.
@@ -1050,21 +1053,22 @@ def test_setup_dodecahdron_ligand_box(
     )
     dag_setup_unit = _get_units(dag.protocol_units, HybridTopologySetupUnit)[0]
 
-    with tmpdir.as_cwd():
-        hs = dag_setup_unit.run(dry=True)["hybrid_system"]
+    hs = dag_setup_unit.run(dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path)[
+        "hybrid_system"
+    ]
 
-        vectors = hs.getDefaultPeriodicBoxVectors()
+    vectors = hs.getDefaultPeriodicBoxVectors()
 
-        width = float(from_openmm(vectors)[0][0].to("nanometer").m)
-        # dodecahedron has the following shape:
-        # [width, 0, 0], [0, width, 0], [0.5, 0.5, 0.5 * sqrt(2)] * width
+    width = float(from_openmm(vectors)[0][0].to("nanometer").m)
+    # dodecahedron has the following shape:
+    # [width, 0, 0], [0, width, 0], [0.5, 0.5, 0.5 * sqrt(2)] * width
 
-        expected_vectors = [
-            [width, 0, 0],
-            [0, width, 0],
-            [0.5 * width, 0.5 * width, 0.5 * sqrt(2) * width],
-        ] * unit.nanometer
-        assert_allclose(expected_vectors, from_openmm(vectors))
+    expected_vectors = [
+        [width, 0, 0],
+        [0, width, 0],
+        [0.5 * width, 0.5 * width, 0.5 * sqrt(2) * width],
+    ] * unit.nanometer
+    assert_allclose(expected_vectors, from_openmm(vectors))
 
 
 @pytest.mark.slow
@@ -1075,7 +1079,7 @@ def test_dry_run_complex(
     benzene_to_toluene_mapping,
     method,
     solv_settings,
-    tmpdir,
+    tmp_path,
 ):
     # this will be very time consuming
     solv_settings.simulation_settings.sampler_method = method
@@ -1092,23 +1096,26 @@ def test_dry_run_complex(
     dag_setup_unit = _get_units(dag.protocol_units, HybridTopologySetupUnit)[0]
     dag_sim_unit = _get_units(dag.protocol_units, HybridTopologyMultiStateSimulationUnit)[0]
 
-    with tmpdir.as_cwd():
-        setup_results = dag_setup_unit.run(dry=True)
-        sim_results = dag_sim_unit.run(
-            system=setup_results["hybrid_system"],
-            positions=setup_results["hybrid_positions"],
-            selection_indices=setup_results["selection_indices"],
-            dry=True,
-        )
-        sampler = sim_results["sampler"]
-        assert isinstance(sampler, MultiStateSampler)
-        assert sampler.is_periodic
-        assert isinstance(sampler._thermodynamic_states[0].barostat, MonteCarloBarostat)
-        assert sampler._thermodynamic_states[1].pressure == 1 * omm_unit.bar
+    setup_results = dag_setup_unit.run(
+        dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path
+    )
+    sim_results = dag_sim_unit.run(
+        system=setup_results["hybrid_system"],
+        positions=setup_results["hybrid_positions"],
+        selection_indices=setup_results["selection_indices"],
+        dry=True,
+        scratch_basepath=tmp_path,
+        shared_basepath=tmp_path,
+    )
+    sampler = sim_results["sampler"]
+    assert isinstance(sampler, MultiStateSampler)
+    assert sampler.is_periodic
+    assert isinstance(sampler._thermodynamic_states[0].barostat, MonteCarloBarostat)
+    assert sampler._thermodynamic_states[1].pressure == 1 * omm_unit.bar
 
-        # Check we have the right number of atoms in the PDB
-        pdb = mdt.load_pdb("hybrid_system.pdb")
-        assert pdb.n_atoms == 2629
+    # Check we have the right number of atoms in the PDB
+    pdb = mdt.load_pdb(tmp_path / "hybrid_system.pdb")
+    assert pdb.n_atoms == 2629
 
 
 def test_lambda_schedule_default():
@@ -1125,7 +1132,7 @@ def test_lambda_schedule(windows):
 
 
 def test_setup_ligand_overlap_warning(
-    benzene_vacuum_system, toluene_vacuum_system, benzene_to_toluene_mapping, vac_settings, tmpdir
+    benzene_vacuum_system, toluene_vacuum_system, benzene_to_toluene_mapping, vac_settings, tmp_path
 ):
     protocol = openmm_rfe.RelativeHybridTopologyProtocol(
         settings=vac_settings,
@@ -1159,8 +1166,8 @@ def test_setup_ligand_overlap_warning(
         dag_setup_unit = [
             pu for pu in dag.protocol_units if isinstance(pu, HybridTopologySetupUnit)
         ][0]
-        with tmpdir.as_cwd():
-            dag_setup_unit.run(dry=True)
+
+        dag_setup_unit.run(dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path)
 
 
 @pytest.fixture
@@ -1218,7 +1225,7 @@ def unit_mock_patcher():
         yield
 
 
-def test_unit_tagging(solvent_protocol_dag, unit_mock_patcher, tmpdir):
+def test_unit_tagging(solvent_protocol_dag, unit_mock_patcher, tmp_path):
     # test that executing the Units includes correct generation and repeat info
     dag_units = solvent_protocol_dag.protocol_units
 
@@ -1232,18 +1239,18 @@ def test_unit_tagging(solvent_protocol_dag, unit_mock_patcher, tmpdir):
 
     for u in setup_units:
         rid = u.inputs["repeat_id"]
-        setup_results[rid] = u.execute(context=gufe.Context(tmpdir, tmpdir))
+        setup_results[rid] = u.execute(context=gufe.Context(tmp_path, tmp_path))
 
     for u in sim_units:
         rid = u.inputs["repeat_id"]
         sim_results[rid] = u.execute(
-            context=gufe.Context(tmpdir, tmpdir), setup_results=setup_results[rid]
+            context=gufe.Context(tmp_path, tmp_path), setup_results=setup_results[rid]
         )
 
     for u in analysis_units:
         rid = u.inputs["repeat_id"]
         analysis_results[rid] = u.execute(
-            context=gufe.Context(tmpdir, tmpdir),
+            context=gufe.Context(tmp_path, tmp_path),
             setup_results=setup_results[rid],
             simulation_results=sim_results[rid],
         )
@@ -1257,12 +1264,12 @@ def test_unit_tagging(solvent_protocol_dag, unit_mock_patcher, tmpdir):
     assert len(setup_results) == len(sim_results) == len(analysis_results) == 3
 
 
-def test_gather(solvent_protocol_dag, unit_mock_patcher, tmpdir):
+def test_gather(solvent_protocol_dag, unit_mock_patcher, tmp_path):
     # check .gather behaves as expected
     dagres = gufe.protocols.execute_DAG(
         solvent_protocol_dag,
-        shared_basedir=tmpdir,
-        scratch_basedir=tmpdir,
+        shared_basedir=tmp_path,
+        scratch_basedir=tmp_path,
         keep_shared=True,
     )
 
@@ -2040,7 +2047,7 @@ def _assert_total_charge(system, atom_classes, chgA, chgB):
     assert chgB == pytest.approx(np.sum(stateB_charges))
 
 
-def test_dry_run_alchemwater_solvent(benzene_to_benzoic_mapping, solv_settings, tmpdir):
+def test_dry_run_alchemwater_solvent(benzene_to_benzoic_mapping, solv_settings, tmp_path):
     stateA_system = openfe.ChemicalSystem(
         {
             "ligand": benzene_to_benzoic_mapping.componentA,
@@ -2067,14 +2074,13 @@ def test_dry_run_alchemwater_solvent(benzene_to_benzoic_mapping, solv_settings, 
 
     dag_setup_unit = _get_units(dag.protocol_units, HybridTopologySetupUnit)[0]
 
-    with tmpdir.as_cwd():
-        results = dag_setup_unit.run(dry=True)
-        htf = results["hybrid_factory"]
-        _assert_total_charge(htf.hybrid_system, htf._atom_classes, 0, 0)
+    results = dag_setup_unit.run(dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path)
+    htf = results["hybrid_factory"]
+    _assert_total_charge(htf.hybrid_system, htf._atom_classes, 0, 0)
 
-        assert len(htf._atom_classes["core_atoms"]) == 14
-        assert len(htf._atom_classes["unique_new_atoms"]) == 3
-        assert len(htf._atom_classes["unique_old_atoms"]) == 1
+    assert len(htf._atom_classes["core_atoms"]) == 14
+    assert len(htf._atom_classes["unique_new_atoms"]) == 3
+    assert len(htf._atom_classes["unique_old_atoms"]) == 1
 
 
 @pytest.mark.slow
@@ -2098,7 +2104,7 @@ def test_setup_complex_alchemwater_totcharge(
     core_atoms,
     new_uniq,
     old_uniq,
-    tmpdir,
+    tmp_path,
     request,
     T4_protein_component,
     solv_settings,
@@ -2136,24 +2142,24 @@ def test_setup_complex_alchemwater_totcharge(
     )
     dag_setup_unit = _get_units(dag.protocol_units, HybridTopologySetupUnit)[0]
 
-    with tmpdir.as_cwd():
-        setup_results = dag_setup_unit.run(dry=True)
-        htf = setup_results["hybrid_factory"]
-        _assert_total_charge(htf.hybrid_system, htf._atom_classes, chgA, chgB)
+    setup_results = dag_setup_unit.run(
+        dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path
+    )
+    htf = setup_results["hybrid_factory"]
+    _assert_total_charge(htf.hybrid_system, htf._atom_classes, chgA, chgB)
 
-        assert len(htf._atom_classes["core_atoms"]) == core_atoms
-        assert len(htf._atom_classes["unique_new_atoms"]) == new_uniq
-        assert len(htf._atom_classes["unique_old_atoms"]) == old_uniq
+    assert len(htf._atom_classes["core_atoms"]) == core_atoms
+    assert len(htf._atom_classes["unique_new_atoms"]) == new_uniq
+    assert len(htf._atom_classes["unique_old_atoms"]) == old_uniq
 
 
-def test_structural_analysis_error(tmpdir):
-    with tmpdir.as_cwd():
-        ret = openmm_rfe.hybridtop_units.HybridTopologyMultiStateAnalysisUnit._structural_analysis(
-            Path("."),
-            Path("."),
-            Path("."),
-            True,
-        )
+def test_structural_analysis_error(tmp_path):
+    ret = openmm_rfe.hybridtop_units.HybridTopologyMultiStateAnalysisUnit._structural_analysis(
+        Path(tmp_path),
+        Path(tmp_path),
+        Path(tmp_path),
+        True,
+    )
 
     assert "structural_analysis_error" in ret
     assert "structural_analysis" not in ret
@@ -2174,7 +2180,7 @@ def test_dry_run_vacuum_write_frequency(
     positions_write_frequency,
     velocities_write_frequency,
     vac_settings,
-    tmpdir,
+    tmp_path,
 ):
     vac_settings.output_settings.positions_write_frequency = positions_write_frequency
     vac_settings.output_settings.velocities_write_frequency = velocities_write_frequency
@@ -2195,24 +2201,27 @@ def test_dry_run_vacuum_write_frequency(
     dag_setup_unit = _get_units(dag.protocol_units, HybridTopologySetupUnit)[0]
     dag_sim_unit = _get_units(dag.protocol_units, HybridTopologyMultiStateSimulationUnit)[0]
 
-    with tmpdir.as_cwd():
-        # Manually run the units
-        setup_results = dag_setup_unit.run(dry=True)
+    # Manually run the units
+    setup_results = dag_setup_unit.run(
+        dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path
+    )
 
-        sim_results = dag_sim_unit.run(
-            system=setup_results["hybrid_system"],
-            positions=setup_results["hybrid_positions"],
-            selection_indices=setup_results["selection_indices"],
-            dry=True,
-        )
+    sim_results = dag_sim_unit.run(
+        system=setup_results["hybrid_system"],
+        positions=setup_results["hybrid_positions"],
+        selection_indices=setup_results["selection_indices"],
+        dry=True,
+        scratch_basepath=tmp_path,
+        shared_basepath=tmp_path,
+    )
 
-        sampler = sim_results["sampler"]
-        reporter = sampler._reporter
-        if positions_write_frequency:
-            assert reporter.position_interval == positions_write_frequency.m
-        else:
-            assert reporter.position_interval == 0
-        if velocities_write_frequency:
-            assert reporter.velocity_interval == velocities_write_frequency.m
-        else:
-            assert reporter.velocity_interval == 0
+    sampler = sim_results["sampler"]
+    reporter = sampler._reporter
+    if positions_write_frequency:
+        assert reporter.position_interval == positions_write_frequency.m
+    else:
+        assert reporter.position_interval == 0
+    if velocities_write_frequency:
+        assert reporter.velocity_interval == velocities_write_frequency.m
+    else:
+        assert reporter.velocity_interval == 0

--- a/src/openfe/tests/protocols/openmm_rfe/test_hybrid_top_resume.py
+++ b/src/openfe/tests/protocols/openmm_rfe/test_hybrid_top_resume.py
@@ -148,7 +148,7 @@ class TestCheckpointResuming:
 
         # 1. Check that the trajectory / checkpoint contain what we expect
         reporter = MultiStateReporter(
-            f"{tmp_path}/simulation.nc",
+            tmp_path / "simulation.nc",
             checkpoint_storage="checkpoint.chk",
         )
         sampler = HybridRepexSampler.from_storage(reporter)
@@ -194,7 +194,7 @@ class TestCheckpointResuming:
 
         # 3. Analyze the trajectory/checkpoint again
         reporter = MultiStateReporter(
-            f"{tmp_path}/simulation.nc",
+            tmp_path / "simulation.nc",
             checkpoint_storage="checkpoint.chk",
         )
         sampler = HybridRepexSampler.from_storage(reporter)
@@ -394,13 +394,13 @@ class TestCheckpointResuming:
         """
         # copy files
         if bad_file == "trajectory":
-            with open(f"{tmp_path}/simulation.nc", "w") as f:
+            with open(tmp_path / "simulation.nc", "w") as f:
                 f.write("foo")
         else:
             self._copy_simfiles(tmp_path, htop_trajectory_path)
 
         if bad_file == "checkpoint":
-            with open(f"{tmp_path}/checkpoint.chk", "w") as f:
+            with open(tmp_path / "checkpoint.chk", "w") as f:
                 f.write("bar")
         else:
             self._copy_simfiles(tmp_path, htop_checkpoint_path)

--- a/src/openfe/tests/protocols/openmm_rfe/test_hybrid_top_resume.py
+++ b/src/openfe/tests/protocols/openmm_rfe/test_hybrid_top_resume.py
@@ -133,23 +133,23 @@ class TestCheckpointResuming:
         return positions
 
     @staticmethod
-    def _copy_simfiles(cwd: pathlib.Path, filepath):
-        shutil.copyfile(filepath, f"{cwd}/{filepath.name}")
+    def _copy_simfiles(basedir: pathlib.Path, filepath):
+        shutil.copyfile(filepath, f"{basedir}/{filepath.name}")
 
     @pytest.mark.integration
-    def test_resume(self, protocol_dag, htop_trajectory_path, htop_checkpoint_path, tmpdir):
+    def test_resume(self, protocol_dag, htop_trajectory_path, htop_checkpoint_path, tmp_path):
         """
         Attempt to resume a simulation unit with pre-existing checkpoint &
         trajectory files.
         """
         # define a temp directory path & copy files
-        cwd = pathlib.Path(str(tmpdir))
-        self._copy_simfiles(cwd, htop_trajectory_path)
-        self._copy_simfiles(cwd, htop_checkpoint_path)
+        basedir = tmp_path
+        self._copy_simfiles(basedir, htop_trajectory_path)
+        self._copy_simfiles(basedir, htop_checkpoint_path)
 
         # 1. Check that the trajectory / checkpoint contain what we expect
         reporter = MultiStateReporter(
-            f"{cwd}/simulation.nc",
+            f"{basedir}/simulation.nc",
             checkpoint_storage="checkpoint.chk",
         )
         sampler = HybridRepexSampler.from_storage(reporter)
@@ -171,15 +171,15 @@ class TestCheckpointResuming:
         analysis_unit = _get_units(pus, HybridTopologyMultiStateAnalysisUnit)[0]
 
         # Dry run the setup since it'll be easier to use the objects directly
-        setup_results = setup_unit.run(dry=True, scratch_basepath=cwd, shared_basepath=cwd)
+        setup_results = setup_unit.run(dry=True, scratch_basepath=basedir, shared_basepath=basedir)
 
         # Now we run the simulation in resume mode
         sim_results = simulation_unit.run(
             system=setup_results["hybrid_system"],
             positions=setup_results["hybrid_positions"],
             selection_indices=setup_results["selection_indices"],
-            scratch_basepath=cwd,
-            shared_basepath=cwd,
+            scratch_basepath=basedir,
+            shared_basepath=basedir,
         )
 
         # Finally we analyze the results
@@ -187,13 +187,13 @@ class TestCheckpointResuming:
             pdb_file=setup_results["pdb_structure"],
             trajectory=sim_results["nc"],
             checkpoint=sim_results["checkpoint"],
-            scratch_basepath=cwd,
-            shared_basepath=cwd,
+            scratch_basepath=basedir,
+            shared_basepath=basedir,
         )
 
         # 3. Analyze the trajectory/checkpoint again
         reporter = MultiStateReporter(
-            f"{cwd}/simulation.nc",
+            f"{basedir}/simulation.nc",
             checkpoint_storage="checkpoint.chk",
         )
         sampler = HybridRepexSampler.from_storage(reporter)
@@ -214,12 +214,12 @@ class TestCheckpointResuming:
         del sampler
 
         # Check the openfe-analysis outputs are there
-        structural_analysis_file = cwd / "structural_analysis.npz"
+        structural_analysis_file = basedir / "structural_analysis.npz"
         assert (structural_analysis_file).exists()
 
     @pytest.mark.slow
     def test_resume_fail_particles(
-        self, protocol_dag, htop_trajectory_path, htop_checkpoint_path, tmpdir
+        self, protocol_dag, htop_trajectory_path, htop_checkpoint_path, tmp_path
     ):
         """
         Test that the run unit will fail with a system incompatible
@@ -228,16 +228,16 @@ class TestCheckpointResuming:
         Here we check that we don't have the same particles / mass.
         """
         # define a temp directory path & copy files
-        cwd = pathlib.Path(str(tmpdir))
-        self._copy_simfiles(cwd, htop_trajectory_path)
-        self._copy_simfiles(cwd, htop_checkpoint_path)
+        basedir = tmp_path
+        self._copy_simfiles(basedir, htop_trajectory_path)
+        self._copy_simfiles(basedir, htop_checkpoint_path)
 
         pus = list(protocol_dag.protocol_units)
         setup_unit = _get_units(pus, HybridTopologySetupUnit)[0]
         simulation_unit = _get_units(pus, HybridTopologyMultiStateSimulationUnit)[0]
 
         # Dry run the setup since it'll be easier to use the objects directly
-        setup_results = setup_unit.run(dry=True, scratch_basepath=cwd, shared_basepath=cwd)
+        setup_results = setup_unit.run(dry=True, scratch_basepath=basedir, shared_basepath=basedir)
 
         # Fake system should trigger a mismatch
         errmsg = "Stored checkpoint System particles do not"
@@ -246,13 +246,13 @@ class TestCheckpointResuming:
                 system=openmm.System(),
                 positions=setup_results["hybrid_positions"],
                 selection_indices=setup_results["selection_indices"],
-                scratch_basepath=cwd,
-                shared_basepath=cwd,
+                scratch_basepath=basedir,
+                shared_basepath=basedir,
             )
 
     @pytest.mark.slow
     def test_resume_fail_constraints(
-        self, protocol_dag, htop_trajectory_path, htop_checkpoint_path, tmpdir
+        self, protocol_dag, htop_trajectory_path, htop_checkpoint_path, tmp_path
     ):
         """
         Test that the run unit will fail with a system incompatible
@@ -261,16 +261,16 @@ class TestCheckpointResuming:
         Here we check that we don't have the same constraints.
         """
         # define a temp directory path & copy files
-        cwd = pathlib.Path(str(tmpdir))
-        self._copy_simfiles(cwd, htop_trajectory_path)
-        self._copy_simfiles(cwd, htop_checkpoint_path)
+        basedir = tmp_path
+        self._copy_simfiles(basedir, htop_trajectory_path)
+        self._copy_simfiles(basedir, htop_checkpoint_path)
 
         pus = list(protocol_dag.protocol_units)
         setup_unit = _get_units(pus, HybridTopologySetupUnit)[0]
         simulation_unit = _get_units(pus, HybridTopologyMultiStateSimulationUnit)[0]
 
         # Dry run the setup since it'll be easier to use the objects directly
-        setup_results = setup_unit.run(dry=True, scratch_basepath=cwd, shared_basepath=cwd)
+        setup_results = setup_unit.run(dry=True, scratch_basepath=basedir, shared_basepath=basedir)
 
         # Create a fake system without constraints
         fake_system = copy.deepcopy(setup_results["hybrid_system"])
@@ -285,13 +285,13 @@ class TestCheckpointResuming:
                 system=fake_system,
                 positions=setup_results["hybrid_positions"],
                 selection_indices=setup_results["selection_indices"],
-                scratch_basepath=cwd,
-                shared_basepath=cwd,
+                scratch_basepath=basedir,
+                shared_basepath=basedir,
             )
 
     @pytest.mark.slow
     def test_resume_fail_forces(
-        self, protocol_dag, htop_trajectory_path, htop_checkpoint_path, tmpdir
+        self, protocol_dag, htop_trajectory_path, htop_checkpoint_path, tmp_path
     ):
         """
         Test that the run unit will fail with a system incompatible
@@ -300,16 +300,16 @@ class TestCheckpointResuming:
         Here we check we don't have the same forces.
         """
         # define a temp directory path & copy files
-        cwd = pathlib.Path(str(tmpdir))
-        self._copy_simfiles(cwd, htop_trajectory_path)
-        self._copy_simfiles(cwd, htop_checkpoint_path)
+        basedir = tmp_path
+        self._copy_simfiles(basedir, htop_trajectory_path)
+        self._copy_simfiles(basedir, htop_checkpoint_path)
 
         pus = list(protocol_dag.protocol_units)
         setup_unit = _get_units(pus, HybridTopologySetupUnit)[0]
         simulation_unit = _get_units(pus, HybridTopologyMultiStateSimulationUnit)[0]
 
         # Dry run the setup since it'll be easier to use the objects directly
-        setup_results = setup_unit.run(dry=True, scratch_basepath=cwd, shared_basepath=cwd)
+        setup_results = setup_unit.run(dry=True, scratch_basepath=basedir, shared_basepath=basedir)
 
         # Create a fake system without the last force
         fake_system = copy.deepcopy(setup_results["hybrid_system"])
@@ -322,14 +322,14 @@ class TestCheckpointResuming:
                 system=fake_system,
                 positions=setup_results["hybrid_positions"],
                 selection_indices=setup_results["selection_indices"],
-                scratch_basepath=cwd,
-                shared_basepath=cwd,
+                scratch_basepath=basedir,
+                shared_basepath=basedir,
             )
 
     @pytest.mark.slow
     @pytest.mark.parametrize("forcetype", [openmm.NonbondedForce, openmm.MonteCarloBarostat])
     def test_resume_differ_forces(
-        self, forcetype, protocol_dag, htop_trajectory_path, htop_checkpoint_path, tmpdir
+        self, forcetype, protocol_dag, htop_trajectory_path, htop_checkpoint_path, tmp_path
     ):
         """
         Test that the run unit will fail with a system incompatible
@@ -338,16 +338,16 @@ class TestCheckpointResuming:
         Here we check we have a different force
         """
         # define a temp directory path & copy files
-        cwd = pathlib.Path(str(tmpdir))
-        self._copy_simfiles(cwd, htop_trajectory_path)
-        self._copy_simfiles(cwd, htop_checkpoint_path)
+        basedir = tmp_path
+        self._copy_simfiles(basedir, htop_trajectory_path)
+        self._copy_simfiles(basedir, htop_checkpoint_path)
 
         pus = list(protocol_dag.protocol_units)
         setup_unit = _get_units(pus, HybridTopologySetupUnit)[0]
         simulation_unit = _get_units(pus, HybridTopologyMultiStateSimulationUnit)[0]
 
         # Dry run the setup since it'll be easier to use the objects directly
-        setup_results = setup_unit.run(dry=True, scratch_basepath=cwd, shared_basepath=cwd)
+        setup_results = setup_unit.run(dry=True, scratch_basepath=basedir, shared_basepath=basedir)
 
         # Create a fake system with the fake forcetype
         fake_system = copy.deepcopy(setup_results["hybrid_system"])
@@ -374,77 +374,77 @@ class TestCheckpointResuming:
                 system=fake_system,
                 positions=setup_results["hybrid_positions"],
                 selection_indices=setup_results["selection_indices"],
-                scratch_basepath=cwd,
-                shared_basepath=cwd,
+                scratch_basepath=basedir,
+                shared_basepath=basedir,
             )
 
     @pytest.mark.slow
     @pytest.mark.parametrize("bad_file", ["trajectory", "checkpoint"])
     def test_resume_bad_files(
-        self, protocol_dag, htop_trajectory_path, htop_checkpoint_path, bad_file, tmpdir
+        self, protocol_dag, htop_trajectory_path, htop_checkpoint_path, bad_file, tmp_path
     ):
         """
         Test what happens when you have a bad trajectory and/or checkpoint
         files.
         """
         # define a temp directory path & copy files
-        cwd = pathlib.Path(str(tmpdir))
+        basedir = tmp_path
 
         if bad_file == "trajectory":
-            with open(f"{cwd}/simulation.nc", "w") as f:
+            with open(f"{basedir}/simulation.nc", "w") as f:
                 f.write("foo")
         else:
-            self._copy_simfiles(cwd, htop_trajectory_path)
+            self._copy_simfiles(basedir, htop_trajectory_path)
 
         if bad_file == "checkpoint":
-            with open(f"{cwd}/checkpoint.chk", "w") as f:
+            with open(f"{basedir}/checkpoint.chk", "w") as f:
                 f.write("bar")
         else:
-            self._copy_simfiles(cwd, htop_checkpoint_path)
+            self._copy_simfiles(basedir, htop_checkpoint_path)
 
         pus = list(protocol_dag.protocol_units)
         setup_unit = _get_units(pus, HybridTopologySetupUnit)[0]
         simulation_unit = _get_units(pus, HybridTopologyMultiStateSimulationUnit)[0]
 
         # Dry run the setup since it'll be easier to use the objects directly
-        setup_results = setup_unit.run(dry=True, scratch_basepath=cwd, shared_basepath=cwd)
+        setup_results = setup_unit.run(dry=True, scratch_basepath=basedir, shared_basepath=basedir)
 
         with pytest.raises(OSError, match="Unknown file format"):
             _ = simulation_unit.run(
                 system=setup_results["hybrid_system"],
                 positions=setup_results["hybrid_positions"],
                 selection_indices=setup_results["selection_indices"],
-                scratch_basepath=cwd,
-                shared_basepath=cwd,
+                scratch_basepath=basedir,
+                shared_basepath=basedir,
             )
 
     @pytest.mark.slow
     @pytest.mark.parametrize("missing_file", ["trajectory", "checkpoint"])
     def test_missing_file(
-        self, protocol_dag, htop_trajectory_path, htop_checkpoint_path, missing_file, tmpdir
+        self, protocol_dag, htop_trajectory_path, htop_checkpoint_path, missing_file, tmp_path
     ):
         """
         Test that an error is thrown if either file is missing but the other isn't.
         """
         # define a temp directory path & copy files
-        cwd = pathlib.Path(str(tmpdir))
+        basedir = tmp_path
 
         if missing_file == "trajectory":
             pass
         else:
-            self._copy_simfiles(cwd, htop_trajectory_path)
+            self._copy_simfiles(basedir, htop_trajectory_path)
 
         if missing_file == "checkpoint":
             pass
         else:
-            self._copy_simfiles(cwd, htop_checkpoint_path)
+            self._copy_simfiles(basedir, htop_checkpoint_path)
 
         pus = list(protocol_dag.protocol_units)
         setup_unit = _get_units(pus, HybridTopologySetupUnit)[0]
         simulation_unit = _get_units(pus, HybridTopologyMultiStateSimulationUnit)[0]
 
         # Dry run the setup since it'll be easier to use the objects directly
-        setup_results = setup_unit.run(dry=True, scratch_basepath=cwd, shared_basepath=cwd)
+        setup_results = setup_unit.run(dry=True, scratch_basepath=basedir, shared_basepath=basedir)
 
         errmsg = f"file is present but not the {missing_file} file."
         with pytest.raises(IOError, match=errmsg):
@@ -452,6 +452,6 @@ class TestCheckpointResuming:
                 system=setup_results["hybrid_system"],
                 positions=setup_results["hybrid_positions"],
                 selection_indices=setup_results["selection_indices"],
-                scratch_basepath=cwd,
-                shared_basepath=cwd,
+                scratch_basepath=basedir,
+                shared_basepath=basedir,
             )

--- a/src/openfe/tests/protocols/openmm_rfe/test_hybrid_top_resume.py
+++ b/src/openfe/tests/protocols/openmm_rfe/test_hybrid_top_resume.py
@@ -142,14 +142,13 @@ class TestCheckpointResuming:
         Attempt to resume a simulation unit with pre-existing checkpoint &
         trajectory files.
         """
-        # define a temp directory path & copy files
-        basedir = tmp_path
-        self._copy_simfiles(basedir, htop_trajectory_path)
-        self._copy_simfiles(basedir, htop_checkpoint_path)
+        # copy files
+        self._copy_simfiles(tmp_path, htop_trajectory_path)
+        self._copy_simfiles(tmp_path, htop_checkpoint_path)
 
         # 1. Check that the trajectory / checkpoint contain what we expect
         reporter = MultiStateReporter(
-            f"{basedir}/simulation.nc",
+            f"{tmp_path}/simulation.nc",
             checkpoint_storage="checkpoint.chk",
         )
         sampler = HybridRepexSampler.from_storage(reporter)
@@ -171,15 +170,17 @@ class TestCheckpointResuming:
         analysis_unit = _get_units(pus, HybridTopologyMultiStateAnalysisUnit)[0]
 
         # Dry run the setup since it'll be easier to use the objects directly
-        setup_results = setup_unit.run(dry=True, scratch_basepath=basedir, shared_basepath=basedir)
+        setup_results = setup_unit.run(
+            dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path
+        )
 
         # Now we run the simulation in resume mode
         sim_results = simulation_unit.run(
             system=setup_results["hybrid_system"],
             positions=setup_results["hybrid_positions"],
             selection_indices=setup_results["selection_indices"],
-            scratch_basepath=basedir,
-            shared_basepath=basedir,
+            scratch_basepath=tmp_path,
+            shared_basepath=tmp_path,
         )
 
         # Finally we analyze the results
@@ -187,13 +188,13 @@ class TestCheckpointResuming:
             pdb_file=setup_results["pdb_structure"],
             trajectory=sim_results["nc"],
             checkpoint=sim_results["checkpoint"],
-            scratch_basepath=basedir,
-            shared_basepath=basedir,
+            scratch_basepath=tmp_path,
+            shared_basepath=tmp_path,
         )
 
         # 3. Analyze the trajectory/checkpoint again
         reporter = MultiStateReporter(
-            f"{basedir}/simulation.nc",
+            f"{tmp_path}/simulation.nc",
             checkpoint_storage="checkpoint.chk",
         )
         sampler = HybridRepexSampler.from_storage(reporter)
@@ -214,7 +215,7 @@ class TestCheckpointResuming:
         del sampler
 
         # Check the openfe-analysis outputs are there
-        structural_analysis_file = basedir / "structural_analysis.npz"
+        structural_analysis_file = tmp_path / "structural_analysis.npz"
         assert (structural_analysis_file).exists()
 
     @pytest.mark.slow
@@ -227,17 +228,18 @@ class TestCheckpointResuming:
 
         Here we check that we don't have the same particles / mass.
         """
-        # define a temp directory path & copy files
-        basedir = tmp_path
-        self._copy_simfiles(basedir, htop_trajectory_path)
-        self._copy_simfiles(basedir, htop_checkpoint_path)
+        # copy files
+        self._copy_simfiles(tmp_path, htop_trajectory_path)
+        self._copy_simfiles(tmp_path, htop_checkpoint_path)
 
         pus = list(protocol_dag.protocol_units)
         setup_unit = _get_units(pus, HybridTopologySetupUnit)[0]
         simulation_unit = _get_units(pus, HybridTopologyMultiStateSimulationUnit)[0]
 
         # Dry run the setup since it'll be easier to use the objects directly
-        setup_results = setup_unit.run(dry=True, scratch_basepath=basedir, shared_basepath=basedir)
+        setup_results = setup_unit.run(
+            dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path
+        )
 
         # Fake system should trigger a mismatch
         errmsg = "Stored checkpoint System particles do not"
@@ -246,8 +248,8 @@ class TestCheckpointResuming:
                 system=openmm.System(),
                 positions=setup_results["hybrid_positions"],
                 selection_indices=setup_results["selection_indices"],
-                scratch_basepath=basedir,
-                shared_basepath=basedir,
+                scratch_basepath=tmp_path,
+                shared_basepath=tmp_path,
             )
 
     @pytest.mark.slow
@@ -260,17 +262,18 @@ class TestCheckpointResuming:
 
         Here we check that we don't have the same constraints.
         """
-        # define a temp directory path & copy files
-        basedir = tmp_path
-        self._copy_simfiles(basedir, htop_trajectory_path)
-        self._copy_simfiles(basedir, htop_checkpoint_path)
+        # copy files
+        self._copy_simfiles(tmp_path, htop_trajectory_path)
+        self._copy_simfiles(tmp_path, htop_checkpoint_path)
 
         pus = list(protocol_dag.protocol_units)
         setup_unit = _get_units(pus, HybridTopologySetupUnit)[0]
         simulation_unit = _get_units(pus, HybridTopologyMultiStateSimulationUnit)[0]
 
         # Dry run the setup since it'll be easier to use the objects directly
-        setup_results = setup_unit.run(dry=True, scratch_basepath=basedir, shared_basepath=basedir)
+        setup_results = setup_unit.run(
+            dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path
+        )
 
         # Create a fake system without constraints
         fake_system = copy.deepcopy(setup_results["hybrid_system"])
@@ -285,8 +288,8 @@ class TestCheckpointResuming:
                 system=fake_system,
                 positions=setup_results["hybrid_positions"],
                 selection_indices=setup_results["selection_indices"],
-                scratch_basepath=basedir,
-                shared_basepath=basedir,
+                scratch_basepath=tmp_path,
+                shared_basepath=tmp_path,
             )
 
     @pytest.mark.slow
@@ -299,17 +302,18 @@ class TestCheckpointResuming:
 
         Here we check we don't have the same forces.
         """
-        # define a temp directory path & copy files
-        basedir = tmp_path
-        self._copy_simfiles(basedir, htop_trajectory_path)
-        self._copy_simfiles(basedir, htop_checkpoint_path)
+        # copy files
+        self._copy_simfiles(tmp_path, htop_trajectory_path)
+        self._copy_simfiles(tmp_path, htop_checkpoint_path)
 
         pus = list(protocol_dag.protocol_units)
         setup_unit = _get_units(pus, HybridTopologySetupUnit)[0]
         simulation_unit = _get_units(pus, HybridTopologyMultiStateSimulationUnit)[0]
 
         # Dry run the setup since it'll be easier to use the objects directly
-        setup_results = setup_unit.run(dry=True, scratch_basepath=basedir, shared_basepath=basedir)
+        setup_results = setup_unit.run(
+            dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path
+        )
 
         # Create a fake system without the last force
         fake_system = copy.deepcopy(setup_results["hybrid_system"])
@@ -322,8 +326,8 @@ class TestCheckpointResuming:
                 system=fake_system,
                 positions=setup_results["hybrid_positions"],
                 selection_indices=setup_results["selection_indices"],
-                scratch_basepath=basedir,
-                shared_basepath=basedir,
+                scratch_basepath=tmp_path,
+                shared_basepath=tmp_path,
             )
 
     @pytest.mark.slow
@@ -337,17 +341,18 @@ class TestCheckpointResuming:
 
         Here we check we have a different force
         """
-        # define a temp directory path & copy files
-        basedir = tmp_path
-        self._copy_simfiles(basedir, htop_trajectory_path)
-        self._copy_simfiles(basedir, htop_checkpoint_path)
+        # copy files
+        self._copy_simfiles(tmp_path, htop_trajectory_path)
+        self._copy_simfiles(tmp_path, htop_checkpoint_path)
 
         pus = list(protocol_dag.protocol_units)
         setup_unit = _get_units(pus, HybridTopologySetupUnit)[0]
         simulation_unit = _get_units(pus, HybridTopologyMultiStateSimulationUnit)[0]
 
         # Dry run the setup since it'll be easier to use the objects directly
-        setup_results = setup_unit.run(dry=True, scratch_basepath=basedir, shared_basepath=basedir)
+        setup_results = setup_unit.run(
+            dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path
+        )
 
         # Create a fake system with the fake forcetype
         fake_system = copy.deepcopy(setup_results["hybrid_system"])
@@ -374,8 +379,8 @@ class TestCheckpointResuming:
                 system=fake_system,
                 positions=setup_results["hybrid_positions"],
                 selection_indices=setup_results["selection_indices"],
-                scratch_basepath=basedir,
-                shared_basepath=basedir,
+                scratch_basepath=tmp_path,
+                shared_basepath=tmp_path,
             )
 
     @pytest.mark.slow
@@ -387,35 +392,35 @@ class TestCheckpointResuming:
         Test what happens when you have a bad trajectory and/or checkpoint
         files.
         """
-        # define a temp directory path & copy files
-        basedir = tmp_path
-
+        # copy files
         if bad_file == "trajectory":
-            with open(f"{basedir}/simulation.nc", "w") as f:
+            with open(f"{tmp_path}/simulation.nc", "w") as f:
                 f.write("foo")
         else:
-            self._copy_simfiles(basedir, htop_trajectory_path)
+            self._copy_simfiles(tmp_path, htop_trajectory_path)
 
         if bad_file == "checkpoint":
-            with open(f"{basedir}/checkpoint.chk", "w") as f:
+            with open(f"{tmp_path}/checkpoint.chk", "w") as f:
                 f.write("bar")
         else:
-            self._copy_simfiles(basedir, htop_checkpoint_path)
+            self._copy_simfiles(tmp_path, htop_checkpoint_path)
 
         pus = list(protocol_dag.protocol_units)
         setup_unit = _get_units(pus, HybridTopologySetupUnit)[0]
         simulation_unit = _get_units(pus, HybridTopologyMultiStateSimulationUnit)[0]
 
         # Dry run the setup since it'll be easier to use the objects directly
-        setup_results = setup_unit.run(dry=True, scratch_basepath=basedir, shared_basepath=basedir)
+        setup_results = setup_unit.run(
+            dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path
+        )
 
         with pytest.raises(OSError, match="Unknown file format"):
             _ = simulation_unit.run(
                 system=setup_results["hybrid_system"],
                 positions=setup_results["hybrid_positions"],
                 selection_indices=setup_results["selection_indices"],
-                scratch_basepath=basedir,
-                shared_basepath=basedir,
+                scratch_basepath=tmp_path,
+                shared_basepath=tmp_path,
             )
 
     @pytest.mark.slow
@@ -426,25 +431,25 @@ class TestCheckpointResuming:
         """
         Test that an error is thrown if either file is missing but the other isn't.
         """
-        # define a temp directory path & copy files
-        basedir = tmp_path
-
+        # copy files
         if missing_file == "trajectory":
             pass
         else:
-            self._copy_simfiles(basedir, htop_trajectory_path)
+            self._copy_simfiles(tmp_path, htop_trajectory_path)
 
         if missing_file == "checkpoint":
             pass
         else:
-            self._copy_simfiles(basedir, htop_checkpoint_path)
+            self._copy_simfiles(tmp_path, htop_checkpoint_path)
 
         pus = list(protocol_dag.protocol_units)
         setup_unit = _get_units(pus, HybridTopologySetupUnit)[0]
         simulation_unit = _get_units(pus, HybridTopologyMultiStateSimulationUnit)[0]
 
         # Dry run the setup since it'll be easier to use the objects directly
-        setup_results = setup_unit.run(dry=True, scratch_basepath=basedir, shared_basepath=basedir)
+        setup_results = setup_unit.run(
+            dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path
+        )
 
         errmsg = f"file is present but not the {missing_file} file."
         with pytest.raises(IOError, match=errmsg):
@@ -452,6 +457,6 @@ class TestCheckpointResuming:
                 system=setup_results["hybrid_system"],
                 positions=setup_results["hybrid_positions"],
                 selection_indices=setup_results["selection_indices"],
-                scratch_basepath=basedir,
-                shared_basepath=basedir,
+                scratch_basepath=tmp_path,
+                shared_basepath=tmp_path,
             )

--- a/src/openfe/tests/protocols/openmm_rfe/test_hybrid_top_slow.py
+++ b/src/openfe/tests/protocols/openmm_rfe/test_hybrid_top_slow.py
@@ -21,7 +21,7 @@ def test_openmm_run_engine(
     platform,
     get_available_openmm_platforms,
     benzene_modifications,
-    tmpdir,
+    tmp_path,
 ):
     if platform not in get_available_openmm_platforms:
         pytest.skip(f"OpenMM Platform: {platform} not available")
@@ -58,15 +58,14 @@ def test_openmm_run_engine(
         mapping=[m],
     )
 
-    cwd = pathlib.Path(str(tmpdir))
-    r = execute_DAG(dag, shared_basedir=cwd, scratch_basedir=cwd, keep_shared=True)
+    r = execute_DAG(dag, shared_basedir=tmp_path, scratch_basedir=tmp_path, keep_shared=True)
 
     assert r.ok()
 
     # Get the path to the simulation unit shared
     for pur in r.protocol_unit_results:
         if "Simulation" in pur.name:
-            sim_shared = tmpdir / f"shared_{pur.source_key}_attempt_0"
+            sim_shared = tmp_path / f"shared_{pur.source_key}_attempt_0"
             assert sim_shared.exists()
             assert pathlib.Path(sim_shared).is_dir()
 
@@ -74,7 +73,7 @@ def test_openmm_run_engine(
         if "Analysis" not in pur.name:
             continue
 
-        analysis_shared = tmpdir / f"shared_{pur.source_key}_attempt_0"
+        analysis_shared = tmp_path / f"shared_{pur.source_key}_attempt_0"
         assert analysis_shared.exists()
         assert pathlib.Path(analysis_shared).is_dir()
 
@@ -129,7 +128,7 @@ def test_openmm_run_engine(
     HAS_OPENEYE and HAS_NAGL,
     reason="NAGL/openeye incompatibility. See https://github.com/openforcefield/openff-nagl/issues/177",
 )
-def test_run_eg5_sim(eg5_protein, eg5_ligands, eg5_cofactor, tmpdir):
+def test_run_eg5_sim(eg5_protein, eg5_ligands, eg5_cofactor, tmp_path):
     # this runs a very short eg5 complex leg
     # different to previous test:
     # - has a cofactor
@@ -167,15 +166,14 @@ def test_run_eg5_sim(eg5_protein, eg5_ligands, eg5_cofactor, tmpdir):
 
     dag = p.create(stateA=sys1, stateB=sys2, mapping=[m])
 
-    cwd = pathlib.Path(str(tmpdir))
-    r = execute_DAG(dag, shared_basedir=cwd, scratch_basedir=cwd, keep_shared=True)
+    r = execute_DAG(dag, shared_basedir=tmp_path, scratch_basedir=tmp_path, keep_shared=True)
 
     assert r.ok()
 
 
 @pytest.mark.integration
 @pytest.mark.flaky(reruns=3)
-def test_run_dodecahedron_sim(benzene_system, toluene_system, benzene_to_toluene_mapping, tmpdir):
+def test_run_dodecahedron_sim(benzene_system, toluene_system, benzene_to_toluene_mapping, tmp_path):
     """
     Test that we can run a ligand in solvent RFE with a non-cubic box
     """
@@ -195,12 +193,10 @@ def test_run_dodecahedron_sim(benzene_system, toluene_system, benzene_to_toluene
         mapping=benzene_to_toluene_mapping,
     )
 
-    cwd = pathlib.Path(str(tmpdir))
-
     r = execute_DAG(
         dag,
-        shared_basedir=cwd,
-        scratch_basedir=cwd,
+        shared_basedir=tmp_path,
+        scratch_basedir=tmp_path,
         keep_shared=True,
     )
 

--- a/src/openfe/tests/protocols/openmm_rfe/test_hybrid_top_validation.py
+++ b/src/openfe/tests/protocols/openmm_rfe/test_hybrid_top_validation.py
@@ -588,7 +588,6 @@ def test_n_replicas_not_n_windows(
     toluene_vacuum_system,
     benzene_to_toluene_mapping,
     vac_settings,
-    tmpdir,
 ):
     # For PR #125 we pin such that the number of lambda windows
     # equals the numbers of replicas used - TODO: remove limitation

--- a/src/openfe/tests/protocols/openmm_septop/test_septop_protocol.py
+++ b/src/openfe/tests/protocols/openmm_septop/test_septop_protocol.py
@@ -1235,7 +1235,7 @@ class TestT4LXmlRegression:
             assert a[2] == b[2]
 
 
-def test_unit_tagging(benzene_toluene_dag, tmpdir):
+def test_unit_tagging(benzene_toluene_dag, tmp_path):
     # test that executing the units includes correct gen and repeat info
     dag_units = benzene_toluene_dag.protocol_units
     with (
@@ -1280,7 +1280,7 @@ def test_unit_tagging(benzene_toluene_dag, tmpdir):
     ):
         results = []
         for u in dag_units:
-            ret = u.execute(context=gufe.Context(tmpdir, tmpdir))
+            ret = u.execute(context=gufe.Context(tmp_path, tmp_path))
             results.append(ret)
     solv_repeats = set()
     complex_repeats = set()
@@ -1295,7 +1295,7 @@ def test_unit_tagging(benzene_toluene_dag, tmpdir):
     assert len(complex_repeats) == len(solv_repeats) == 2
 
 
-def test_gather(benzene_toluene_dag, tmpdir):
+def test_gather(benzene_toluene_dag, tmp_path):
     # check that .gather behaves as expected
     with (
         mock.patch(
@@ -1339,8 +1339,8 @@ def test_gather(benzene_toluene_dag, tmpdir):
     ):
         dagres = gufe.protocols.execute_DAG(
             benzene_toluene_dag,
-            shared_basedir=tmpdir,
-            scratch_basedir=tmpdir,
+            shared_basedir=tmp_path,
+            scratch_basedir=tmp_path,
             keep_shared=True,
         )
 

--- a/src/openfe/tests/protocols/openmm_septop/test_septop_protocol.py
+++ b/src/openfe/tests/protocols/openmm_septop/test_septop_protocol.py
@@ -695,7 +695,7 @@ def benzene_toluene_dag(
     )
 
 
-def test_dry_run_benzene_toluene(benzene_toluene_dag, tmpdir):
+def test_dry_run_benzene_toluene(benzene_toluene_dag, tmp_path):
     prot_units = list(benzene_toluene_dag.protocol_units)
 
     assert len(prot_units) == 4
@@ -709,81 +709,84 @@ def test_dry_run_benzene_toluene(benzene_toluene_dag, tmpdir):
     assert len(complex_setup_unit) == 1
     assert len(complex_run_unit) == 1
 
-    with tmpdir.as_cwd():
-        solv_setup_output = solv_setup_unit[0].run(dry=True)
-        pdb = md.load_pdb("topology.pdb")
-        assert pdb.n_atoms == 1762
-        central_atoms = np.array([[2, 19]], dtype=np.int32)
-        distance = md.compute_distances(pdb, central_atoms)[0][0]
-        assert np.isclose(distance, 0.8661)
-        serialized_topology = solv_setup_output["topology"]
-        serialized_system = solv_setup_output["system"]
-        solv_sampler = sol_run_unit[0].run(
-            serialized_system, serialized_topology, dry=True
-        )["debug"]["sampler"]  # fmt: skip
+    solv_setup_output = solv_setup_unit[0].run(
+        dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path
+    )
+    pdb = md.load_pdb(tmp_path / "topology.pdb")
+    assert pdb.n_atoms == 1762
+    central_atoms = np.array([[2, 19]], dtype=np.int32)
+    distance = md.compute_distances(pdb, central_atoms)[0][0]
+    assert np.isclose(distance, 0.8661)
+    serialized_topology = solv_setup_output["topology"]
+    serialized_system = solv_setup_output["system"]
+    solv_sampler = sol_run_unit[0].run(
+        serialized_system, serialized_topology, dry=True,scratch_basepath=tmp_path, shared_basepath=tmp_path
+    )["debug"]["sampler"]  # fmt: skip
 
-        assert solv_sampler.is_periodic
-        assert isinstance(solv_sampler, MultiStateSampler)
-        assert isinstance(solv_sampler._thermodynamic_states[0].barostat, MonteCarloBarostat)
-        assert solv_sampler._thermodynamic_states[1].pressure == 1 * openmm.unit.bar
-        # Check we have the right number of atoms in the PDB
-        pdb = md.load_pdb("alchemical_system.pdb")
-        assert pdb.n_atoms == 31
+    assert solv_sampler.is_periodic
+    assert isinstance(solv_sampler, MultiStateSampler)
+    assert isinstance(solv_sampler._thermodynamic_states[0].barostat, MonteCarloBarostat)
+    assert solv_sampler._thermodynamic_states[1].pressure == 1 * openmm.unit.bar
+    # Check we have the right number of atoms in the PDB
+    pdb = md.load_pdb(tmp_path / "alchemical_system.pdb")
+    assert pdb.n_atoms == 31
 
-        # Test the solvent system
-        alchem_system = deserialize(serialized_system)
-        assert len(alchem_system.getForces()) == 14
-        _assert_num_forces(alchem_system, NonbondedForce, 1)
-        _assert_num_forces(alchem_system, CustomNonbondedForce, 4)
-        _assert_num_forces(alchem_system, CustomBondForce, 4)
-        _assert_num_forces(alchem_system, HarmonicBondForce, 2)
-        _assert_num_forces(alchem_system, HarmonicAngleForce, 1)
-        _assert_num_forces(alchem_system, PeriodicTorsionForce, 1)
-        _assert_num_forces(alchem_system, MonteCarloBarostat, 1)
+    # Test the solvent system
+    alchem_system = deserialize(serialized_system)
+    assert len(alchem_system.getForces()) == 14
+    _assert_num_forces(alchem_system, NonbondedForce, 1)
+    _assert_num_forces(alchem_system, CustomNonbondedForce, 4)
+    _assert_num_forces(alchem_system, CustomBondForce, 4)
+    _assert_num_forces(alchem_system, HarmonicBondForce, 2)
+    _assert_num_forces(alchem_system, HarmonicAngleForce, 1)
+    _assert_num_forces(alchem_system, PeriodicTorsionForce, 1)
+    _assert_num_forces(alchem_system, MonteCarloBarostat, 1)
 
-        # Check steric forces
-        for f in alchem_system.getForces():
-            if isinstance(f, CustomNonbondedForce) and "U_sterics" in f.getEnergyFunction():
-                _verify_alchemical_sterics_force_parameters(f)
+    # Check steric forces
+    for f in alchem_system.getForces():
+        if isinstance(f, CustomNonbondedForce) and "U_sterics" in f.getEnergyFunction():
+            _verify_alchemical_sterics_force_parameters(f)
 
-        complex_setup_output = complex_setup_unit[0].run(dry=True)
-        serialized_topology = complex_setup_output["topology"]
-        serialized_system = complex_setup_output["system"]
-        complex_sampler = complex_run_unit[0].run(
-            serialized_system, serialized_topology, dry=True
-        )["debug"]["sampler"]  # fmt: skip
+    complex_setup_output = complex_setup_unit[0].run(
+        dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path
+    )
+    serialized_topology = complex_setup_output["topology"]
+    serialized_system = complex_setup_output["system"]
+    complex_sampler = complex_run_unit[0].run(
+        serialized_system, serialized_topology, dry=True,scratch_basepath=tmp_path, shared_basepath=tmp_path
+    )["debug"]["sampler"]  # fmt: skip
 
-        assert complex_sampler.is_periodic
-        assert isinstance(complex_sampler, MultiStateSampler)
-        assert isinstance(complex_sampler._thermodynamic_states[0].barostat, MonteCarloBarostat)
-        assert complex_sampler._thermodynamic_states[1].pressure == 1 * openmm.unit.bar
-        # Check we have the right number of atoms in the PDB
-        pdb = md.load_pdb("alchemical_system.pdb")
-        assert pdb.n_atoms == 2687
+    assert complex_sampler.is_periodic
+    assert isinstance(complex_sampler, MultiStateSampler)
+    assert isinstance(complex_sampler._thermodynamic_states[0].barostat, MonteCarloBarostat)
+    assert complex_sampler._thermodynamic_states[1].pressure == 1 * openmm.unit.bar
+    # Check we have the right number of atoms in the PDB
+    pdb = md.load_pdb(tmp_path / "alchemical_system.pdb")
+    assert pdb.n_atoms == 2687
 
-        # Test the complex system
-        alchem_system = deserialize(serialized_system)
-        assert len(alchem_system.getForces()) == 15
-        _assert_num_forces(alchem_system, NonbondedForce, 1)
-        _assert_num_forces(alchem_system, CustomNonbondedForce, 4)
-        _assert_num_forces(alchem_system, CustomBondForce, 4)
-        _assert_num_forces(alchem_system, HarmonicBondForce, 1)
-        _assert_num_forces(alchem_system, HarmonicAngleForce, 1)
-        _assert_num_forces(alchem_system, PeriodicTorsionForce, 1)
-        _assert_num_forces(alchem_system, CustomCompoundBondForce, 2)
-        _assert_num_forces(alchem_system, MonteCarloBarostat, 1)
+    # Test the complex system
+    alchem_system = deserialize(serialized_system)
+    assert len(alchem_system.getForces()) == 15
+    _assert_num_forces(alchem_system, NonbondedForce, 1)
+    _assert_num_forces(alchem_system, CustomNonbondedForce, 4)
+    _assert_num_forces(alchem_system, CustomBondForce, 4)
+    _assert_num_forces(alchem_system, HarmonicBondForce, 1)
+    _assert_num_forces(alchem_system, HarmonicAngleForce, 1)
+    _assert_num_forces(alchem_system, PeriodicTorsionForce, 1)
+    _assert_num_forces(alchem_system, CustomCompoundBondForce, 2)
+    _assert_num_forces(alchem_system, MonteCarloBarostat, 1)
 
-        # Check steric forces
-        for f in alchem_system.getForces():
-            if isinstance(f, CustomNonbondedForce) and "U_sterics" in f.getEnergyFunction():
-                _verify_alchemical_sterics_force_parameters(f)
+    # Check steric forces
+    for f in alchem_system.getForces():
+        if isinstance(f, CustomNonbondedForce) and "U_sterics" in f.getEnergyFunction():
+            _verify_alchemical_sterics_force_parameters(f)
 
 
 @pytest.mark.parametrize("method", ["repex", "sams", "independent"])
 def test_dry_run_methods(
     benzene_complex_system,
     toluene_complex_system,
-    tmpdir,
+    tmp_path,
     protocol_dry_settings,
     method,
 ):
@@ -804,22 +807,24 @@ def test_dry_run_methods(
     # Only check the cutoff for the Solvent SetUp Unit
     solv_setup_unit = [u for u in dag_units if isinstance(u, SepTopSolventSetupUnit)]
     sol_run_unit = [u for u in dag_units if isinstance(u, SepTopSolventRunUnit)]
-    with tmpdir.as_cwd():
-        solv_setup_output = solv_setup_unit[0].run(dry=True)
-        serialized_topology = solv_setup_output["topology"]
-        serialized_system = solv_setup_output["system"]
-        solv_sampler = sol_run_unit[0].run(
-            serialized_system, serialized_topology, dry=True
-        )["debug"]["sampler"]  # fmt: skip
 
-        assert isinstance(solv_sampler, MultiStateSampler)
-        assert solv_sampler.is_periodic
-        assert isinstance(solv_sampler._thermodynamic_states[0].barostat, MonteCarloBarostat)
-        assert solv_sampler._thermodynamic_states[1].pressure == 1 * openmm.unit.bar
+    solv_setup_output = solv_setup_unit[0].run(
+        dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path
+    )
+    serialized_topology = solv_setup_output["topology"]
+    serialized_system = solv_setup_output["system"]
+    solv_sampler = sol_run_unit[0].run(
+        serialized_system, serialized_topology, dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path
+    )["debug"]["sampler"]  # fmt: skip
 
-        # Check we have the right number of atoms in the PDB
-        pdb = md.load_pdb("alchemical_system.pdb")
-        assert pdb.n_atoms == 27
+    assert isinstance(solv_sampler, MultiStateSampler)
+    assert solv_sampler.is_periodic
+    assert isinstance(solv_sampler._thermodynamic_states[0].barostat, MonteCarloBarostat)
+    assert solv_sampler._thermodynamic_states[1].pressure == 1 * openmm.unit.bar
+
+    # Check we have the right number of atoms in the PDB
+    pdb = md.load_pdb(tmp_path / "alchemical_system.pdb")
+    assert pdb.n_atoms == 27
 
 
 @pytest.mark.parametrize(
@@ -834,7 +839,7 @@ def test_dry_run_ligand_system_pressure(
     pressure,
     benzene_complex_system,
     toluene_complex_system,
-    tmpdir,
+    tmp_path,
     protocol_dry_settings,
 ):
     """
@@ -855,22 +860,23 @@ def test_dry_run_ligand_system_pressure(
     # Only check the cutoff for the Solvent SetUp Unit
     solv_setup_unit = [u for u in dag_units if isinstance(u, SepTopSolventSetupUnit)]
     sol_run_unit = [u for u in dag_units if isinstance(u, SepTopSolventRunUnit)]
-    with tmpdir.as_cwd():
-        solv_setup_output = solv_setup_unit[0].run(dry=True)
-        serialized_topology = solv_setup_output["topology"]
-        serialized_system = solv_setup_output["system"]
-        solv_sampler = sol_run_unit[0].run(
-            serialized_system, serialized_topology, dry=True
-        )["debug"]["sampler"]  # fmt: skip
+    solv_setup_output = solv_setup_unit[0].run(
+        dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path
+    )
+    serialized_topology = solv_setup_output["topology"]
+    serialized_system = solv_setup_output["system"]
+    solv_sampler = sol_run_unit[0].run(
+        serialized_system, serialized_topology, dry=True,scratch_basepath=tmp_path, shared_basepath=tmp_path
+    )["debug"]["sampler"]  # fmt: skip
 
-        # at this point, the units will be in openmm units
-        assert solv_sampler._thermodynamic_states[1].pressure == pressure * openmm.unit.bar
+    # at this point, the units will be in openmm units
+    assert solv_sampler._thermodynamic_states[1].pressure == pressure * openmm.unit.bar
 
 
 def test_virtual_sites_no_reassign(
     benzene_complex_system,
     toluene_complex_system,
-    tmpdir,
+    tmp_path,
     protocol_dry_settings,
 ):
     """
@@ -895,10 +901,9 @@ def test_virtual_sites_no_reassign(
     dag_units = list(dag.protocol_units)
     # Only check the Solvent Unit
     solv_setup_unit = [u for u in dag_units if isinstance(u, SepTopSolventSetupUnit)]
-    with tmpdir.as_cwd():
-        errmsg = "Simulations with virtual sites without velocity"
-        with pytest.raises(ValueError, match=errmsg):
-            solv_setup_output = solv_setup_unit[0].run(dry=True)
+    errmsg = "Simulations with virtual sites without velocity"
+    with pytest.raises(ValueError, match=errmsg):
+        _ = solv_setup_unit[0].run(dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path)
 
 
 @pytest.mark.parametrize(
@@ -909,7 +914,7 @@ def test_dry_run_ligand_system_cutoff(
     cutoff,
     benzene_complex_system,
     toluene_complex_system,
-    tmpdir,
+    tmp_path,
     protocol_dry_settings,
 ):
     """
@@ -930,24 +935,25 @@ def test_dry_run_ligand_system_cutoff(
     # Only check the cutoff for the Solvent SetUp Unit
     solv_setup_unit = [u for u in dag_units if isinstance(u, SepTopSolventSetupUnit)]
 
-    with tmpdir.as_cwd():
-        serialized_system = solv_setup_unit[0].run(dry=True)["system"]
-        system = deserialize(serialized_system)
-        nbfs = [
-            f
-            for f in system.getForces()
-            if isinstance(f, CustomNonbondedForce) or isinstance(f, NonbondedForce)
-        ]
+    serialized_system = solv_setup_unit[0].run(
+        dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path
+    )["system"]
+    system = deserialize(serialized_system)
+    nbfs = [
+        f
+        for f in system.getForces()
+        if isinstance(f, CustomNonbondedForce) or isinstance(f, NonbondedForce)
+    ]
 
-        for f in nbfs:
-            f_cutoff = from_openmm(f.getCutoffDistance())
-            assert f_cutoff == cutoff
+    for f in nbfs:
+        f_cutoff = from_openmm(f.getCutoffDistance())
+        assert f_cutoff == cutoff
 
 
 def test_dry_run_benzene_toluene_tip4p(
     benzene_complex_system,
     toluene_complex_system,
-    tmpdir,
+    tmp_path,
     protocol_dry_settings,
 ):
     protocol_dry_settings.forcefield_settings.forcefields = [
@@ -978,21 +984,22 @@ def test_dry_run_benzene_toluene_tip4p(
     assert len(solv_setup_unit) == 1
     assert len(sol_run_unit) == 1
 
-    with tmpdir.as_cwd():
-        solv_setup_output = solv_setup_unit[0].run(dry=True)
-        serialized_topology = solv_setup_output["topology"]
-        serialized_system = solv_setup_output["system"]
-        solv_run = sol_run_unit[0].run(
-            serialized_system, serialized_topology, dry=True
-        )["debug"]["sampler"]  # fmt: skip
+    solv_setup_output = solv_setup_unit[0].run(
+        dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path
+    )
+    serialized_topology = solv_setup_output["topology"]
+    serialized_system = solv_setup_output["system"]
+    solv_run = sol_run_unit[0].run(
+        serialized_system, serialized_topology, dry=True,scratch_basepath=tmp_path, shared_basepath=tmp_path
+    )["debug"]["sampler"]  # fmt: skip
 
-        assert solv_run.is_periodic
+    assert solv_run.is_periodic
 
 
 def test_dry_run_benzene_toluene_noncubic(
     benzene_complex_system,
     toluene_complex_system,
-    tmpdir,
+    tmp_path,
     protocol_dry_settings,
 ):
     protocol_dry_settings.solvent_solvation_settings.solvent_padding = 1.5 * offunit.nanometer
@@ -1016,31 +1023,32 @@ def test_dry_run_benzene_toluene_noncubic(
 
     assert len(solv_setup_unit) == 1
 
-    with tmpdir.as_cwd():
-        solv_setup_output = solv_setup_unit[0].run(dry=True)
-        serialized_system = solv_setup_output["system"]
-        system = deserialize(serialized_system)
-        vectors = system.getDefaultPeriodicBoxVectors()
-        width = float(from_openmm(vectors)[0][0].to("nanometer").m)
+    solv_setup_output = solv_setup_unit[0].run(
+        dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path
+    )
+    serialized_system = solv_setup_output["system"]
+    system = deserialize(serialized_system)
+    vectors = system.getDefaultPeriodicBoxVectors()
+    width = float(from_openmm(vectors)[0][0].to("nanometer").m)
 
-        # dodecahedron has the following shape:
-        # [width, 0, 0], [0, width, 0], [0.5, 0.5, 0.5 * sqrt(2)] * width
+    # dodecahedron has the following shape:
+    # [width, 0, 0], [0, width, 0], [0.5, 0.5, 0.5 * sqrt(2)] * width
 
-        expected_vectors = [
-            [width, 0, 0],
-            [0, width, 0],
-            [0.5 * width, 0.5 * width, 0.5 * math.sqrt(2) * width],
-        ] * offunit.nanometer
-        assert_allclose(
-            expected_vectors,
-            from_openmm(vectors),
-        )
+    expected_vectors = [
+        [width, 0, 0],
+        [0, width, 0],
+        [0.5 * width, 0.5 * width, 0.5 * math.sqrt(2) * width],
+    ] * offunit.nanometer
+    assert_allclose(
+        expected_vectors,
+        from_openmm(vectors),
+    )
 
 
 def test_dry_run_solv_user_charges_benzene_toluene(
     benzene_modifications,
     T4_protein_component,
-    tmpdir,
+    tmp_path,
     protocol_dry_settings,
 ):
     """
@@ -1105,48 +1113,50 @@ def test_dry_run_solv_user_charges_benzene_toluene(
     complex_setup_unit = [u for u in prot_units if isinstance(u, SepTopComplexSetupUnit)]
 
     # check sol_unit charges
-    with tmpdir.as_cwd():
-        serialized_system = solv_setup_unit[0].run(dry=True)["system"]
-        system = deserialize(serialized_system)
-        nonbond = [f for f in system.getForces() if isinstance(f, openmm.NonbondedForce)]
-        assert len(nonbond) == 1
+    serialized_system = solv_setup_unit[0].run(
+        dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path
+    )["system"]
+    system = deserialize(serialized_system)
+    nonbond = [f for f in system.getForces() if isinstance(f, openmm.NonbondedForce)]
+    assert len(nonbond) == 1
 
-        # loop through the 12 benzene atoms
-        # partial charge is stored in the offset
-        for i in range(12):
-            offsets = nonbond[0].getParticleParameterOffset(i)
-            c = ensure_quantity(offsets[2], "openff")
-            assert pytest.approx(c) == benzene_charge[i]
-        # loop through 15 toluene atoms
-        for inx, i in enumerate(range(12, 27)):
-            offsets = nonbond[0].getParticleParameterOffset(i)
-            c = ensure_quantity(offsets[2], "openff")
-            assert pytest.approx(c) == toluene_charge[inx]
+    # loop through the 12 benzene atoms
+    # partial charge is stored in the offset
+    for i in range(12):
+        offsets = nonbond[0].getParticleParameterOffset(i)
+        c = ensure_quantity(offsets[2], "openff")
+        assert pytest.approx(c) == benzene_charge[i]
+    # loop through 15 toluene atoms
+    for inx, i in enumerate(range(12, 27)):
+        offsets = nonbond[0].getParticleParameterOffset(i)
+        c = ensure_quantity(offsets[2], "openff")
+        assert pytest.approx(c) == toluene_charge[inx]
 
     # check complex_unit charges
-    with tmpdir.as_cwd():
-        serialized_system = complex_setup_unit[0].run(dry=True)["system"]
-        system = deserialize(serialized_system)
-        nonbond = [f for f in system.getForces() if isinstance(f, openmm.NonbondedForce)]
-        assert len(nonbond) == 1
+    serialized_system = complex_setup_unit[0].run(
+        dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path
+    )["system"]
+    system = deserialize(serialized_system)
+    nonbond = [f for f in system.getForces() if isinstance(f, openmm.NonbondedForce)]
+    assert len(nonbond) == 1
 
-        # loop through the 12 benzene atoms
-        # partial charge is stored in the offset
-        for i in range(12):
-            offsets = nonbond[0].getParticleParameterOffset(i)
-            c = ensure_quantity(offsets[2], "openff")
-            assert pytest.approx(c) == benzene_charge[i]
-        # loop through 15 toluene atoms
-        for inx, i in enumerate(range(12, 27)):
-            offsets = nonbond[0].getParticleParameterOffset(i)
-            c = ensure_quantity(offsets[2], "openff")
-            assert pytest.approx(c) == toluene_charge[inx]
+    # loop through the 12 benzene atoms
+    # partial charge is stored in the offset
+    for i in range(12):
+        offsets = nonbond[0].getParticleParameterOffset(i)
+        c = ensure_quantity(offsets[2], "openff")
+        assert pytest.approx(c) == benzene_charge[i]
+    # loop through 15 toluene atoms
+    for inx, i in enumerate(range(12, 27)):
+        offsets = nonbond[0].getParticleParameterOffset(i)
+        c = ensure_quantity(offsets[2], "openff")
+        assert pytest.approx(c) == toluene_charge[inx]
 
 
 def test_high_timestep(
     benzene_complex_system,
     toluene_complex_system,
-    tmpdir,
+    tmp_path,
     protocol_dry_settings,
 ):
     protocol_dry_settings.forcefield_settings.hydrogen_mass = 1.0
@@ -1161,10 +1171,9 @@ def test_high_timestep(
     )
     prot_units = list(dag.protocol_units)
 
-    with tmpdir.as_cwd():
-        errmsg = "too large for hydrogen mass"
-        with pytest.raises(ValueError, match=errmsg):
-            prot_units[0].run(dry=True)
+    errmsg = "too large for hydrogen mass"
+    with pytest.raises(ValueError, match=errmsg):
+        prot_units[0].run(dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path)
 
 
 @pytest.fixture

--- a/src/openfe/tests/protocols/openmm_septop/test_septop_slow.py
+++ b/src/openfe/tests/protocols/openmm_septop/test_septop_slow.py
@@ -105,7 +105,7 @@ def test_lambda_energies(
     eg5_ligands,
     eg5_protein,
     eg5_cofactor,
-    tmpdir,
+    tmp_path,
     default_settings,
 ):
     # check system parametrisation works even if confgen fails
@@ -151,62 +151,61 @@ def test_lambda_energies(
     prot_units = list(dag.protocol_units)
     solv_setup_unit = [u for u in prot_units if isinstance(u, SepTopSolventSetupUnit)]
 
-    with tmpdir.as_cwd():
-        output = solv_setup_unit[0].run()
-        system = output["system"]
-        alchemical_system = deserialize(system)
-        topology = output["topology"]
-        pdb = openmm.app.pdbfile.PDBFile(str(topology))
-        positions = pdb.getPositions(asNumpy=True)
+    output = solv_setup_unit[0].run(scratch_basepath=tmp_path, shared_basepath=tmp_path)
+    system = output["system"]
+    alchemical_system = deserialize(system)
+    topology = output["topology"]
+    pdb = openmm.app.pdbfile.PDBFile(str(topology))
+    positions = pdb.getPositions(asNumpy=True)
 
-        # Remove Harmonic restraint force solvent
-        alchemical_system.removeForce(13)
+    # Remove Harmonic restraint force solvent
+    alchemical_system.removeForce(13)
 
-        (
-            na_A,
-            na_B,
-            nonbonded,
-            energy,
-            energy_0,
-            energy_7,
-            energy_8,
-            energy_12,
-            energy_13,
-        ) = compare_energies(alchemical_system, positions)
+    (
+        na_A,
+        na_B,
+        nonbonded,
+        energy,
+        energy_0,
+        energy_7,
+        energy_8,
+        energy_12,
+        energy_13,
+    ) = compare_energies(alchemical_system, positions)
 
-        for key, value in energy.items():
-            if key == na_A:
-                assert_allclose(from_openmm(value), from_openmm(energy_0[key]))
-                assert_allclose(from_openmm(value), from_openmm(energy_7[key]))
-                assert_allclose(from_openmm(value), from_openmm(energy_8[key]))
-                assert_allclose(from_openmm(value), from_openmm(energy_12[key]))
-                assert not np.allclose(from_openmm(value), from_openmm(energy_13[key]))
+    for key, value in energy.items():
+        if key == na_A:
+            assert_allclose(from_openmm(value), from_openmm(energy_0[key]))
+            assert_allclose(from_openmm(value), from_openmm(energy_7[key]))
+            assert_allclose(from_openmm(value), from_openmm(energy_8[key]))
+            assert_allclose(from_openmm(value), from_openmm(energy_12[key]))
+            assert not np.allclose(from_openmm(value), from_openmm(energy_13[key]))
 
-            elif key == na_B:
-                assert not np.allclose(from_openmm(value), from_openmm(energy_0[key]))
-                assert_allclose(from_openmm(energy_0[key]), 0)
-                assert_allclose(from_openmm(value), from_openmm(energy_7[key]))
-                assert_allclose(from_openmm(value), from_openmm(energy_8[key]))
-                assert_allclose(from_openmm(value), from_openmm(energy_12[key]))
-                assert_allclose(from_openmm(value), from_openmm(energy_13[key]))
+        elif key == na_B:
+            assert not np.allclose(from_openmm(value), from_openmm(energy_0[key]))
+            assert_allclose(from_openmm(energy_0[key]), 0)
+            assert_allclose(from_openmm(value), from_openmm(energy_7[key]))
+            assert_allclose(from_openmm(value), from_openmm(energy_8[key]))
+            assert_allclose(from_openmm(value), from_openmm(energy_12[key]))
+            assert_allclose(from_openmm(value), from_openmm(energy_13[key]))
 
-            elif key == nonbonded:
-                assert not np.allclose(from_openmm(value), from_openmm(energy_0[key]))
-                assert_allclose(
-                    from_openmm(energy_0[key]),
-                    from_openmm(energy_7[key]),
-                    rtol=1e-05,
-                )
-                assert not np.allclose(from_openmm(energy_0[key]), from_openmm(energy_8[key]))
-                assert not np.allclose(from_openmm(energy_0[key]), from_openmm(energy_12[key]))
-                assert not np.allclose(from_openmm(energy_0[key]), from_openmm(energy_13[key]))
+        elif key == nonbonded:
+            assert not np.allclose(from_openmm(value), from_openmm(energy_0[key]))
+            assert_allclose(
+                from_openmm(energy_0[key]),
+                from_openmm(energy_7[key]),
+                rtol=1e-05,
+            )
+            assert not np.allclose(from_openmm(energy_0[key]), from_openmm(energy_8[key]))
+            assert not np.allclose(from_openmm(energy_0[key]), from_openmm(energy_12[key]))
+            assert not np.allclose(from_openmm(energy_0[key]), from_openmm(energy_13[key]))
 
-            else:
-                assert_allclose(from_openmm(value), from_openmm(energy_0[key]))
-                assert_allclose(from_openmm(value), from_openmm(energy_7[key]))
-                assert_allclose(from_openmm(value), from_openmm(energy_8[key]))
-                assert_allclose(from_openmm(value), from_openmm(energy_12[key]))
-                assert_allclose(from_openmm(value), from_openmm(energy_13[key]))
+        else:
+            assert_allclose(from_openmm(value), from_openmm(energy_0[key]))
+            assert_allclose(from_openmm(value), from_openmm(energy_7[key]))
+            assert_allclose(from_openmm(value), from_openmm(energy_8[key]))
+            assert_allclose(from_openmm(value), from_openmm(energy_12[key]))
+            assert_allclose(from_openmm(value), from_openmm(energy_13[key]))
 
 
 @pytest.mark.integration
@@ -300,7 +299,7 @@ def test_restraints_solvent(
     available_platforms,
     benzene_complex_system,
     toluene_complex_system,
-    tmpdir,
+    tmp_path,
     default_settings,
 ):
     if platform not in available_platforms:
@@ -328,11 +327,11 @@ def test_restraints_solvent(
     )
     prot_units = list(dag.protocol_units)
     solv_setup_unit = [u for u in prot_units if isinstance(u, SepTopSolventSetupUnit)]
-    with tmpdir.as_cwd():
-        solv_setup_output = solv_setup_unit[0].run()
-        pdb = md.load_pdb("topology.pdb")
-        assert pdb.n_atoms == 1762
-        central_atoms = np.array([[2, 19]], dtype=np.int32)
-        distance = md.compute_distances(pdb, central_atoms)[0][0]
-        # For right now just checking that ligands at least somewhat apart
-        assert distance > 0.5
+
+    solv_setup_output = solv_setup_unit[0].run(scratch_basepath=tmp_path, shared_basepath=tmp_path)
+    pdb = md.load_pdb(tmp_path / "topology.pdb")
+    assert pdb.n_atoms == 1762
+    central_atoms = np.array([[2, 19]], dtype=np.int32)
+    distance = md.compute_distances(pdb, central_atoms)[0][0]
+    # For right now just checking that ligands at least somewhat apart
+    assert distance > 0.5

--- a/src/openfe/tests/protocols/openmm_septop/test_septop_slow.py
+++ b/src/openfe/tests/protocols/openmm_septop/test_septop_slow.py
@@ -217,7 +217,7 @@ def test_openmm_run_engine(
     available_platforms,
     benzene_modifications,
     T4_protein_component,
-    tmpdir,
+    tmp_path,
     default_settings,
 ):
     if platform not in available_platforms:
@@ -270,12 +270,11 @@ def test_openmm_run_engine(
         mapping=None,
     )
 
-    cwd = pathlib.Path(str(tmpdir))
-    r = execute_DAG(dag, shared_basedir=cwd, scratch_basedir=cwd, keep_shared=True)
+    r = execute_DAG(dag, shared_basedir=tmp_path, scratch_basedir=tmp_path, keep_shared=True)
 
     assert r.ok()
     for pur in r.protocol_unit_results:
-        unit_shared = tmpdir / f"shared_{pur.source_key}_attempt_0"
+        unit_shared = tmp_path / f"shared_{pur.source_key}_attempt_0"
         assert unit_shared.exists()
         assert pathlib.Path(unit_shared).is_dir()
         if "SepTopComplexRunUnit" in pur.source_key.split("-") or "SepTopSolventRunUnit" in pur.source_key.split("-"):  # fmt: skip

--- a/src/openfe/tests/protocols/test_openmmutils.py
+++ b/src/openfe/tests/protocols/test_openmmutils.py
@@ -350,13 +350,12 @@ class TestFEAnalysis:
             rtol=5e-01,
         )  # fmt: skip
 
-    def test_plots(self, analyzer, tmpdir):
-        with tmpdir.as_cwd():
-            analyzer.plot(filepath=Path("."), filename_prefix="")
-            assert Path("forward_reverse_convergence.png").is_file()
-            assert Path("mbar_overlap_matrix.png").is_file()
-            assert Path("replica_exchange_matrix.png").is_file()
-            assert Path("replica_state_timeseries.png").is_file()
+    def test_plots(self, analyzer, tmp_path):
+        analyzer.plot(filepath=Path(tmp_path), filename_prefix="")
+        assert Path(tmp_path / "forward_reverse_convergence.png").is_file()
+        assert Path(tmp_path / "mbar_overlap_matrix.png").is_file()
+        assert Path(tmp_path / "replica_exchange_matrix.png").is_file()
+        assert Path(tmp_path / "replica_state_timeseries.png").is_file()
 
     def test_plot_convergence_bad_units(self, analyzer):
         with pytest.raises(ValueError, match="Unknown plotting units"):

--- a/src/openfe/tests/protocols/test_openmmutils_serialization.py
+++ b/src/openfe/tests/protocols/test_openmmutils_serialization.py
@@ -26,8 +26,8 @@ def test_serialize_xml(tmp_path):
         assert f.read() == "<data>"
 
 
-def test_serialize_bz2(tmpdir):
-    filename = pathlib.Path(tmpdir / "file.xml.bz2")
+def test_serialize_bz2(tmp_path):
+    filename = pathlib.Path(tmp_path / "file.xml.bz2")
     expected = "<bz2_data>"
 
     with mock.patch("openmm.XmlSerializer.serialize", return_value=expected):
@@ -38,8 +38,8 @@ def test_serialize_bz2(tmpdir):
     assert read_back == expected
 
 
-def test_deserialize_xml(tmpdir):
-    filename = pathlib.Path(tmpdir / "file.xml")
+def test_deserialize_xml(tmp_path):
+    filename = pathlib.Path(tmp_path / "file.xml")
     filename.write_text("<xml>things</xml>")
 
     with mock.patch("openmm.XmlSerializer.deserialize", return_value="DESERIALIZED") as deser:
@@ -49,8 +49,8 @@ def test_deserialize_xml(tmpdir):
     assert result == "DESERIALIZED"
 
 
-def test_deserialize_bz2(tmpdir):
-    filename = pathlib.Path(tmpdir / "file.xml.bz2")
+def test_deserialize_bz2(tmp_path):
+    filename = pathlib.Path(tmp_path / "file.xml.bz2")
     expected_serialized = "<xml>bz2</xml>"
     with bz2.open(filename, "wb") as f:
         f.write(expected_serialized.encode())

--- a/src/openfe/tests/setup/test_network_planning.py
+++ b/src/openfe/tests/setup/test_network_planning.py
@@ -743,17 +743,16 @@ benzene >> benzaldehyde
 """
 
 
-def test_bad_orion_network(benzene_modifications, tmpdir):
-    with tmpdir.as_cwd():
-        with open("bad_orion_net.dat", "w") as f:
-            f.write(BAD_ORION_NETWORK)
+def test_bad_orion_network(benzene_modifications, tmp_path):
+    with open(tmp_path / "bad_orion_net.dat", "w") as f:
+        f.write(BAD_ORION_NETWORK)
 
-        with pytest.raises(KeyError, match="line does not match"):
-            _ = openfe.setup.ligand_network_planning.load_orion_network(
-                ligands=[lig for lig in benzene_modifications.values()],
-                mapper=openfe.LomapAtomMapper(),
-                network_file="bad_orion_net.dat",
-            )
+    with pytest.raises(KeyError, match="line does not match"):
+        _ = openfe.setup.ligand_network_planning.load_orion_network(
+            ligands=[lig for lig in benzene_modifications.values()],
+            mapper=openfe.LomapAtomMapper(),
+            network_file=tmp_path / "bad_orion_net.dat",
+        )
 
 
 BAD_EDGES = """\
@@ -766,14 +765,13 @@ BAD_EDGES = """\
 """
 
 
-def test_bad_edges_network(benzene_modifications, tmpdir):
-    with tmpdir.as_cwd():
-        with open("bad_edges.edges", "w") as f:
-            f.write(BAD_EDGES)
+def test_bad_edges_network(benzene_modifications, tmp_path):
+    with open(tmp_path / "bad_edges.edges", "w") as f:
+        f.write(BAD_EDGES)
 
-        with pytest.raises(KeyError, match="line does not match"):
-            _ = openfe.setup.ligand_network_planning.load_fepplus_network(
-                ligands=[lig for lig in benzene_modifications.values()],
-                mapper=openfe.LomapAtomMapper(),
-                network_file="bad_edges.edges",
-            )
+    with pytest.raises(KeyError, match="line does not match"):
+        _ = openfe.setup.ligand_network_planning.load_fepplus_network(
+            ligands=[lig for lig in benzene_modifications.values()],
+            mapper=openfe.LomapAtomMapper(),
+            network_file=tmp_path / "bad_edges.edges",
+        )

--- a/src/openfe/tests/storage/test_metadatastore.py
+++ b/src/openfe/tests/storage/test_metadatastore.py
@@ -10,10 +10,10 @@ from openfe.storage.metadatastore import JSONMetadataStore, PerFileJSONMetadataS
 
 
 @pytest.fixture
-def json_metadata(tmpdir):
+def json_metadata(tmp_path):
     metadata_dict = {"path/to/foo.txt": {"md5": "bar"}}
-    external_store = FileStorage(str(tmpdir))
-    with open(tmpdir / "metadata.json", mode="wb") as f:
+    external_store = FileStorage(tmp_path)
+    with open(tmp_path / "metadata.json", mode="wb") as f:
         f.write(json.dumps(metadata_dict).encode("utf-8"))
     json_metadata = JSONMetadataStore(external_store)
     return json_metadata
@@ -22,8 +22,8 @@ def json_metadata(tmpdir):
 @pytest.fixture
 def per_file_metadata(tmp_path):
     metadata_dict = {"path": "path/to/foo.txt", "metadata": {"md5": "bar"}}
-    external_store = FileStorage(str(tmp_path))
     metadata_loc = "metadata/path/to/foo.txt.json"
+    external_store = FileStorage(tmp_path)
     metadata_path = tmp_path / pathlib.Path(metadata_loc)
     metadata_path.parent.mkdir(parents=True, exist_ok=True)
     with open(metadata_path, mode="wb") as f:
@@ -87,8 +87,8 @@ class TestJSONMetadataStore(MetadataTests):
     def test_load_all_metadata(self, json_metadata):
         self._test_load_all_metadata(json_metadata)
 
-    def test_load_all_metadata_nofile(self, tmpdir):
-        json_metadata = JSONMetadataStore(FileStorage(str(tmpdir)))
+    def test_load_all_metadata_nofile(self, tmp_path):
+        json_metadata = JSONMetadataStore(FileStorage(tmp_path))
         # implicitly called on init anyway
         assert json_metadata._metadata_cache == {}
         # but we also call explicitly

--- a/src/openfe/tests/storage/test_resultclient.py
+++ b/src/openfe/tests/storage/test_resultclient.py
@@ -14,7 +14,7 @@ from openfe.storage.resultclient import (
 
 
 @pytest.fixture
-def result_client(tmpdir):
+def result_client():
     external = MemoryStorage()
     result_client = ResultClient(external)
 

--- a/src/openfe/tests/storage/test_resultserver.py
+++ b/src/openfe/tests/storage/test_resultserver.py
@@ -11,8 +11,8 @@ from openfe.storage.resultserver import ResultServer
 
 
 @pytest.fixture
-def result_server(tmpdir):
-    external = FileStorage(tmpdir)
+def result_server(tmp_path):
+    external = FileStorage(tmp_path)
     metadata = JSONMetadataStore(external)
     result_server = ResultServer(external, metadata)
     result_server.store_bytes("path/to/foo.txt", "foo".encode("utf-8"))
@@ -88,9 +88,9 @@ class TestResultServer:
 
         assert contents.decode("utf-8") == "foo"
 
-    def test_delete(self, result_server, tmpdir):
+    def test_delete(self, result_server, tmp_path):
         location = "path/to/foo.txt"
-        path = tmpdir / pathlib.Path(location)
+        path = tmp_path / pathlib.Path(location)
         assert path.exists()
         assert location in result_server.metadata_store
         result_server.delete(location)

--- a/src/openfecli/tests/commands/test_atommapping.py
+++ b/src/openfecli/tests/commands/test_atommapping.py
@@ -114,17 +114,17 @@ def test_atommapping_print_dict_main(capsys, mols_AB):
         assert captured.out == str(mapping.componentA_to_componentB) + "\n"
 
 
-def test_atommapping_visualize_main(mols_AB, tmpdir):
+def test_atommapping_visualize_main(mols_AB):
     molA, molB = mols_AB
     mapper = LomapAtomMapper
     pytest.skip()  # TODO: probably with a smoke test
 
 
-def test_atommapping_visualize_main_bad_extension(mols_AB, tmpdir):
+def test_atommapping_visualize_main_bad_extension(mols_AB, tmp_path):
     molA, molB = mols_AB
     mapper = LomapAtomMapper
     mapping = LigandAtomMapping(molA, molB, {i: i for i in range(7)})
     with mock.patch("openfecli.commands.atommapping.generate_mapping", mock.Mock(return_value=mapping)):  # fmt: skip
-        with open(tmpdir / "foo.bar", mode="w") as f:
+        with open(tmp_path / "foo.bar", mode="w") as f:
             with pytest.raises(click.BadParameter, match="Unknown file format"):
                 atommapping_visualize_main(mapper, molA, molB, f, "bar")

--- a/src/openfecli/tests/commands/test_charge_generation.py
+++ b/src/openfecli/tests/commands/test_charge_generation.py
@@ -40,9 +40,9 @@ def methane_with_charges(methane) -> Molecule:
     return methane
 
 
-def test_missing_output(methane, tmpdir):
+def test_missing_output(methane, tmp_path):
     runner = CliRunner()
-    mol_path = tmpdir / "methane.sdf"
+    mol_path = tmp_path / "methane.sdf"
     methane.to_file(str(mol_path), "sdf")
 
     cli_result = runner.invoke(charge_molecules, ["-M", mol_path])
@@ -50,9 +50,9 @@ def test_missing_output(methane, tmpdir):
     assert "Missing option '-o'" in cli_result.output
 
 
-def test_write_charges_to_input(methane, tmpdir):
+def test_write_charges_to_input(methane, tmp_path):
     runner = CliRunner()
-    mol_path = tmpdir / "methane.sdf"
+    mol_path = tmp_path / "methane.sdf"
     methane.to_file(str(mol_path), "sdf")
 
     with runner.isolated_filesystem():
@@ -63,11 +63,11 @@ def test_write_charges_to_input(methane, tmpdir):
             )
 
 
-def test_charge_molecules_default(methane, tmpdir, caplog):
+def test_charge_molecules_default(methane, tmp_path, caplog):
     runner = CliRunner()
-    mol_path = tmpdir / "methane.sdf"
+    mol_path = tmp_path / "methane.sdf"
     methane.to_file(str(mol_path), "sdf")
-    output_file = str(tmpdir / "charged_methane.sdf")
+    output_file = str(tmp_path / "charged_methane.sdf")
     caplog.set_level(logging.INFO)
     with runner.isolated_filesystem():
         # make sure the charges are picked up
@@ -91,12 +91,12 @@ def test_charge_molecules_default(methane, tmpdir, caplog):
     ],
 )
 def test_charge_molecules_overwrite(
-    overwrite, tmpdir, caplog, methane_with_charges, expected_charges
+    overwrite, tmp_path, caplog, methane_with_charges, expected_charges
 ):
     runner = CliRunner()
-    mol_path = tmpdir / "methane.sdf"
+    mol_path = tmp_path / "methane.sdf"
     methane_with_charges.to_file(str(mol_path), "sdf")
-    output_file = str(tmpdir / "charged_methane.sdf")
+    output_file = str(tmp_path / "charged_methane.sdf")
 
     args = ["-M", mol_path, "-o", output_file]
     if overwrite:
@@ -133,14 +133,14 @@ def test_charge_molecules_overwrite(
 @pytest.mark.skipif(
     HAS_OPENEYE, reason="cannot use NAGL with rdkit backend when OpenEye is installed"
 )
-def test_charge_settings(methane, tmpdir, caplog, yaml_nagl_settings, ncores):
+def test_charge_settings(methane, tmp_path, caplog, yaml_nagl_settings, ncores):
     runner = CliRunner()
-    mol_path = tmpdir / "methane.sdf"
+    mol_path = tmp_path / "methane.sdf"
     methane.to_file(str(mol_path), "sdf")
-    output_file = str(tmpdir / "charged_methane.sdf")
+    output_file = str(tmp_path / "charged_methane.sdf")
 
     # use nagl charges for CI speed!
-    settings_path = tmpdir / "settings.yaml"
+    settings_path = tmp_path / "settings.yaml"
     with open(settings_path, "w") as f:
         f.write(yaml_nagl_settings)
 

--- a/src/openfecli/tests/commands/test_plan_rbfe_network.py
+++ b/src/openfecli/tests/commands/test_plan_rbfe_network.py
@@ -23,8 +23,8 @@ from ..utils import assert_click_success
 
 
 @pytest.fixture(scope="session")
-def mol_dir_args(tmpdir_factory):
-    ofe_dir_path = tmpdir_factory.mktemp("moldir")
+def mol_dir_args(tmp_path_factory):
+    ofe_dir_path = tmp_path_factory.mktemp("moldir")
 
     with resources.as_file(resources.files("openfe.tests.data.openmm_rfe")) as d:
         for f in ["ligand_23.sdf", "ligand_55.sdf"]:
@@ -34,8 +34,8 @@ def mol_dir_args(tmpdir_factory):
 
 
 @pytest.fixture(scope="session")
-def dummy_charge_dir_args(tmpdir_factory):
-    ofe_dir_path = tmpdir_factory.mktemp("charge_moldir")
+def dummy_charge_dir_args(tmp_path_factory):
+    ofe_dir_path = tmp_path_factory.mktemp("charge_moldir")
 
     with resources.as_file(resources.files("openfe.tests.data.openmm_rfe")) as d:
         for f in ["dummy_charge_ligand_23.sdf", "dummy_charge_ligand_55.sdf"]:
@@ -152,12 +152,12 @@ partial_charge:
 @pytest.mark.skipif(
     HAS_OPENEYE, reason="cannot use NAGL with rdkit backend when OpenEye is installed"
 )
-def test_plan_rbfe_network(mol_dir_args, protein_args, tmpdir, yaml_nagl_settings):
+def test_plan_rbfe_network(mol_dir_args, protein_args, tmp_path, yaml_nagl_settings):
     """
     smoke test
     """
     # use nagl charges for CI speed!
-    settings_path = tmpdir / "settings.yaml"
+    settings_path = tmp_path / "settings.yaml"
     with open(settings_path, "w") as f:
         f.write(yaml_nagl_settings)
 
@@ -238,11 +238,11 @@ def test_plan_rbfe_network_n_repeats(mol_dir_args, protein_args, input_n_repeat,
 @pytest.mark.skipif(
     HAS_OPENEYE, reason="cannot use NAGL with rdkit backend when OpenEye is installed"
 )
-def test_plan_rbfe_network_charge_overwrite(dummy_charge_dir_args, protein_args, tmpdir, yaml_nagl_settings, overwrite):  # fmt: skip
+def test_plan_rbfe_network_charge_overwrite(dummy_charge_dir_args, protein_args, tmp_path, yaml_nagl_settings, overwrite):  # fmt: skip
     # make sure the dummy charges are overwritten when requested
 
     # use nagl charges for CI speed!
-    settings_path = tmpdir / "settings.yaml"
+    settings_path = tmp_path / "settings.yaml"
     with open(settings_path, "w") as f:
         f.write(yaml_nagl_settings)
 
@@ -293,9 +293,9 @@ def eg5_files():
 @pytest.mark.skipif(
     HAS_OPENEYE, reason="cannot use NAGL with rdkit backend when OpenEye is installed"
 )
-def test_plan_rbfe_network_cofactors(eg5_files, tmpdir, yaml_nagl_settings):
+def test_plan_rbfe_network_cofactors(eg5_files, tmp_path, yaml_nagl_settings):
     # use nagl charges for CI speed!
-    settings_path = tmpdir / "settings.yaml"
+    settings_path = tmp_path / "settings.yaml"
     with open(settings_path, "w") as f:
         f.write(yaml_nagl_settings)
 
@@ -401,9 +401,9 @@ partial_charge:
 @pytest.mark.skipif(
     HAS_OPENEYE, reason="cannot use NAGL with rdkit backend when OpenEye is installed"
 )
-def test_lomap_yaml_plan_rbfe_smoke_test(lomap_yaml_settings, cdk8_files, tmpdir):
+def test_lomap_yaml_plan_rbfe_smoke_test(lomap_yaml_settings, cdk8_files, tmp_path):
     protein, ligand = cdk8_files
-    settings_path = tmpdir / "settings.yaml"
+    settings_path = tmp_path / "settings.yaml"
     with open(settings_path, "w") as f:
         f.write(lomap_yaml_settings)
 
@@ -447,9 +447,9 @@ partial_charge:
 @pytest.mark.skipif(
     HAS_OPENEYE, reason="cannot use NAGL with rdkit backend when OpenEye is installed"
 )
-def test_custom_yaml_plan_radial_smoke_test(custom_yaml_radial, eg5_files, tmpdir):
+def test_custom_yaml_plan_radial_smoke_test(custom_yaml_radial, eg5_files, tmp_path):
     protein, ligand, cofactor = eg5_files
-    settings_path = tmpdir / "settings.yaml"
+    settings_path = tmp_path / "settings.yaml"
     with open(settings_path, "w") as f:
         f.write(custom_yaml_radial)
 

--- a/src/openfecli/tests/commands/test_plan_rhfe_network.py
+++ b/src/openfecli/tests/commands/test_plan_rhfe_network.py
@@ -21,8 +21,8 @@ from openfecli.commands.plan_rhfe_network import (
 
 
 @pytest.fixture(scope="session")
-def mol_dir_args(tmpdir_factory):
-    ofe_dir_path = tmpdir_factory.mktemp("moldir")
+def mol_dir_args(tmp_path_factory):
+    ofe_dir_path = tmp_path_factory.mktemp("moldir")
 
     with resources.as_file(resources.files("openfe.tests.data.openmm_rfe")) as d:
         for f in ["ligand_23.sdf", "ligand_55.sdf"]:
@@ -32,8 +32,8 @@ def mol_dir_args(tmpdir_factory):
 
 
 @pytest.fixture(scope="session")
-def dummy_charge_dir_args(tmpdir_factory):
-    ofe_dir_path = tmpdir_factory.mktemp("charge_moldir")
+def dummy_charge_dir_args(tmp_path_factory):
+    ofe_dir_path = tmp_path_factory.mktemp("charge_moldir")
 
     with resources.as_file(resources.files("openfe.tests.data.openmm_rfe")) as d:
         for f in ["dummy_charge_ligand_23.sdf", "dummy_charge_ligand_55.sdf"]:
@@ -118,12 +118,12 @@ partial_charge:
 @pytest.mark.skipif(
     HAS_OPENEYE, reason="cannot use NAGL with rdkit backend when OpenEye is installed"
 )
-def test_plan_rhfe_network(mol_dir_args, tmpdir, yaml_nagl_settings):
+def test_plan_rhfe_network(mol_dir_args, tmp_path, yaml_nagl_settings):
     """
     smoke test
     """
     # use nagl charges for CI speed!
-    settings_path = tmpdir / "settings.yaml"
+    settings_path = tmp_path / "settings.yaml"
     with open(settings_path, "w") as f:
         f.write(yaml_nagl_settings)
 
@@ -196,8 +196,8 @@ partial_charge:
 @pytest.mark.skipif(
     HAS_OPENEYE, reason="cannot use NAGL with rdkit backend when OpenEye is installed"
 )
-def test_custom_yaml_plan_rhfe_smoke_test(custom_yaml_settings, mol_dir_args, tmpdir):
-    settings_path = tmpdir / "settings.yaml"
+def test_custom_yaml_plan_rhfe_smoke_test(custom_yaml_settings, mol_dir_args, tmp_path):
+    settings_path = tmp_path / "settings.yaml"
     with open(settings_path, "w") as f:
         f.write(custom_yaml_settings)
 
@@ -227,11 +227,11 @@ def test_custom_yaml_plan_rhfe_smoke_test(custom_yaml_settings, mol_dir_args, tm
 @pytest.mark.skipif(
     HAS_OPENEYE, reason="cannot use NAGL with rdkit backend when OpenEye is installed"
 )
-def test_plan_rhfe_network_charge_overwrite(dummy_charge_dir_args, tmpdir, yaml_nagl_settings, overwrite):  # fmt: skip
+def test_plan_rhfe_network_charge_overwrite(dummy_charge_dir_args, tmp_path, yaml_nagl_settings, overwrite):  # fmt: skip
     # make sure the dummy charges are overwritten when requested
 
     # use nagl charges for CI speed!
-    settings_path = tmpdir / "settings.yaml"
+    settings_path = tmp_path / "settings.yaml"
     with open(settings_path, "w") as f:
         f.write(yaml_nagl_settings)
 

--- a/src/openfecli/tests/parameters/test_output.py
+++ b/src/openfecli/tests/parameters/test_output.py
@@ -10,8 +10,8 @@ from openfecli.parameters.output import get_file_and_extension
         ("foo.bar.bz", "bz"),
     ],
 )
-def test_get_file_and_extension(tmpdir, fname, expected_ext):
-    with open(tmpdir / fname, mode="w") as file:
+def test_get_file_and_extension(tmp_path, fname, expected_ext):
+    with open(tmp_path / fname, mode="w") as file:
         outfile, ext = get_file_and_extension(file, {})
         assert outfile is file
         assert ext == expected_ext


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
resolves https://github.com/OpenFreeEnergy/openfe/issues/1872

and gets ahead of some headaches seen in #1848 


<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [x] All new code is appropriately documented (user-facing code _must_ have complete docstrings).
* [x] Added a ``news`` entry, or the changes are not user-facing.
* [x] Ran pre-commit: you can run [pre-commit](https://pre-commit.com) locally or comment on this PR with `pre-commit.ci autofix`.

Manual Tests: these are slow so don't need to be run every commit, only before merging and when relevant changes are made (generally at reviewer-discretion). 
* [x] [GPU integration tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/gpu-integration-tests.yaml)
* [ ] [example notebook testing](https://github.com/OpenFreeEnergy/openfe/actions/workflows/test-example-notebooks.yaml)
* [x] [packaging tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/test-feedstock-pkg-build.yaml): run this for any large feature PRs or PRs that add test data.


## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
