### PR TITLE
unify CI runner naming conventions

### DIFF
--- a/.github/workflows/aws-cpu-long-tests.yaml
+++ b/.github/workflows/aws-cpu-long-tests.yaml
@@ -1,4 +1,4 @@
-name: CPU Long Tests (manual dispatch)
+name: "manual AWS: CPU long tests"
 on:
   workflow_dispatch:
 

--- a/.github/workflows/aws-gpu-integration-tests.yaml
+++ b/.github/workflows/aws-gpu-integration-tests.yaml
@@ -1,4 +1,4 @@
-name: GPU Integration Tests (manual dispatch)
+name: "manual AWS: GPU integration tests"
 on:
   workflow_dispatch:
 

--- a/.github/workflows/clean-pr-caches.yaml
+++ b/.github/workflows/clean-pr-caches.yaml
@@ -1,5 +1,5 @@
 # from https://docs.github.com/en/actions/how-tos/manage-workflow-runs/manage-caches#force-deleting-cache-entries
-name: Cleanup github runner caches on closed pull requests
+name: "clean up github runner caches on closed pull requests"
 on:
   workflow_dispatch:
   pull_request:

--- a/.github/workflows/cron-conda.yaml
+++ b/.github/workflows/cron-conda.yaml
@@ -1,4 +1,4 @@
-name: "conda_cron"
+name: "cron: conda builds daily tests"
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/cron-docker.yaml
+++ b/.github/workflows/cron-docker.yaml
@@ -1,4 +1,4 @@
-name: Test Docker Image Building
+name: "cron: docker image daily tests"
 
 on:
   push:

--- a/.github/workflows/cron-package-test.yaml
+++ b/.github/workflows/cron-package-test.yaml
@@ -1,4 +1,4 @@
-name: "Daily package install tests."
+name: "cron: package install daily tests"
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/griffe-api-break.yaml
+++ b/.github/workflows/griffe-api-break.yaml
@@ -1,4 +1,4 @@
-name: Check for API breaks
+name: "PR: griffe check for API breaks"
 
 on:
   pull_request_target:

--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -1,4 +1,4 @@
-name: "mypy static type checking"
+name: "PR: mypy static type checking"
 on:
   pull_request:
     branches:

--- a/.github/workflows/release-docker-image.yaml
+++ b/.github/workflows/release-docker-image.yaml
@@ -8,7 +8,7 @@
 # You can also reference a tag or branch, but the action may change without warning.
 
 # Workflow to automate docker image building during the openfe release process.
-name: Create and publish a Docker image
+name: "release: create and publish a docker image"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release-installers.yaml
+++ b/.github/workflows/release-installers.yaml
@@ -1,4 +1,4 @@
-name: Make single-file installers (manual dispatch)
+name: "release: make single-file installers"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release-make-condalock.yaml
+++ b/.github/workflows/release-make-condalock.yaml
@@ -1,4 +1,4 @@
-name: Create OpenFE Conda-Lock File
+name: "release: create openfe conda-lock file"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release-prep-examplenotebooks.yaml
+++ b/.github/workflows/release-prep-examplenotebooks.yaml
@@ -1,4 +1,4 @@
-name: Test example notebooks
+name: "release prep: test example notebooks"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release-prep-feedstock.yaml
+++ b/.github/workflows/release-prep-feedstock.yaml
@@ -1,4 +1,4 @@
-name: Test conda-forge package build
+name: "release prep: test conda-forge package build"
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] All new code is appropriately documented (user-facing code _must_ have complete docstrings).
* [ ] Added a ``news`` entry, or the changes are not user-facing.
* [ ] Ran pre-commit: you can run [pre-commit](https://pre-commit.com) locally or comment on this PR with `pre-commit.ci autofix`.

Manual Tests: these are slow so don't need to be run every commit, only before merging and when relevant changes are made (generally at reviewer-discretion). 
* [ ] [GPU integration tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/gpu-integration-tests.yaml)
* [ ] [example notebook testing](https://github.com/OpenFreeEnergy/openfe/actions/workflows/test-example-notebooks.yaml)
* [ ] [packaging tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/test-feedstock-pkg-build.yaml): run this for any large feature PRs or PRs that add test data.


## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
