### PR TITLE
SepTop: slightly refactor `_execute` calls

### DIFF
--- a/src/openfe/protocols/openmm_septop/base.py
+++ b/src/openfe/protocols/openmm_septop/base.py
@@ -44,7 +44,6 @@ from openmmtools.states import (
     create_thermodynamic_state_protocol,
 )
 
-from openfe.utils import log_system_probe
 from openfe.protocols.openmm_afe.equil_afe_settings import (
     AlchemicalSettings,
     BaseSolvationSettings,
@@ -60,7 +59,7 @@ from openfe.protocols.openmm_md.plain_md_methods import PlainMDProtocolUnit
 from openfe.protocols.openmm_utils import omm_compute
 from openfe.protocols.openmm_utils.omm_settings import SettingsBaseModel
 from openfe.protocols.openmm_utils.serialization import deserialize
-from openfe.utils import without_oechem_backend
+from openfe.utils import log_system_probe, without_oechem_backend
 
 from ..openmm_utils import (
     charge_generation,

--- a/src/openfe/protocols/openmm_septop/base.py
+++ b/src/openfe/protocols/openmm_septop/base.py
@@ -44,6 +44,7 @@ from openmmtools.states import (
     create_thermodynamic_state_protocol,
 )
 
+from openfe.utils import log_system_probe
 from openfe.protocols.openmm_afe.equil_afe_settings import (
     AlchemicalSettings,
     BaseSolvationSettings,

--- a/src/openfe/protocols/openmm_septop/base.py
+++ b/src/openfe/protocols/openmm_septop/base.py
@@ -738,6 +738,22 @@ class BaseSepTopSetupUnit(gufe.ProtocolUnit):
 
         return omm_system, omm_topology, positions, system_modeller, comp_resids
 
+    def _execute(
+        self,
+        ctx: gufe.Context,
+        **kwargs,
+    ) -> dict[str, Any]:
+        log_system_probe(logging.INFO, paths=[ctx.scratch])
+
+        outputs = self.run(scratch_basepath=ctx.scratch, shared_basepath=ctx.shared)
+
+        return {
+            "repeat_id": self._inputs["repeat_id"],
+            "generation": self._inputs["generation"],
+            "simtype": self.simtype,
+            **outputs,
+        }
+
 
 class BaseSepTopRunUnit(gufe.ProtocolUnit):
     """
@@ -1231,22 +1247,22 @@ class BaseSepTopRunUnit(gufe.ProtocolUnit):
 
     def run(
         self,
-        serialized_system,
-        serialized_topology,
-        dry=False,
-        verbose=True,
-        scratch_basepath=None,
-        shared_basepath=None,
+        system: openmm.System,
+        pdb_file: openmm.app.pdbfile.PDBFile,
+        dry: bool = False,
+        verbose: bool = True,
+        scratch_basepath: pathlib.Path | None = None,
+        shared_basepath: pathlib.Path | None = None,
     ) -> dict[str, Any]:
         """
         Run the simulation part of the SepTop protocol.
 
         Parameters
         ----------
-        serialized_system: pathlib.Path
-          Path to the serialized OpenMM system
-        serialized_topology: pathlib.Path
-          Path to the serialized topology of the system
+        system: openmm.System
+          System used for the SepTop calculation.
+        pdb_file: openmm.app.pdbfile.PDBFile
+          OpenMM PDBFile object representing the SepTop System.
         dry: bool
           Do a dry run of the calculation, creating all necessary alchemical
           system components (topology, system, sampler, etc...) but without
@@ -1254,9 +1270,9 @@ class BaseSepTopRunUnit(gufe.ProtocolUnit):
         verbose: bool
           Verbose output of the simulation progress. Output is provided via
           INFO level logging, default True
-        scratch_basepath : pathlib.Path
+        scratch_basepath : pathlib.Path | None
           Path to the scratch (temporary) directory space.
-        shared_basepath : pathlib.Path
+        shared_basepath : pathlib.Path | None
           Path to the shared (persistent) directory space.
 
         Returns
@@ -1274,15 +1290,12 @@ class BaseSepTopRunUnit(gufe.ProtocolUnit):
 
         settings = self._handle_settings()
         alchem_comps, solv_comp, prot_comp, smc_comps = self._get_components()
-
-        system = deserialize(serialized_system)
-        pdb = openmm.app.pdbfile.PDBFile(str(serialized_topology))
-        positions = pdb.getPositions(asNumpy=True)
+        positions = pdb_file.getPositions(asNumpy=True)
 
         # 2. Check that the restraints are correctly applied by running a short equilibration
         equil_positions, box_AB = _pre_equilibrate(
             system,
-            pdb.topology,
+            pdb_file.topology,
             positions,
             settings,
             "AB",
@@ -1305,7 +1318,7 @@ class BaseSepTopRunUnit(gufe.ProtocolUnit):
 
         # 4. Create the multistate reporter & create PDB
         reporter = self._get_reporter(
-            pdb.topology,
+            pdb_file.topology,
             equil_positions,
             settings["simulation_settings"],
             settings["output_settings"],
@@ -1375,3 +1388,29 @@ class BaseSepTopRunUnit(gufe.ProtocolUnit):
             }
         else:
             return {"debug": {"sampler": sampler}}
+
+    def _execute(
+        self,
+        ctx: gufe.Context,
+        *,
+        setup,
+        **kwargs,
+    ) -> dict[str, Any]:
+        log_system_probe(logging.INFO, paths=[ctx.scratch])
+
+        system = deserialize(setup.outputs["system"])
+        pdb_file = openmm.app.pdbfile.PDBFile(str(setup.outputs["topology"]))
+
+        outputs = self.run(
+            system,
+            pdb_file,
+            scratch_basepath=ctx.scratch,
+            shared_basepath=ctx.shared,
+        )
+
+        return {
+            "repeat_id": self._inputs["repeat_id"],
+            "generation": self._inputs["generation"],
+            "simtype": self.simtype,
+            **outputs,
+        }

--- a/src/openfe/protocols/openmm_septop/equil_septop_method.py
+++ b/src/openfe/protocols/openmm_septop/equil_septop_method.py
@@ -89,7 +89,6 @@ from openfe.protocols.restraint_utils.openmm.omm_restraints import (
     BoreschRestraint,
     add_force_in_separate_group,
 )
-from openfe.utils import log_system_probe
 
 from ..openmm_utils import settings_validation, system_validation
 from ..restraint_utils.settings import (

--- a/src/openfe/protocols/openmm_septop/equil_septop_method.py
+++ b/src/openfe/protocols/openmm_septop/equil_septop_method.py
@@ -2284,6 +2284,7 @@ class SepTopSolventRunUnit(SepTopSolventMixin, BaseSepTopRunUnit):
     """
     Protocol Unit for the solvent phase of an relative SepTop free energy
     """
+
     simtype = "solvent"
 
     def _get_lambda_schedule(
@@ -2318,6 +2319,7 @@ class SepTopComplexRunUnit(SepTopComplexMixin, BaseSepTopRunUnit):
     """
     Protocol Unit for the complex phase of an relative SepTop free energy
     """
+
     simtype = "complex"
 
     def _get_lambda_schedule(

--- a/src/openfe/protocols/openmm_septop/equil_septop_method.py
+++ b/src/openfe/protocols/openmm_septop/equil_septop_method.py
@@ -1432,6 +1432,8 @@ class SepTopComplexSetupUnit(SepTopComplexMixin, BaseSepTopSetupUnit):
     Protocol Unit for the complex phase of a SepTop free energy calculation
     """
 
+    simtype = "complex"
+
     def get_system_AB(
         self,
         solv_comp: SolventComponent,
@@ -2025,27 +2027,13 @@ class SepTopComplexSetupUnit(SepTopComplexMixin, BaseSepTopSetupUnit):
             "restraint_geometry_B": restraint_geom_B.model_dump(),
         }
 
-    def _execute(
-        self,
-        ctx: gufe.Context,
-        **kwargs,
-    ) -> dict[str, Any]:
-        log_system_probe(logging.INFO, paths=[ctx.scratch])
-
-        outputs = self.run(scratch_basepath=ctx.scratch, shared_basepath=ctx.shared)
-
-        return {
-            "repeat_id": self._inputs["repeat_id"],
-            "generation": self._inputs["generation"],
-            "simtype": "complex",
-            **outputs,
-        }
-
 
 class SepTopSolventSetupUnit(SepTopSolventMixin, BaseSepTopSetupUnit):
     """
     Protocol Unit for the solvent phase of a relative SepTop free energy
     """
+
+    simtype = "solvent"
 
     @staticmethod
     def _update_positions(
@@ -2292,27 +2280,12 @@ class SepTopSolventSetupUnit(SepTopSolventMixin, BaseSepTopSetupUnit):
             "standard_state_correction": corr.to("kilocalorie_per_mole"),
         }
 
-    def _execute(
-        self,
-        ctx: gufe.Context,
-        **kwargs,
-    ) -> dict[str, Any]:
-        log_system_probe(logging.INFO, paths=[ctx.scratch])
-
-        outputs = self.run(scratch_basepath=ctx.scratch, shared_basepath=ctx.shared)
-
-        return {
-            "repeat_id": self._inputs["repeat_id"],
-            "generation": self._inputs["generation"],
-            "simtype": "solvent",
-            **outputs,
-        }
-
 
 class SepTopSolventRunUnit(SepTopSolventMixin, BaseSepTopRunUnit):
     """
     Protocol Unit for the solvent phase of an relative SepTop free energy
     """
+    simtype = "solvent"
 
     def _get_lambda_schedule(
         self, settings: dict[str, SettingsBaseModel]
@@ -2341,36 +2314,12 @@ class SepTopSolventRunUnit(SepTopSolventMixin, BaseSepTopRunUnit):
 
         return lambdas
 
-    def _execute(
-        self,
-        ctx: gufe.Context,
-        *,
-        setup,
-        **kwargs,
-    ) -> dict[str, Any]:
-        log_system_probe(logging.INFO, paths=[ctx.scratch])
-
-        serialized_system = setup.outputs["system"]
-        serialized_topology = setup.outputs["topology"]
-        outputs = self.run(
-            serialized_system,
-            serialized_topology,
-            scratch_basepath=ctx.scratch,
-            shared_basepath=ctx.shared,
-        )
-
-        return {
-            "repeat_id": self._inputs["repeat_id"],
-            "generation": self._inputs["generation"],
-            "simtype": "solvent",
-            **outputs,
-        }
-
 
 class SepTopComplexRunUnit(SepTopComplexMixin, BaseSepTopRunUnit):
     """
     Protocol Unit for the complex phase of an relative SepTop free energy
     """
+    simtype = "complex"
 
     def _get_lambda_schedule(
         self, settings: dict[str, SettingsBaseModel]
@@ -2399,28 +2348,3 @@ class SepTopComplexRunUnit(SepTopComplexMixin, BaseSepTopRunUnit):
         lambdas["lambda_restraints_B"] = lambda_restraints_B
 
         return lambdas
-
-    def _execute(
-        self,
-        ctx: gufe.Context,
-        *,
-        setup,
-        **kwargs,
-    ) -> dict[str, Any]:
-        log_system_probe(logging.INFO, paths=[ctx.scratch])
-
-        serialized_system = setup.outputs["system"]
-        serialized_topology = setup.outputs["topology"]
-        outputs = self.run(
-            serialized_system,
-            serialized_topology,
-            scratch_basepath=ctx.scratch,
-            shared_basepath=ctx.shared,
-        )
-
-        return {
-            "repeat_id": self._inputs["repeat_id"],
-            "generation": self._inputs["generation"],
-            "simtype": "complex",
-            **outputs,
-        }

--- a/src/openfe/tests/protocols/openmm_septop/test_septop_protocol.py
+++ b/src/openfe/tests/protocols/openmm_septop/test_septop_protocol.py
@@ -717,10 +717,14 @@ def test_dry_run_benzene_toluene(benzene_toluene_dag, tmp_path):
     central_atoms = np.array([[2, 19]], dtype=np.int32)
     distance = md.compute_distances(pdb, central_atoms)[0][0]
     assert np.isclose(distance, 0.8661)
-    serialized_topology = solv_setup_output["topology"]
-    serialized_system = solv_setup_output["system"]
+    pdb_file = openmm.app.pdbfile.PDBFile(str(solv_setup_output["topology"]))
+    alchem_system = deserialize(solv_setup_output["system"])
     solv_sampler = sol_run_unit[0].run(
-        serialized_system, serialized_topology, dry=True,scratch_basepath=tmp_path, shared_basepath=tmp_path
+        alchem_system,
+        pdb_file,
+        dry=True,
+        scratch_basepath=tmp_path,
+        shared_basepath=tmp_path,
     )["debug"]["sampler"]  # fmt: skip
 
     assert solv_sampler.is_periodic
@@ -732,7 +736,6 @@ def test_dry_run_benzene_toluene(benzene_toluene_dag, tmp_path):
     assert pdb.n_atoms == 31
 
     # Test the solvent system
-    alchem_system = deserialize(serialized_system)
     assert len(alchem_system.getForces()) == 14
     _assert_num_forces(alchem_system, NonbondedForce, 1)
     _assert_num_forces(alchem_system, CustomNonbondedForce, 4)
@@ -750,10 +753,14 @@ def test_dry_run_benzene_toluene(benzene_toluene_dag, tmp_path):
     complex_setup_output = complex_setup_unit[0].run(
         dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path
     )
-    serialized_topology = complex_setup_output["topology"]
-    serialized_system = complex_setup_output["system"]
+    pdb_file = openmm.app.pdbfile.PDBFile(str(complex_setup_output["topology"]))
+    alchem_system = deserialize(complex_setup_output["system"])
     complex_sampler = complex_run_unit[0].run(
-        serialized_system, serialized_topology, dry=True,scratch_basepath=tmp_path, shared_basepath=tmp_path
+        alchem_system,
+        pdb_file,
+        dry=True,
+        scratch_basepath=tmp_path,
+        shared_basepath=tmp_path,
     )["debug"]["sampler"]  # fmt: skip
 
     assert complex_sampler.is_periodic
@@ -765,7 +772,6 @@ def test_dry_run_benzene_toluene(benzene_toluene_dag, tmp_path):
     assert pdb.n_atoms == 2687
 
     # Test the complex system
-    alchem_system = deserialize(serialized_system)
     assert len(alchem_system.getForces()) == 15
     _assert_num_forces(alchem_system, NonbondedForce, 1)
     _assert_num_forces(alchem_system, CustomNonbondedForce, 4)
@@ -811,10 +817,14 @@ def test_dry_run_methods(
     solv_setup_output = solv_setup_unit[0].run(
         dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path
     )
-    serialized_topology = solv_setup_output["topology"]
-    serialized_system = solv_setup_output["system"]
+    pdb_file = openmm.app.pdbfile.PDBFile(str(solv_setup_output["topology"]))
+    alchem_system = deserialize(solv_setup_output["system"])
     solv_sampler = sol_run_unit[0].run(
-        serialized_system, serialized_topology, dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path
+        alchem_system,
+        pdb_file,
+        dry=True,
+        scratch_basepath=tmp_path,
+        shared_basepath=tmp_path,
     )["debug"]["sampler"]  # fmt: skip
 
     assert isinstance(solv_sampler, MultiStateSampler)
@@ -863,10 +873,14 @@ def test_dry_run_ligand_system_pressure(
     solv_setup_output = solv_setup_unit[0].run(
         dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path
     )
-    serialized_topology = solv_setup_output["topology"]
-    serialized_system = solv_setup_output["system"]
+    pdb_file = openmm.app.pdbfile.PDBFile(str(solv_setup_output["topology"]))
+    alchem_system = deserialize(solv_setup_output["system"])
     solv_sampler = sol_run_unit[0].run(
-        serialized_system, serialized_topology, dry=True,scratch_basepath=tmp_path, shared_basepath=tmp_path
+        alchem_system,
+        pdb_file,
+        dry=True,
+        scratch_basepath=tmp_path,
+        shared_basepath=tmp_path,
     )["debug"]["sampler"]  # fmt: skip
 
     # at this point, the units will be in openmm units
@@ -987,10 +1001,15 @@ def test_dry_run_benzene_toluene_tip4p(
     solv_setup_output = solv_setup_unit[0].run(
         dry=True, scratch_basepath=tmp_path, shared_basepath=tmp_path
     )
-    serialized_topology = solv_setup_output["topology"]
-    serialized_system = solv_setup_output["system"]
+
+    pdb_file = openmm.app.pdbfile.PDBFile(str(solv_setup_output["topology"]))
+    alchem_system = deserialize(solv_setup_output["system"])
     solv_run = sol_run_unit[0].run(
-        serialized_system, serialized_topology, dry=True,scratch_basepath=tmp_path, shared_basepath=tmp_path
+        alchem_system,
+        pdb_file,
+        dry=True,
+        scratch_basepath=tmp_path,
+        shared_basepath=tmp_path,
     )["debug"]["sampler"]  # fmt: skip
 
     assert solv_run.is_periodic


### PR DESCRIPTION
Fixes #1919 

Main tasks:
  - Moved `_execute` back into the base units.
  - Move deserialization back into `_execute` rather than `run`

Checklist
* [ ] All new code is appropriately documented (user-facing code _must_ have complete docstrings).
* [ ] Added a ``news`` entry, or the changes are not user-facing.
* [ ] Ran pre-commit: you can run [pre-commit](https://pre-commit.com) locally or comment on this PR with `pre-commit.ci autofix`.

Manual Tests: these are slow so don't need to be run every commit, only before merging and when relevant changes are made (generally at reviewer-discretion). 
* [ ] [GPU integration tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/aws-gpu-integration-tests.yaml)
* [ ] [example notebook testing](https://github.com/OpenFreeEnergy/openfe/actions/workflows/release-prep-examplenotebooks.yaml)
* [ ] [packaging tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/cron-package-test.yaml): run this for any large feature PRs or PRs that add test data.


## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
