### PR TITLE
Add ahfe resume test to be integration

### DIFF
--- a/src/openfe/tests/protocols/openmm_ahfe/test_ahfe_resume.py
+++ b/src/openfe/tests/protocols/openmm_ahfe/test_ahfe_resume.py
@@ -178,6 +178,7 @@ class TestCheckpointResuming:
     def _copy_simfiles(cwd: pathlib.Path, filepath):
         shutil.copyfile(filepath, f"{cwd}/{filepath.name}")
 
+    @pytest.mark.integration
     def test_resume(
         self, protocol_dag, ahfe_solv_trajectory_path, ahfe_solv_checkpoint_path, tmp_path
     ):


### PR DESCRIPTION
The pytest mark for that test was accidentally removed at some point, we should never be running this out of GPU integration tests since it actually runs a simulation.

Checklist
* [ ] All new code is appropriately documented (user-facing code _must_ have complete docstrings).
* [ ] Added a ``news`` entry, or the changes are not user-facing.
* [ ] Ran pre-commit: you can run [pre-commit](https://pre-commit.com) locally or comment on this PR with `pre-commit.ci autofix`.

Manual Tests: these are slow so don't need to be run every commit, only before merging and when relevant changes are made (generally at reviewer-discretion). 
* [ ] [GPU integration tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/aws-gpu-integration-tests.yaml)
* [ ] [example notebook testing](https://github.com/OpenFreeEnergy/openfe/actions/workflows/release-prep-examplenotebooks.yaml)
* [ ] [packaging tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/cron-package-test.yaml): run this for any large feature PRs or PRs that add test data.


## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
