### PR TITLE
include output json in caching hash

### DIFF
--- a/src/openfecli/commands/quickrun.py
+++ b/src/openfecli/commands/quickrun.py
@@ -130,7 +130,7 @@ def quickrun(transformation, work_dir, output, resume):
 
     if cached_dag_path.is_file():
         if resume:
-            write(f"Attempting to resume execution using existing edges from '{cached_dag_path}'")
+            write(f"Attempting to resume execution using '{cached_dag_path}'")
             try:
                 dag = ProtocolDAG.from_json(cached_dag_path)
             except JSONDecodeError:
@@ -147,7 +147,7 @@ def quickrun(transformation, work_dir, output, resume):
     else:
         if resume:
             write(
-                f"openfe quickrun was run with --resume, but no checkpoint found at {cached_dag_path}. Starting new execution."
+                f"openfe quickrun was run with --resume, but no cached results found at {cached_dag_path}. Starting new execution."
             )
 
         # Create the DAG instead and then serialize for later resuming

--- a/src/openfecli/commands/quickrun.py
+++ b/src/openfecli/commands/quickrun.py
@@ -97,18 +97,23 @@ def quickrun(transformation, work_dir, output, resume):
     # turn warnings into log message (don't show stack trace)
     logging.captureWarnings(True)
 
+    click.secho(f"\nCurrent directory: {os.getcwd()}/")
     if work_dir is None:
+        click.secho(f"Creating working directory: {work_dir}/")
         work_dir = pathlib.Path(os.getcwd())
     else:
+        click.secho(f"Using existing working directory: {work_dir}/")
         work_dir.mkdir(exist_ok=True, parents=True)
 
-    write("Loading file...")
     trans = Transformation.from_json(transformation)
 
     if output is None:
         output = work_dir / (str(trans.key) + "_results.json")
     else:
         output.parent.mkdir(exist_ok=True, parents=True)
+
+    click.secho(f"Loading transformation from: {transformation.name}")
+    click.secho(f"When simulation is complete, results will be written to: {output}\n")
 
     # Attempt to either deserialize or freshly create DAG
     cache_basedir = work_dir / "quickrun_cache"
@@ -121,7 +126,9 @@ def quickrun(transformation, work_dir, output, resume):
             try:
                 dag = ProtocolDAG.from_json(cached_dag_path)
             except JSONDecodeError:
-                errmsg = f"Recovery failed, please remove {cached_dag_path} and any results from your working directory before continuing to create a new protocol."
+                # we can't tell the user which gufe-generated cache dir to delete, since we'd need to load the JSON to know the DAG's key
+                # however, just removing the cached_dag_path is sufficient to trigger a fresh DAG to be generated, and the gufe-generated cached dir will just be stale.
+                errmsg = f"Recovery failed, please remove {cached_dag_path} before continuing to create a new protocol."
                 raise click.ClickException(errmsg)
 
             write("Success. Resuming execution...")
@@ -131,7 +138,7 @@ def quickrun(transformation, work_dir, output, resume):
 
     else:
         if resume:
