### PR TITLE
Fix typo in quickrun execution error message.

### DIFF
--- a/src/openfecli/commands/quickrun.py
+++ b/src/openfecli/commands/quickrun.py
@@ -136,7 +136,7 @@ def quickrun(transformation, work_dir, output, resume):
             except JSONDecodeError:
                 # we can't tell the user which gufe-generated cache dir to delete, since we'd need to load the JSON to know the DAG's key
                 # however, just removing the cached_dag_path is sufficient to trigger a fresh DAG to be generated, and the gufe-generated cached dir will just be stale.
-                errmsg = f"Recovery failed, please remove {cached_dag_path} before continuing to create a new protocol."
+                errmsg = f"Recovery failed, please remove {cached_dag_path} before executing a new transformation simulation."
                 raise click.ClickException(errmsg)
 
             write("Success. Resuming execution...")


### PR DESCRIPTION
Working on #1878 and noticing that the wording was somewhat confusing (we're not creating a new protocol and everywhere else we are talking about executing transformations / simulations).

Checklist
* [ ] All new code is appropriately documented (user-facing code _must_ have complete docstrings).
* [ ] Added a ``news`` entry, or the changes are not user-facing.
* [ ] Ran pre-commit: you can run [pre-commit](https://pre-commit.com) locally or comment on this PR with `pre-commit.ci autofix`.

Manual Tests: these are slow so don't need to be run every commit, only before merging and when relevant changes are made (generally at reviewer-discretion). 
* [ ] [GPU integration tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/gpu-integration-tests.yaml)
* [ ] [example notebook testing](https://github.com/OpenFreeEnergy/openfe/actions/workflows/test-example-notebooks.yaml)
* [ ] [packaging tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/test-feedstock-pkg-build.yaml): run this for any large feature PRs or PRs that add test data.


## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
