### PR TITLE
speed up cli responsiveness 

### DIFF
--- a/news/fix_cli_lag.rst
+++ b/news/fix_cli_lag.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed slow response time of CLI commands (`PR #1972 <https://github.com/OpenFreeEnergy/openfe/pull/1972>`_).
+
+**Security:**
+
+* <news item>

--- a/src/openfecli/commands/gather_abfe.py
+++ b/src/openfecli/commands/gather_abfe.py
@@ -6,7 +6,6 @@ from typing import List, Literal
 import click
 import numpy as np
 import pandas as pd
-from openff.units import unit
 
 from openfecli import OFECommandPlugin
 from openfecli.clicktypes import HyphenAwareChoice
@@ -107,6 +106,8 @@ def _get_legs_from_result_jsons(
         Data extracted from the given result JSONs, organized by the leg's ligand name and simulation type.
     """
     from collections import defaultdict
+
+    from openff.units import unit
 
     dgs = defaultdict(lambda: defaultdict(list))
 

--- a/src/openfecli/commands/gather_septop.py
+++ b/src/openfecli/commands/gather_septop.py
@@ -6,8 +6,6 @@ from typing import List, Literal
 import click
 import numpy as np
 import pandas as pd
-from cinnabar import FEMap, Measurement
-from openff.units import unit
 
 from openfecli import OFECommandPlugin
 from openfecli.clicktypes import HyphenAwareChoice
@@ -83,6 +81,8 @@ def _get_legs_from_result_jsons(
         Data extracted from the given result JSONs, organized by the leg's ligand names and simulation type.
     """
     from collections import defaultdict
+
+    from openff.units import unit
 
     ddgs = defaultdict(lambda: defaultdict(list))
 
@@ -253,6 +253,8 @@ def _generate_dg_mle(
     pd.DataFrame
         A pandas DataFrame with the dG results for each ligand pair.
     """
+    from cinnabar import FEMap, Measurement
+    from openff.units import unit
 
     DDGs = _get_ddgs(results_dict)
 

--- a/src/openfecli/commands/test.py
+++ b/src/openfecli/commands/test.py
@@ -4,11 +4,7 @@ import sys
 import click
 import pytest
 
-from openfe.data import _downloader
-from openfe.data._registry import zenodo_data_registry as api_test_data_registry
 from openfecli import OFECommandPlugin
-from openfecli.data._registry import POOCH_CACHE
-from openfecli.data._registry import zenodo_data_registry as cli_test_data_registry
 from openfecli.utils import write
 
 
@@ -34,7 +30,13 @@ def test(long, download_only):
     """
 
     if download_only:
+        from openfe.data import _downloader
+        from openfe.data._registry import zenodo_data_registry as api_test_data_registry
+        from openfecli.data._registry import POOCH_CACHE
+        from openfecli.data._registry import zenodo_data_registry as cli_test_data_registry
+
         click.echo(f"Checking for test data in cache location:\n{POOCH_CACHE}")
+
         _downloader.retrieve_registry_data(
             cli_test_data_registry + api_test_data_registry, POOCH_CACHE
         )

--- a/src/openfecli/parameters/protein.py
+++ b/src/openfecli/parameters/protein.py
@@ -6,8 +6,6 @@ from typing import Iterable
 import click
 from plugcli.params import Option
 
-from openfe import ProteinComponent, ProteinMembraneComponent
-
 _PDB_EXT = [".pdb"]
 _PDBX_EXT = [".cif", ".pdbx"]
 
@@ -16,7 +14,7 @@ def _contains_any_substring(input: str, substrings: Iterable[str]) -> bool:
     return any([substring in input for substring in substrings])
 
 
-def _load_protein_from_file(input_file, protein_class: ProteinComponent | ProteinMembraneComponent):
+def _load_protein_from_file(input_file, protein_class):
     valid_ext = _PDB_EXT + _PDBX_EXT
     info_str = (
         f"Unable to load a {protein_class.__name__} from {click.format_filename(input_file)}: "
@@ -34,10 +32,14 @@ def _load_protein_from_file(input_file, protein_class: ProteinComponent | Protei
 
 # TODO: these functions are shims to work with plugcli. We should consider migrating to just click.
 def _get_protein(user_input, context):
+    from openfe import ProteinComponent
+
     return _load_protein_from_file(user_input, ProteinComponent)
 
 
 def _get_protein_membrane(user_input, context):
+    from openfe import ProteinMembraneComponent
+
     return _load_protein_from_file(user_input, ProteinMembraneComponent)
 
 

--- a/src/openfecli/plan_alchemical_networks_utils.py
+++ b/src/openfecli/plan_alchemical_networks_utils.py
@@ -2,15 +2,15 @@
 # For details, see https://github.com/OpenFreeEnergy/openfe
 from __future__ import annotations
 
-import json
 import pathlib
 
+from openfe import AlchemicalNetwork, LigandNetwork
 from openfecli.utils import write
 
 
 def plan_alchemical_network_output(
-    alchemical_network,
-    ligand_network,
+    alchemical_network: AlchemicalNetwork,
+    ligand_network: LigandNetwork,
     folder_path: pathlib.Path,
 ):
     """Write the contents of an alchemical network into the structure"""

--- a/src/openfecli/plan_alchemical_networks_utils.py
+++ b/src/openfecli/plan_alchemical_networks_utils.py
@@ -5,13 +5,12 @@ from __future__ import annotations
 import json
 import pathlib
 
-from openfe import AlchemicalNetwork, LigandNetwork
 from openfecli.utils import write
 
 
 def plan_alchemical_network_output(
-    alchemical_network: AlchemicalNetwork,
-    ligand_network: LigandNetwork,
+    alchemical_network,
+    ligand_network,
     folder_path: pathlib.Path,
 ):
     """Write the contents of an alchemical network into the structure"""


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

as raised by @dwhswenson - calling the command line is taking ~5s as of v1.11. This PR rearranges some imports so that we're back to aroudn ~0.4 seconds.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [x] All new code is appropriately documented (user-facing code _must_ have complete docstrings).
* [x] Added a ``news`` entry, or the changes are not user-facing.
* [x] Ran pre-commit: you can run [pre-commit](https://pre-commit.com) locally or comment on this PR with `pre-commit.ci autofix`.

Manual Tests: these are slow so don't need to be run every commit, only before merging and when relevant changes are made (generally at reviewer-discretion). 
* [ ] [GPU integration tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/aws-gpu-integration-tests.yaml)
* [ ] [example notebook testing](https://github.com/OpenFreeEnergy/openfe/actions/workflows/release-prep-examplenotebooks.yaml)
* [ ] [packaging tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/cron-package-test.yaml): run this for any large feature PRs or PRs that add test data.


## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
