### PR TITLE
Minor fix to support ABFE gathering with openfe v1.9+

### DIFF
--- a/src/openfecli/commands/gather_abfe.py
+++ b/src/openfecli/commands/gather_abfe.py
@@ -116,8 +116,14 @@ def _get_legs_from_result_jsons(
             continue
 
         dgs[name]["overall"].append([result["estimate"], result["uncertainty"]])
-        proto_key = [k for k in result["unit_results"].keys() if k.startswith("ProtocolUnitResult")]
+        proto_key = [
+            k for k in result["unit_results"].keys()
+            if k.startswith("ProtocolUnitResult")
+        ]
         for p in proto_key:
+            if ("Setup" in result["unit_results"][p]["source_key"]
+                or "Simulation" in result["unit_results"][p]["source_key"]):
+                continue
             if "unit_estimate" in result["unit_results"][p]["outputs"]:
                 simtype = result["unit_results"][p]["outputs"]["simtype"]
                 dg = result["unit_results"][p]["outputs"]["unit_estimate"]
@@ -126,7 +132,8 @@ def _get_legs_from_result_jsons(
                 dgs[name][simtype].append([dg, dg_error])
             if "standard_state_correction" in result["unit_results"][p]["outputs"]:
                 corr = result["unit_results"][p]["outputs"]["standard_state_correction"]
-                dgs[name]["standard_state_correction"].append([corr, 0 * unit.kilocalorie_per_mole])
+                if not np.isclose(corr.m, 0):
+                    dgs[name]["standard_state_correction"].append([corr, 0 * unit.kilocalorie_per_mole])
             else:
                 continue
     return dgs

--- a/src/openfecli/commands/gather_abfe.py
+++ b/src/openfecli/commands/gather_abfe.py
@@ -134,6 +134,10 @@ def _get_legs_from_result_jsons(
                 dgs[name][simtype].append([dg, dg_error])
             if "standard_state_correction" in result["unit_results"][p]["outputs"]:
                 corr = result["unit_results"][p]["outputs"]["standard_state_correction"]
+                # In openfe v1.9+, standard state corrections are set to 0 kcal/mol
+                # when no correction is being applied (e.g. no restraints).
+                # To make raw outputs similar to pre-v1.9, we exclude corrections
+                # if they are close to 0.
                 if not np.isclose(corr.m, 0):
                     dgs[name]["standard_state_correction"].append(
                         [corr, 0 * unit.kilocalorie_per_mole]

--- a/src/openfecli/commands/gather_abfe.py
+++ b/src/openfecli/commands/gather_abfe.py
@@ -116,13 +116,12 @@ def _get_legs_from_result_jsons(
             continue
 
         dgs[name]["overall"].append([result["estimate"], result["uncertainty"]])
-        proto_key = [
-            k for k in result["unit_results"].keys()
-            if k.startswith("ProtocolUnitResult")
-        ]
+        proto_key = [k for k in result["unit_results"].keys() if k.startswith("ProtocolUnitResult")]
         for p in proto_key:
-            if ("Setup" in result["unit_results"][p]["source_key"]
-                or "Simulation" in result["unit_results"][p]["source_key"]):
+            if (
+                "Setup" in result["unit_results"][p]["source_key"]
+                or "Simulation" in result["unit_results"][p]["source_key"]
+            ):
                 continue
             if "unit_estimate" in result["unit_results"][p]["outputs"]:
                 simtype = result["unit_results"][p]["outputs"]["simtype"]
@@ -133,7 +132,9 @@ def _get_legs_from_result_jsons(
             if "standard_state_correction" in result["unit_results"][p]["outputs"]:
                 corr = result["unit_results"][p]["outputs"]["standard_state_correction"]
                 if not np.isclose(corr.m, 0):
-                    dgs[name]["standard_state_correction"].append([corr, 0 * unit.kilocalorie_per_mole])
+                    dgs[name]["standard_state_correction"].append(
+                        [corr, 0 * unit.kilocalorie_per_mole]
+                    )
             else:
                 continue
     return dgs

--- a/src/openfecli/commands/gather_abfe.py
+++ b/src/openfecli/commands/gather_abfe.py
@@ -118,6 +118,9 @@ def _get_legs_from_result_jsons(
         dgs[name]["overall"].append([result["estimate"], result["uncertainty"]])
         proto_key = [k for k in result["unit_results"].keys() if k.startswith("ProtocolUnitResult")]
         for p in proto_key:
+            # In openfe v1.9+, we only want to pick up results from
+            # the Analysis Unit. To ensure backwards compatibility with
+            # prior releases of openfe v1.x, we exclude Setup and Simulation
             if (
                 "Setup" in result["unit_results"][p]["source_key"]
                 or "Simulation" in result["unit_results"][p]["source_key"]

--- a/src/openfecli/tests/commands/test_gather/test_abfe_full_results_multiple_units_raw_.tsv
+++ b/src/openfecli/tests/commands/test_gather/test_abfe_full_results_multiple_units_raw_.tsv
@@ -5,15 +5,6 @@ complex	1	36.34	0.91
 solvent	1	5.5	1.4
 solvent	1	5.4	1.4
 solvent	1	6.5	1.4
-standard_state_correction	1	0.0	0.0
 standard_state_correction	1	-9.0	0.0
-standard_state_correction	1	0.0	0.0
-standard_state_correction	1	-9.0	0.0
-standard_state_correction	1	0.0	0.0
 standard_state_correction	1	-9.3	0.0
-standard_state_correction	1	-9.3	0.0
-standard_state_correction	1	0.0	0.0
-standard_state_correction	1	0.0	0.0
 standard_state_correction	1	-8.9	0.0
-standard_state_correction	1	-8.9	0.0
-standard_state_correction	1	0.0	0.0

--- a/src/openfecli/tests/commands/test_gather/test_abfe_single_repeat_multiple_units_raw_.tsv
+++ b/src/openfecli/tests/commands/test_gather/test_abfe_single_repeat_multiple_units_raw_.tsv
@@ -1,7 +1,4 @@
 leg	ligand	DG (kcal/mol)	MBAR uncertainty (kcal/mol)
 complex	1	34.77	0.81
 solvent	1	5.5	1.4
-standard_state_correction	1	0.0	0.0
-standard_state_correction	1	-9.0	0.0
-standard_state_correction	1	0.0	0.0
 standard_state_correction	1	-9.0	0.0


### PR DESCRIPTION
Small update to gather machinery to avoid picking results from UnitResults that aren't the Analysis unit.
It's not the nicest fix, but it works in a backwards compatible manner.

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
