### PR TITLE
quickrun testing: check default filename creation

### DIFF
--- a/src/openfecli/tests/commands/test_quickrun.py
+++ b/src/openfecli/tests/commands/test_quickrun.py
@@ -2,9 +2,9 @@ import json
 import pathlib
 from importlib import resources
 
-import click
 import pytest
 from click.testing import CliRunner
+from gufe import Transformation
 from gufe.tokenization import JSON_HANDLER
 
 from openfecli.commands.quickrun import quickrun
@@ -33,13 +33,14 @@ def test_quickrun(extra_args, json_file):
         result = runner.invoke(quickrun, [json_file] + extras)
         assert result.exit_code == 0
         assert "Here is the result" in result.output
+        trans = Transformation.from_json(json_file)
 
-        if outfile := extra_args.get("-o"):
-            assert pathlib.Path(outfile).exists()
-            with open(outfile, mode="r") as outf:
-                dct = json.load(outf, cls=JSON_HANDLER.decoder)
+        outfile = pathlib.Path(extra_args.get("-o", f"{trans.key}_results.json"))
+        assert pathlib.Path(outfile).exists()
+        with open(outfile, mode="r") as outf:
+            dct = json.load(outf, cls=JSON_HANDLER.decoder)
 
-            assert set(dct) == {"estimate", "uncertainty", "protocol_result", "unit_results"}
+        assert set(dct) == {"estimate", "uncertainty", "protocol_result", "unit_results"}
 
         # TODO: need a protocol that drops files to actually do this!
         # if directory := extra_args.get('-d'):

--- a/src/openfecli/tests/commands/test_quickrun.py
+++ b/src/openfecli/tests/commands/test_quickrun.py
@@ -30,12 +30,17 @@ def test_quickrun(extra_args, json_file):
 
     runner = CliRunner()
     with runner.isolated_filesystem():
+        trans = Transformation.from_json(json_file)
+        outfile = pathlib.Path(extra_args.get("-o", f"{trans.key}_results.json"))
+
+        # output json shouldn't be created before quickrun is executed
+        assert not pathlib.Path(outfile).exists()
+
         result = runner.invoke(quickrun, [json_file] + extras)
         assert result.exit_code == 0
         assert "Here is the result" in result.output
-        trans = Transformation.from_json(json_file)
 
-        outfile = pathlib.Path(extra_args.get("-o", f"{trans.key}_results.json"))
+        # output json should exist and have results after execution
         assert pathlib.Path(outfile).exists()
         with open(outfile, mode="r") as outf:
             dct = json.load(outf, cls=JSON_HANDLER.decoder)


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

When we added the default -o behavior, we didn't update the tests to cover that case.
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [x] All new code is appropriately documented (user-facing code _must_ have complete docstrings).
* [x] Added a ``news`` entry, or the changes are not user-facing.
* [x] Ran pre-commit: you can run [pre-commit](https://pre-commit.com) locally or comment on this PR with `pre-commit.ci autofix`.

Manual Tests: these are slow so don't need to be run every commit, only before merging and when relevant changes are made (generally at reviewer-discretion). 
* [ ] [GPU integration tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/gpu-integration-tests.yaml)
* [ ] [example notebook testing](https://github.com/OpenFreeEnergy/openfe/actions/workflows/test-example-notebooks.yaml)
* [ ] [packaging tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/test-feedstock-pkg-build.yaml): run this for any large feature PRs or PRs that add test data.


## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
