### PR TITLE
Don't use the CUDA platform by default in tests

### DIFF
--- a/src/openfe/tests/protocols/openmm_ahfe/test_ahfe_resume.py
+++ b/src/openfe/tests/protocols/openmm_ahfe/test_ahfe_resume.py
@@ -42,6 +42,8 @@ def protocol_settings():
     settings.solvent_simulation_settings.time_per_iteration = 2.5 * offunit.picosecond
     settings.vacuum_output_settings.checkpoint_interval = 100 * offunit.picosecond
     settings.solvent_output_settings.checkpoint_interval = 100 * offunit.picosecond
+    settings.vacuum_engine_settings.compute_platform = None
+    settings.solvent_engine_settings.compute_platform = None
     return settings
 
 


### PR DESCRIPTION
Fixes #1880

Checklist
* [N/A] All new code is appropriately documented (user-facing code _must_ have complete docstrings).
* [N/A] Added a ``news`` entry, or the changes are not user-facing.
* [ ] Ran pre-commit: you can run [pre-commit](https://pre-commit.com) locally or comment on this PR with `pre-commit.ci autofix`.

Manual Tests: these are slow so don't need to be run every commit, only before merging and when relevant changes are made (generally at reviewer-discretion). 
* [ ] [GPU integration tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/gpu-integration-tests.yaml)
* [ ] [example notebook testing](https://github.com/OpenFreeEnergy/openfe/actions/workflows/test-example-notebooks.yaml)
* [ ] [packaging tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/test-feedstock-pkg-build.yaml): run this for any large feature PRs or PRs that add test data.


## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
