### PR TITLE
ruff format code in docstrings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ fallback_version = "0.0.0"
 
 [tool.ruff]
 line-length = 100
+format.docstring-code-format = true
 
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
 lint.select = [

--- a/src/openfe/utils/logging_control.py
+++ b/src/openfe/utils/logging_control.py
@@ -114,7 +114,7 @@ def _silence_message(msg: str | list[str], logger_names: str | list[str]) -> Non
     --------
     >>> _silence_message(
     ...     msg="****** PyMBAR will use 64-bit JAX! *******",
-    ...     logger_names=["pymbar.timeseries", "pymbar.mbar_solvers"]
+    ...     logger_names=["pymbar.timeseries", "pymbar.mbar_solvers"],
     ... )
     """
     if isinstance(logger_names, str):
@@ -158,10 +158,7 @@ def _append_logger(suffix: str | list[str], logger_names: str | list[str]) -> No
 
     Examples
     --------
-    >>> _append_logger(
-    ...     suffix=" [DEPRECATED]",
-    ...     logger_names="myapp"
-    ... )
+    >>> _append_logger(suffix=" [DEPRECATED]", logger_names="myapp")
     """
     if isinstance(logger_names, str):
         logger_names = [logger_names]


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [ ] All new code is appropriately documented (user-facing code _must_ have complete docstrings).
* [ ] Added a ``news`` entry, or the changes are not user-facing.
* [ ] Ran pre-commit: you can run [pre-commit](https://pre-commit.com) locally or comment on this PR with `pre-commit.ci autofix`.

Manual Tests: these are slow so don't need to be run every commit, only before merging and when relevant changes are made (generally at reviewer-discretion). 
* [ ] [GPU integration tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/gpu-integration-tests.yaml)
* [ ] [example notebook testing](https://github.com/OpenFreeEnergy/openfe/actions/workflows/test-example-notebooks.yaml)
* [ ] [packaging tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/test-feedstock-pkg-build.yaml): run this for any large feature PRs or PRs that add test data.


## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