-            click.echo(
+            write(
                 f"openfe quickrun was run with --resume, but no checkpoint found at {cached_dag_path}. Starting new execution."
             )
 

--- a/src/openfecli/commands/quickrun.py
+++ b/src/openfecli/commands/quickrun.py
@@ -156,7 +156,7 @@ def quickrun(transformation, work_dir, output, resume):
         cache_basedir.mkdir(exist_ok=True)
         dag.to_json(cached_dag_path)
 
-    write("Starting the simulations for this edge...")
+    write("\nStarting the simulations for this edge...\n")
     dagresult = execute_DAG(
         dag,
         shared_basedir=work_dir,

--- a/src/openfecli/commands/quickrun.py
+++ b/src/openfecli/commands/quickrun.py
@@ -115,6 +115,14 @@ def quickrun(transformation, work_dir, output, resume):
     click.secho(f"Loading transformation from: {transformation.name}")
     click.secho(f"When simulation is complete, results will be written to: {output}\n")
 
+    resume_command = f"openfe quickrun {transformation.name} -o {output} -d {work_dir} --resume\n"
+
+    click.secho(
+        "If this simulation is interrupted or fails, you may attempt to resume execution using:",
+        bold=True,
+    )
+    click.secho(resume_command)
+
     # Attempt to either deserialize or freshly create DAG
     cache_basedir = work_dir / "quickrun_cache"
     hashed_key = _hash_quickrun_inputs(output, trans)
@@ -134,7 +142,7 @@ def quickrun(transformation, work_dir, output, resume):
             write("Success. Resuming execution...")
         else:
             errmsg = f"Transformation has been started but is incomplete. Please remove {cached_dag_path} and rerun, or resume execution using the ``--resume`` flag."
-            raise click.ClickException(errmsg)
+            raise click.ClickException(click.style(errmsg, fg="red"))
 
     else:
         if resume:

--- a/src/openfecli/commands/quickrun.py
+++ b/src/openfecli/commands/quickrun.py
@@ -1,6 +1,7 @@
 # This code is part of OpenFE and is licensed under the MIT license.
 # For details, see https://github.com/OpenFreeEnergy/openfe
 
+import hashlib
 import json
 import pathlib
 import warnings
@@ -14,6 +15,12 @@ from openfecli.utils import configure_logger, print_duration, write
 def _format_exception(exception) -> str:
     """Takes the exception as stored by Gufe and reformats it."""
     return f"{exception[0]}: {exception[1][0]}"
+
+
+def _hash_quickrun_inputs(output, transformation):
+    string_rep = f"{output.absolute()}{transformation.key}"
+    hasher = hashlib.md5(string_rep.encode(), usedforsecurity=False)
+    return hasher.hexdigest()
 
 
 @click.command("quickrun", short_help="Run a given transformation, saved as a JSON file")
@@ -105,31 +112,34 @@ def quickrun(transformation, work_dir, output, resume):
 
     # Attempt to either deserialize or freshly create DAG
     cache_basedir = work_dir / "quickrun_cache"
-    trans_DAG_json = cache_basedir / f"{trans.key}-ProtocolDAG.json"
+    hashed_key = _hash_quickrun_inputs(output, trans)
+    cached_dag_path = cache_basedir / f"dag-cache-{hashed_key}.json"
 
-    if trans_DAG_json.is_file():
+    if cached_dag_path.is_file():
         if resume:
-            write(f"Attempting to resume execution using existing edges from '{trans_DAG_json}'")
+            write(f"Attempting to resume execution using existing edges from '{cached_dag_path}'")
             try:
-                dag = ProtocolDAG.from_json(trans_DAG_json)
+                dag = ProtocolDAG.from_json(cached_dag_path)
             except JSONDecodeError:
-                errmsg = f"Recovery failed, please remove {trans_DAG_json} and any results from your working directory before continuing to create a new protocol."
+                errmsg = f"Recovery failed, please remove {cached_dag_path} and any results from your working directory before continuing to create a new protocol."
                 raise click.ClickException(errmsg)
+
+            write("Success. Resuming execution...")
         else:
-            errmsg = f"Transformation has been started but is incomplete. Please remove {trans_DAG_json} and rerun, or resume execution using the ``--resume`` flag."
+            errmsg = f"Transformation has been started but is incomplete. Please remove {cached_dag_path} and rerun, or resume execution using the ``--resume`` flag."
             raise click.ClickException(errmsg)
 
     else:
         if resume:
             click.echo(
-                f"openfe quickrun was run with --resume, but no checkpoint found at {trans_DAG_json}. Starting new execution."
+                f"openfe quickrun was run with --resume, but no checkpoint found at {cached_dag_path}. Starting new execution."
             )
 
         # Create the DAG instead and then serialize for later resuming
         write("Planning simulations for this edge...")
         dag = trans.create()
         cache_basedir.mkdir(exist_ok=True)
-        dag.to_json(trans_DAG_json)
+        dag.to_json(cached_dag_path)
 
     write("Starting the simulations for this edge...")
     dagresult = execute_DAG(
@@ -163,7 +173,7 @@ def quickrun(transformation, work_dir, output, resume):
         json.dump(out_dict, outf, cls=JSON_HANDLER.encoder)
 
     # remove the checkpoint since the job has completed
-    os.remove(trans_DAG_json)
+    os.remove(cached_dag_path)
 
     write(f"Here is the result:\n\tdG = {estimate} ± {uncertainty}\n")
     write("")

--- a/src/openfecli/tests/commands/test_quickrun.py
+++ b/src/openfecli/tests/commands/test_quickrun.py
@@ -28,27 +28,28 @@ def test_quickrun(extra_args, json_file):
 
     runner = CliRunner()
     with runner.isolated_filesystem():
+        # figure out what cached json should be
+        trans = Transformation.from_json(json_file)
+        work_dir = extra_args.get("-d", ".")
+        outfile = pathlib.Path(extra_args.get("-o", f"{trans.key}_results.json"))
+        hashed_key = _hash_quickrun_inputs(outfile, trans)
+
+        # output json shouldn't be created before quickrun is executed
+        assert not pathlib.Path(outfile).exists()
         result = runner.invoke(quickrun, [json_file] + extras)
 
         assert_click_success(result)
         assert "Here is the result" in result.output
-        trans = Transformation.from_json(json_file)
-
-        # figure out what cached json should be
-        work_dir = extra_args.get("-d", ".")
-        output_json = pathlib.Path(extra_args.get("-o", f"{trans.key}_results.json"))
-        hashed_key = _hash_quickrun_inputs(output_json, trans)
 
         # checkpoint should be deleted when job is complete
         assert not pathlib.Path(work_dir, "quickrun_cache", f"dag-cache-{hashed_key}.json").exists()
 
-        if outfile := extra_args.get("-o"):
-            assert pathlib.Path(outfile).exists()
-            with open(outfile, mode="r") as outf:
-                dct = json.load(outf, cls=JSON_HANDLER.decoder)
+        # output json should exist with data when job is complete
+        assert pathlib.Path(outfile).exists()
+        with open(outfile, mode="r") as outf:
+            dct = json.load(outf, cls=JSON_HANDLER.decoder)
 
-            assert set(dct) == {"estimate", "uncertainty", "protocol_result", "unit_results"}
-
+        assert set(dct) == {"estimate", "uncertainty", "protocol_result", "unit_results"}
         # TODO: need a protocol that drops files to actually do this!
         # if directory := extra_args.get('-d'):
         #     dirpath = pathlib.Path(directory)
@@ -72,8 +73,8 @@ def test_quickrun_interrupted(extra_args, json_file):
         trans = Transformation.from_json(json_file)
         # figure out what cached json should be
         work_dir = pathlib.Path(extra_args.get("-d", ".")).absolute()
-        output_json = pathlib.Path(extra_args.get("-o", f"{trans.key}_results.json"))
-        hashed_key = _hash_quickrun_inputs(output_json, trans)
+        outfile = pathlib.Path(extra_args.get("-o", f"{trans.key}_results.json"))
+        hashed_key = _hash_quickrun_inputs(outfile, trans)
 
         assert pathlib.Path(work_dir, "quickrun_cache", f"dag-cache-{hashed_key}.json").exists()
 
@@ -131,8 +132,8 @@ def test_quickrun_existing_checkpoint(json_file):
     runner = CliRunner()
     with runner.isolated_filesystem():
         work_dir = pathlib.Path(".")
-        output_json = pathlib.Path(work_dir, f"{trans.key}_results.json")
-        hashed_key = _hash_quickrun_inputs(output_json, trans)
+        outfile = pathlib.Path(work_dir, f"{trans.key}_results.json")
+        hashed_key = _hash_quickrun_inputs(outfile, trans)
         pathlib.Path("quickrun_cache").mkdir()
         dag.to_json(pathlib.Path(work_dir, "quickrun_cache", f"dag-cache-{hashed_key}.json"))
         result = runner.invoke(quickrun, [json_file])
@@ -148,8 +149,8 @@ def test_quickrun_resume_from_checkpoint(json_file):
     runner = CliRunner()
     with runner.isolated_filesystem():
         work_dir = pathlib.Path(".")
-        output_json = pathlib.Path(work_dir, f"{trans.key}_results.json")
-        hashed_key = _hash_quickrun_inputs(output_json, trans)
+        outfile = pathlib.Path(work_dir, f"{trans.key}_results.json")
+        hashed_key = _hash_quickrun_inputs(outfile, trans)
         pathlib.Path("quickrun_cache").mkdir()
         dag.to_json(pathlib.Path(work_dir, "quickrun_cache", f"dag-cache-{hashed_key}.json"))
         result = runner.invoke(quickrun, [json_file, "--resume"])
@@ -165,8 +166,8 @@ def test_quickrun_resume_invalid_checkpoint(json_file):
     runner = CliRunner()
     with runner.isolated_filesystem():
         work_dir = pathlib.Path(".")
-        output_json = pathlib.Path(work_dir, f"{trans.key}_results.json")
-        hashed_key = _hash_quickrun_inputs(output_json, trans)
+        outfile = pathlib.Path(work_dir, f"{trans.key}_results.json")
+        hashed_key = _hash_quickrun_inputs(outfile, trans)
         pathlib.Path("quickrun_cache").mkdir()
         pathlib.Path(work_dir, "quickrun_cache", f"dag-cache-{hashed_key}.json").touch()
         result = runner.invoke(quickrun, [json_file, "--resume"])

--- a/src/openfecli/tests/commands/test_quickrun.py
+++ b/src/openfecli/tests/commands/test_quickrun.py
@@ -36,7 +36,7 @@ def test_quickrun(extra_args, json_file):
 
         # figure out what cached json should be
         work_dir = extra_args.get("-d", ".")
-        output_json = pathlib.Path(work_dir, extra_args.get("-o", f"{trans.key}_results.json"))
+        output_json = pathlib.Path(extra_args.get("-o", f"{trans.key}_results.json"))
         hashed_key = _hash_quickrun_inputs(output_json, trans)
 
         # checkpoint should be deleted when job is complete
@@ -59,7 +59,7 @@ def test_quickrun(extra_args, json_file):
 
 @pytest.mark.parametrize("extra_args", [{}, {"-d": "foo_dir", "-o": "foo.json"}])
 def test_quickrun_interrupted(extra_args, json_file):
-    """If a quickrun is unable to complete, the ProtocolDAG.json checkpoint should exist."""
+    """If quickrun is unable to complete, the ProtocolDAG.json checkpoint should exist."""
     extras = sum([list(kv) for kv in extra_args.items()], [])
 
     runner = CliRunner()

--- a/src/openfecli/tests/commands/test_quickrun.py
+++ b/src/openfecli/tests/commands/test_quickrun.py
@@ -9,7 +9,7 @@ from click.testing import CliRunner
 from gufe import Transformation
 from gufe.tokenization import JSON_HANDLER
 
-from openfecli.commands.quickrun import quickrun
+from openfecli.commands.quickrun import _hash_quickrun_inputs, quickrun
 
 from ..utils import assert_click_success
 
@@ -33,10 +33,14 @@ def test_quickrun(extra_args, json_file):
         assert_click_success(result)
         assert "Here is the result" in result.output
         trans = Transformation.from_json(json_file)
+
+        # figure out what cached json should be
+        work_dir = extra_args.get("-d", ".")
+        output_json = pathlib.Path(work_dir, extra_args.get("-o", f"{trans.key}_results.json"))
+        hashed_key = _hash_quickrun_inputs(output_json, trans)
+
         # checkpoint should be deleted when job is complete
-        assert not pathlib.Path(
-            extra_args.get("-d", ""), "quickrun_cache", f"{trans.key}-ProtocolDAG.json"
-        ).exists()
+        assert not pathlib.Path(work_dir, "quickrun_cache", f"dag-cache-{hashed_key}.json").exists()
 
         if outfile := extra_args.get("-o"):
             assert pathlib.Path(outfile).exists()
@@ -64,10 +68,14 @@ def test_quickrun_interrupted(extra_args, json_file):
             result = runner.invoke(quickrun, [json_file] + extras)
 
         assert "Here is the result" not in result.output
+
         trans = Transformation.from_json(json_file)
-        assert pathlib.Path(
-            extra_args.get("-d", ""), "quickrun_cache", f"{trans.key}-ProtocolDAG.json"
-        ).exists()
+        # figure out what cached json should be
+        work_dir = pathlib.Path(extra_args.get("-d", ".")).absolute()
+        output_json = pathlib.Path(extra_args.get("-o", f"{trans.key}_results.json"))
+        hashed_key = _hash_quickrun_inputs(output_json, trans)
+
+        assert pathlib.Path(work_dir, "quickrun_cache", f"dag-cache-{hashed_key}.json").exists()
 
 
 def test_quickrun_output_file_exists(json_file):
@@ -122,8 +130,11 @@ def test_quickrun_existing_checkpoint(json_file):
 
     runner = CliRunner()
     with runner.isolated_filesystem():
+        work_dir = pathlib.Path(".")
+        output_json = pathlib.Path(work_dir, f"{trans.key}_results.json")
+        hashed_key = _hash_quickrun_inputs(output_json, trans)
         pathlib.Path("quickrun_cache").mkdir()
-        dag.to_json(pathlib.Path("quickrun_cache", f"{trans.key}-ProtocolDAG.json"))
+        dag.to_json(pathlib.Path(work_dir, "quickrun_cache", f"dag-cache-{hashed_key}.json"))
         result = runner.invoke(quickrun, [json_file])
         assert result.exit_code == 1
         assert "Attempting to resume" not in result.output
@@ -136,8 +147,11 @@ def test_quickrun_resume_from_checkpoint(json_file):
 
     runner = CliRunner()
     with runner.isolated_filesystem():
+        work_dir = pathlib.Path(".")
+        output_json = pathlib.Path(work_dir, f"{trans.key}_results.json")
+        hashed_key = _hash_quickrun_inputs(output_json, trans)
         pathlib.Path("quickrun_cache").mkdir()
-        dag.to_json(pathlib.Path("quickrun_cache", f"{trans.key}-ProtocolDAG.json"))
+        dag.to_json(pathlib.Path(work_dir, "quickrun_cache", f"dag-cache-{hashed_key}.json"))
         result = runner.invoke(quickrun, [json_file, "--resume"])
 
         assert_click_success(result)
@@ -150,8 +164,11 @@ def test_quickrun_resume_invalid_checkpoint(json_file):
 
     runner = CliRunner()
     with runner.isolated_filesystem():
+        work_dir = pathlib.Path(".")
+        output_json = pathlib.Path(work_dir, f"{trans.key}_results.json")
+        hashed_key = _hash_quickrun_inputs(output_json, trans)
         pathlib.Path("quickrun_cache").mkdir()
-        pathlib.Path("quickrun_cache", f"{trans.key}-ProtocolDAG.json").touch()
+        pathlib.Path(work_dir, "quickrun_cache", f"dag-cache-{hashed_key}.json").touch()
         result = runner.invoke(quickrun, [json_file, "--resume"])
 
         assert result.exit_code == 1

--- a/src/openfecli/tests/commands/test_quickrun.py
+++ b/src/openfecli/tests/commands/test_quickrun.py
@@ -60,22 +60,21 @@ def test_quickrun(extra_args, json_file):
 
 @pytest.mark.parametrize("extra_args", [{}, {"-d": "foo_dir", "-o": "foo.json"}])
 def test_quickrun_interrupted(extra_args, json_file):
-    """If quickrun is unable to complete, the ProtocolDAG.json checkpoint should exist."""
+    """If quickrun starts but is unable to complete, the ProtocolDAG.json cached checkpoint should exist."""
     extras = sum([list(kv) for kv in extra_args.items()], [])
 
     runner = CliRunner()
     with runner.isolated_filesystem():
-        with mock.patch("gufe.protocols.protocoldag.execute_DAG", side_effect=RuntimeError):
-            result = runner.invoke(quickrun, [json_file] + extras)
-
-        assert "Here is the result" not in result.output
-
-        trans = Transformation.from_json(json_file)
         # figure out what cached json should be
+        trans = Transformation.from_json(json_file)
         work_dir = pathlib.Path(extra_args.get("-d", ".")).absolute()
         outfile = pathlib.Path(extra_args.get("-o", f"{trans.key}_results.json"))
         hashed_key = _hash_quickrun_inputs(outfile, trans)
 
+        with mock.patch("gufe.protocols.protocoldag.execute_DAG", side_effect=RuntimeError):
+            result = runner.invoke(quickrun, [json_file] + extras)
+
+        assert "Here is the result" not in result.output
         assert pathlib.Path(work_dir, "quickrun_cache", f"dag-cache-{hashed_key}.json").exists()
 
 
@@ -124,18 +123,17 @@ def test_quickrun_unit_error():
         # protocol dag results maybe?
 
 
-def test_quickrun_existing_checkpoint(json_file):
+def test_quickrun_existing_checkpoint_error(json_file):
     """In the default case where resume=False, if the checkpoint exists, quickrun should error out and not attempt to execute."""
     trans = Transformation.from_json(json_file)
     dag = trans.create()
 
     runner = CliRunner()
     with runner.isolated_filesystem():
-        work_dir = pathlib.Path(".")
-        outfile = pathlib.Path(work_dir, f"{trans.key}_results.json")
+        outfile = pathlib.Path(f"{trans.key}_results.json")
         hashed_key = _hash_quickrun_inputs(outfile, trans)
         pathlib.Path("quickrun_cache").mkdir()
-        dag.to_json(pathlib.Path(work_dir, "quickrun_cache", f"dag-cache-{hashed_key}.json"))
+        dag.to_json(pathlib.Path("quickrun_cache", f"dag-cache-{hashed_key}.json"))
         result = runner.invoke(quickrun, [json_file])
         assert result.exit_code == 1
         assert "Attempting to resume" not in result.output
@@ -148,15 +146,16 @@ def test_quickrun_resume_from_checkpoint(json_file):
 
     runner = CliRunner()
     with runner.isolated_filesystem():
-        work_dir = pathlib.Path(".")
-        outfile = pathlib.Path(work_dir, f"{trans.key}_results.json")
+        outfile = pathlib.Path(f"{trans.key}_results.json")
         hashed_key = _hash_quickrun_inputs(outfile, trans)
         pathlib.Path("quickrun_cache").mkdir()
-        dag.to_json(pathlib.Path(work_dir, "quickrun_cache", f"dag-cache-{hashed_key}.json"))
+        dag_cache = pathlib.Path("quickrun_cache", f"dag-cache-{hashed_key}.json")
+        dag.to_json(dag_cache)
         result = runner.invoke(quickrun, [json_file, "--resume"])
 
         assert_click_success(result)
-        assert "Attempting to resume" in result.output
+        assert f"resume execution using '{dag_cache.absolute()}" in result.output
+        assert "Success" in result.output
 
 
 def test_quickrun_resume_invalid_checkpoint(json_file):
@@ -165,22 +164,31 @@ def test_quickrun_resume_invalid_checkpoint(json_file):
 
     runner = CliRunner()
     with runner.isolated_filesystem():
-        work_dir = pathlib.Path(".")
-        outfile = pathlib.Path(work_dir, f"{trans.key}_results.json")
+        outfile = pathlib.Path(f"{trans.key}_results.json")
         hashed_key = _hash_quickrun_inputs(outfile, trans)
         pathlib.Path("quickrun_cache").mkdir()
-        pathlib.Path(work_dir, "quickrun_cache", f"dag-cache-{hashed_key}.json").touch()
+        dag_cache = pathlib.Path("quickrun_cache", f"dag-cache-{hashed_key}.json")
+        dag_cache.touch()
         result = runner.invoke(quickrun, [json_file, "--resume"])
 
         assert result.exit_code == 1
-        assert "Attempting to resume" in result.output
+        assert f"resume execution using '{dag_cache.absolute()}" in result.output
         assert "Recovery failed" in result.stderr
 
 
 def test_quickrun_resume_missing_checkpoint(json_file):
-    """If --resume is passed but there's not checkpoint, just echo a message and keep going."""
+    """If --resume is passed but there's no checkpoint, just echo a message and start from scratch."""
     runner = CliRunner()
     with runner.isolated_filesystem():
+        # determine what the cache to be looked for should be named
+        trans = Transformation.from_json(json_file)
+        outfile = pathlib.Path(f"{trans.key}_results.json")
+        hashed_key = _hash_quickrun_inputs(outfile, trans)
+        dag_cache = pathlib.Path("quickrun_cache", f"dag-cache-{hashed_key}.json")
+
         result = runner.invoke(quickrun, [json_file, "--resume"])
         assert_click_success(result)
-        assert "openfe quickrun was run with --resume, but no checkpoint found at" in result.output
+        assert (
+            f"openfe quickrun was run with --resume, but no cached results found at {dag_cache.absolute()}"
+            in result.output
+        )


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
this is a first pass at how we could implement what I described here: https://github.com/OpenFreeEnergy/openfe/pull/1848#discussion_r2977178286


<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [x] All new code is appropriately documented (user-facing code _must_ have complete docstrings).
* [x] Added a ``news`` entry, or the changes are not user-facing.
* [x] Ran pre-commit: you can run [pre-commit](https://pre-commit.com) locally or comment on this PR with `pre-commit.ci autofix`.

Manual Tests: these are slow so don't need to be run every commit, only before merging and when relevant changes are made (generally at reviewer-discretion). 
* [ ] [GPU integration tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/gpu-integration-tests.yaml)
* [ ] [example notebook testing](https://github.com/OpenFreeEnergy/openfe/actions/workflows/test-example-notebooks.yaml)
* [ ] [packaging tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/test-feedstock-pkg-build.yaml): run this for any large feature PRs or PRs that add test data.


## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
