### PR TITLE
Support for charge changes in the HybTop protocol for explicitly solvated systems

### DIFF
--- a/news/membrane_charge_change.rst
+++ b/news/membrane_charge_change.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Improved alchemical charge correction to support explicitly solvated systems
+(:class:`SolvatedPDBComponent`) by determining ion parameters from the forcefield if not present in the topology. PR #1978
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/openfe/protocols/openmm_rfe/_rfe_utils/topologyhelpers.py
+++ b/src/openfe/protocols/openmm_rfe/_rfe_utils/topologyhelpers.py
@@ -166,7 +166,7 @@ def _get_ion_parameters(
             continue
         charge, _, _ = nbf.getParticleParameters(atom.index)
         charge_val = charge.value_in_unit(omm_unit.elementary_charge)
-        if (abs(abs(charge_val) - 1.0) < 0.01 and np.sign(charge_val) == desired_sign):
+        if np.isclose(abs(charge_val), 1.0, atol=0.01) and np.sign(charge_val) == desired_sign:
             ion_counts[residue.name] += 1
             if residue.name not in ion_atom_indices:
                 ion_atom_indices[residue.name] = atom.index

--- a/src/openfe/protocols/openmm_rfe/_rfe_utils/topologyhelpers.py
+++ b/src/openfe/protocols/openmm_rfe/_rfe_utils/topologyhelpers.py
@@ -62,90 +62,55 @@ def _get_ion_parameters_from_forcefield(
 
     return nbf.getParticleParameters(0)
 
-
-def _get_ion_and_water_parameters(
+def _get_water_parameters(
     topology: app.Topology,
     system: System,
-    forcefield: app.ForceField,
-    charge_difference: int,
     water_resname: str = 'HOH',
 ) -> tuple:
     """
-    Get ion NonbondedForce parameters and water charges.
-
-    Scans the topology for the most abundant monovalent ion of the appropriate
-    charge sign, identified by single-atom residues with a partial charge
-    close to +/- 1.
-    If no matching ion is found, falls back to NA or CL.
+    Get water oxygen and hydrogen partial charges from the system.
 
     Parameters
     ----------
     topology : app.Topology
-        The topology to search.
-    system : openmm.System
-        The system associated with the topology.
-    forcefield : app.ForceField
-        Used as a fallback to obtain ion parameters when no matching ion is
-        present in the topology.
-    charge_difference : int
-        Charge difference between state A and state B, used to determine the
-        required ion charge sign.
+      The topology to search for water atoms.
+    system : app.System
+      The system associated with the input topology object.
     water_resname : str
-        Residue name of water. Default 'HOH'.
+      The residue name of the water. Default 'HOH'.
 
     Returns
     -------
-    ion_charge, ion_sigma, ion_epsilon : openmm.unit.Quantity
-        NonbondedForce parameters for the ion.
-    o_charge, h_charge : openmm.unit.Quantity
-        Partial charges of the water oxygen and hydrogen.
+    o_charge : openmm.unit.Quantity
+      The partial charge of the water oxygen.
+    h_charge : openmm.unit.Quantity
+      The partial charge of the water hydrogen.
+
+    Raises
+    ------
+    ValueError
+      If no water residue named ``water_resname`` with O and H atoms
+      is found in the topology.
     """
     nbf = [i for i in system.getForces() if isinstance(i, NonbondedForce)][0]
-
-    desired_sign = np.sign(charge_difference)
-
-    ion_counts = Counter()
-    ion_atom_indices = {}
 
     o_charge = None
     h_charge = None
 
     for residue in topology.residues():
-        atoms = list(residue.atoms())
-
-        # water parameters
-        if o_charge is None and residue.name == water_resname:
-            for atom in atoms:
-                charge, _, _ = nbf.getParticleParameters(atom.index)
-                if atom.element.symbol == 'O':
-                    o_charge = charge
-                elif atom.element.symbol == 'H':
-                    h_charge = charge
+        if residue.name != water_resname:
             continue
-
-        # ion candidates
-        if len(atoms) != 1:
-            continue
-
-        atom = atoms[0]
-        if atom.element is None:
-            continue
-
-        charge, _, _ = nbf.getParticleParameters(atom.index)
-        charge_val = charge.value_in_unit(omm_unit.elementary_charge)
-
-        # Only monovalent ions for now
-        if not np.isclose(abs(charge_val), 1.0, atol=0.2):
-            continue
-
-        if np.sign(charge_val) != desired_sign:
-            continue
-
-        ion_counts[residue.name] += 1
-        ion_atom_indices.setdefault(
-            residue.name,
-            atom.index,
-        )
+        for atom in residue.atoms():
+            if atom.element is None:
+                continue
+            charge, _, _ = nbf.getParticleParameters(atom.index)
+            if atom.element.symbol == 'O':
+                o_charge = charge
+            elif atom.element.symbol == 'H':
+                h_charge = charge
+        # Stop as soon as we have both charges
+        if o_charge is not None and h_charge is not None:
+            break
 
     if o_charge is None or h_charge is None:
         raise ValueError(
@@ -154,36 +119,82 @@ def _get_ion_and_water_parameters(
             "alchemical charge correction."
         )
 
+    return o_charge, h_charge
+
+def _get_ion_parameters(
+    topology: app.Topology,
+    system: System,
+    charge_difference: int,
+    forcefield: app.ForceField,
+) -> tuple:
+    """
+    Get NonbondedForce parameters for the most abundant monovalent ion of
+    the appropriate charge sign found in the topology. Falls back to
+    'NA' or 'CL' parameters if no ion is found in the topology.
+
+    Parameters
+    ----------
+    topology : app.Topology
+      The topology to search for the most abundant ion type.
+    system : app.System
+      The system associated with the input topology object.
+    charge_difference : int
+      The charge difference between state A and state B. Determines
+      whether to look for a positive or negative ion.
+    forcefield : app.ForceField
+      The force field to use for parameterization if no ion is found
+      in the topology.
+
+    Returns
+    -------
+    ion_charge : openmm.unit.Quantity
+    ion_sigma : openmm.unit.Quantity
+    ion_epsilon : openmm.unit.Quantity
+    """
+    nbf = [i for i in system.getForces() if isinstance(i, NonbondedForce)][0]
+
+    desired_sign = np.sign(charge_difference)
+    ion_counts: Counter = Counter()
+    ion_atom_indices: dict[str, int] = {}
+
+    for residue in topology.residues():
+        atoms = list(residue.atoms())
+        if len(atoms) != 1:
+            continue
+        atom = atoms[0]
+        if atom.element is None:
+            continue
+        charge, _, _ = nbf.getParticleParameters(atom.index)
+        charge_val = charge.value_in_unit(omm_unit.elementary_charge)
+        if (abs(abs(charge_val) - 1.0) < 0.01 and np.sign(charge_val) == desired_sign):
+            ion_counts[residue.name] += 1
+            if residue.name not in ion_atom_indices:
+                ion_atom_indices[residue.name] = atom.index
+
     if ion_counts:
         # Use the most abundant matching ion found in the topology
         best_resname = ion_counts.most_common(1)[0][0]
-        ion_atom_index = ion_atom_indices[best_resname]
-        ion_charge, ion_sigma, ion_epsilon = nbf.getParticleParameters(
-            ion_atom_index
-        )
+        return nbf.getParticleParameters(ion_atom_indices[best_resname])
+
+    # No matching ion in topology: fall back to NA/CL from forcefield
+    if charge_difference > 0:
+        fallback_resname = 'NA'
+        fallback_element = app.Element.getByAtomicNumber(11)  # Na
     else:
-        # No matching ion in topology — fall back to NA/CL from forcefield
-        if charge_difference > 0:
-            fallback_resname = 'NA'
-            fallback_element = app.Element.getByAtomicNumber(11)  # Na
-        else:
-            fallback_resname = 'CL'
-            fallback_element = app.Element.getByAtomicNumber(17)  # Cl
+        fallback_resname = 'CL'
+        fallback_element = app.Element.getByAtomicNumber(17)  # Cl
 
-        wmsg = (
-            f"No monovalent ion with the appropriate charge sign found in "
-            f"the topology. Defaulting to '{fallback_resname}' and obtaining "
-            f"parameters from the forcefield directly."
-        )
-        warnings.warn(wmsg)
-        logger.warning(wmsg)
+    wmsg = (
+        f"No monovalent ion with the appropriate charge sign found in "
+        f"the topology. Defaulting to '{fallback_resname}' and obtaining "
+        f"parameters from the forcefield directly."
+    )
+    warnings.warn(wmsg)
+    logger.warning(wmsg)
 
-        ion_charge, ion_sigma, ion_epsilon = _get_ion_parameters_from_forcefield(
-            forcefield, fallback_resname, fallback_element
-        )
-
-    return ion_charge, ion_sigma, ion_epsilon, o_charge, h_charge
-
+    return _get_ion_parameters_from_forcefield(
+        forcefield, fallback_resname, fallback_element,
+    )
 
 def _fix_alchemical_water_atom_mapping(
     system_mapping: dict[str, Union[dict[int, int], list[int]]],
@@ -265,9 +276,10 @@ def handle_alchemical_waters(
     if charge_difference == 0:
         return None
 
-    ion_charge, ion_sigma, ion_epsilon, o_charge, h_charge = _get_ion_and_water_parameters(
-        topology, system, forcefield, charge_difference, water_resname='HOH',
+    ion_charge, ion_sigma, ion_epsilon = _get_ion_parameters(
+        topology, system, charge_difference, forcefield,
     )
+    o_charge, h_charge = _get_water_parameters(topology, system, water_resname)
 
     # get the nonbonded forces
     nbfrcs = [i for i in system.getForces()

--- a/src/openfe/protocols/openmm_rfe/_rfe_utils/topologyhelpers.py
+++ b/src/openfe/protocols/openmm_rfe/_rfe_utils/topologyhelpers.py
@@ -22,74 +22,165 @@ from openff.units import Quantity, unit
 from openmm import NonbondedForce, System, app
 from openmm import unit as omm_unit
 
-from openfe import SolventComponent
-
 logger = logging.getLogger(__name__)
+
+
+def _get_ion_parameters_from_forcefield(
+    forcefield: app.ForceField,
+    ion_resname: str,
+    ion_element: app.Element,
+) -> tuple:
+    """
+    Get NonbondedForce parameters for a bare monovalent ion by creating a
+    minimal single-ion system via the ForceField. Used as a fallback when
+    no ion of the required type is present in the topology.
+
+    Parameters
+    ----------
+    forcefield : app.ForceField
+        The ForceField to use to parameterize the ion.
+    ion_resname : str
+        The residue name of the ion to parameterize (e.g. 'NA', 'CL').
+    ion_element : app.Element
+        The element of the ion.
+
+    Returns
+    -------
+    ion_charge : openmm.unit.Quantity
+        The partial charge of the ion.
+    ion_sigma : openmm.unit.Quantity
+        The NonbondedForce sigma parameter of the ion.
+    ion_epsilon : openmm.unit.Quantity
+        The NonbondedForce epsilon parameter of the ion.
+    """
+    dummy_top = app.Topology()
+    res = dummy_top.addResidue(ion_resname, dummy_top.addChain())
+    dummy_top.addAtom(ion_resname, ion_element, res)
+    dummy_system = forcefield.createSystem(dummy_top)
+
+    nbf = [i for i in dummy_system.getForces() if isinstance(i, NonbondedForce)][0]
+
+    return nbf.getParticleParameters(0)
 
 
 def _get_ion_and_water_parameters(
     topology: app.Topology,
     system: System,
-    ion_resname: str,
+    forcefield: app.ForceField,
+    charge_difference: int,
     water_resname: str = 'HOH',
-):
+) -> tuple:
     """
-    Get ion, and water (oxygen and hydrogen) atoms parameters.
+    Get ion NonbondedForce parameters and water charges.
+
+    Scans the topology for the most abundant monovalent ion of the appropriate
+    charge sign, identified by single-atom residues with a partial charge
+    close to +/- 1.
+    If no matching ion is found, falls back to NA or CL.
 
     Parameters
     ----------
     topology : app.Topology
-      The topology to search for the ion and water
-    system : app.System
-      The system associated with the input topology object.
-    ion_resname : str
-      The residue name of the ion to get parameters for
+        The topology to search.
+    system : openmm.System
+        The system associated with the topology.
+    forcefield : app.ForceField
+        Used as a fallback to obtain ion parameters when no matching ion is
+        present in the topology.
+    charge_difference : int
+        Charge difference between state A and state B, used to determine the
+        required ion charge sign.
     water_resname : str
-      The residue name of the water to get parameters for. Default 'HOH'.
+        Residue name of water. Default 'HOH'.
 
     Returns
     -------
-    ion_charge : float
-      The partial charge of the ion atom
-    ion_sigma : float
-      The NonbondedForce sigma parameter of the ion atom
-    ion_epsilon : float
-      The NonbondedForce epsilon parameter of the ion atom
-    o_charge : float
-      The partial charge of the water oxygen.
-    h_charge : float
-      The partial charge of the water hydrogen.
-
-    Raises
-    ------
-    ValueError
-      If there are no ``ion_resname`` or ``water_resname`` named residues in
-      the input ``topology``.
-
-    Attribution
-    -----------
-    Based on `perses.utils.charge_changing.get_ion_and_water_parameters`.
+    ion_charge, ion_sigma, ion_epsilon : openmm.unit.Quantity
+        NonbondedForce parameters for the ion.
+    o_charge, h_charge : openmm.unit.Quantity
+        Partial charges of the water oxygen and hydrogen.
     """
-    def _find_atom(topology, resname, elementname):
-        for atom in topology.atoms():
-            if atom.residue.name == resname:
-                if (elementname is None or atom.element.symbol == elementname):
-                    return atom.index
-        errmsg = ("Error encountered when attempting to explicitly handle "
-                  "charge changes using an alchemical water. No residue "
-                  f"named: {resname} found, with element {elementname}")
-        raise ValueError(errmsg)
+    nbf = [i for i in system.getForces() if isinstance(i, NonbondedForce)][0]
 
-    ion_index = _find_atom(topology, ion_resname, None)
-    oxygen_index = _find_atom(topology, water_resname, 'O')
-    hydrogen_index = _find_atom(topology, water_resname, 'H')
+    desired_sign = np.sign(charge_difference)
 
-    nbf = [i for i in system.getForces()
-           if isinstance(i, NonbondedForce)][0]
+    ion_counts = Counter()
+    ion_atom_indices = {}
 
-    ion_charge, ion_sigma, ion_epsilon = nbf.getParticleParameters(ion_index)
-    o_charge, _, _ = nbf.getParticleParameters(oxygen_index)
-    h_charge, _, _ = nbf.getParticleParameters(hydrogen_index)
+    o_charge = None
+    h_charge = None
+
+    for residue in topology.residues():
+        atoms = list(residue.atoms())
+
+        # water parameters
+        if o_charge is None and residue.name == water_resname:
+            for atom in atoms:
+                charge, _, _ = nbf.getParticleParameters(atom.index)
+                if atom.element.symbol == 'O':
+                    o_charge = charge
+                elif atom.element.symbol == 'H':
+                    h_charge = charge
+            continue
+
+        # ion candidates
+        if len(atoms) != 1:
+            continue
+
+        atom = atoms[0]
+        if atom.element is None:
+            continue
+
+        charge, _, _ = nbf.getParticleParameters(atom.index)
+        charge_val = charge.value_in_unit(omm_unit.elementary_charge)
+
+        # Only monovalent ions for now
+        if not np.isclose(abs(charge_val), 1.0, atol=0.2):
+            continue
+
+        if np.sign(charge_val) != desired_sign:
+            continue
+
+        ion_counts[residue.name] += 1
+        ion_atom_indices.setdefault(
+            residue.name,
+            atom.index,
+        )
+
+    if o_charge is None or h_charge is None:
+        raise ValueError(
+            f"Could not find water residue '{water_resname}' with O and H "
+            "atoms in the topology. Water parameters are required for "
+            "alchemical charge correction."
+        )
+
+    if ion_counts:
+        # Use the most abundant matching ion found in the topology
+        best_resname = ion_counts.most_common(1)[0][0]
+        ion_atom_index = ion_atom_indices[best_resname]
+        ion_charge, ion_sigma, ion_epsilon = nbf.getParticleParameters(
+            ion_atom_index
+        )
+    else:
+        # No matching ion in topology — fall back to NA/CL from forcefield
+        if charge_difference > 0:
+            fallback_resname = 'NA'
+            fallback_element = app.Element.getByAtomicNumber(11)  # Na
+        else:
+            fallback_resname = 'CL'
+            fallback_element = app.Element.getByAtomicNumber(17)  # Cl
+
+        wmsg = (
+            f"No monovalent ion with the appropriate charge sign found in "
+            f"the topology. Defaulting to '{fallback_resname}' and obtaining "
+            f"parameters from the forcefield directly."
+        )
+        warnings.warn(wmsg)
+        logger.warning(wmsg)
+
+        ion_charge, ion_sigma, ion_epsilon = _get_ion_parameters_from_forcefield(
+            forcefield, fallback_resname, fallback_element
+        )
 
     return ion_charge, ion_sigma, ion_epsilon, o_charge, h_charge
 
@@ -129,8 +220,7 @@ def handle_alchemical_waters(
     system: System,
     system_mapping: dict,
     charge_difference: int,
-    positive_ion_resname: str,
-    negative_ion_resname: str,
+    forcefield: app.ForceField,
     water_resname: str,
 ):
     """
@@ -148,12 +238,8 @@ def handle_alchemical_waters(
       A dictionary of system mappings between the stateA and stateB systems
     charge_difference : int
       The charge difference between state A and state B.
-    positive_ion_resname : str
-      The name of a positive ion to replace the water with if the absolute
-      charge difference is positive.
-    negative_ion_resname : str
-      The name of a negative ion to replace the water with if the absolute
-      charge difference is negative.
+    forcefield : app.ForceField
+      The forcefield to use for ion parameterization.
     water_resname : str
       The residue name of the water to get parameters for.
 
@@ -176,17 +262,11 @@ def handle_alchemical_waters(
                   f"difference: {abs(charge_difference)}")
         raise ValueError(errmsg)
 
-    if charge_difference > 0:
-        ion_resname = positive_ion_resname
-    elif charge_difference < 0:
-        ion_resname = negative_ion_resname
-    # if there's no charge difference then just skip altogether
-    else:
+    if charge_difference == 0:
         return None
 
     ion_charge, ion_sigma, ion_epsilon, o_charge, h_charge = _get_ion_and_water_parameters(
-        topology, system, ion_resname,
-        water_resname,
+        topology, system, forcefield, charge_difference, water_resname='HOH',
     )
 
     # get the nonbonded forces
@@ -724,60 +804,3 @@ def set_and_check_new_positions(mapping, old_topology, new_topology,
             logging.warning(wmsg)
 
     return new_pos_array * omm_unit.angstrom
-
-
-def _get_ion_resnames_from_topology(topology: app.Topology) -> tuple[str, str]:
-    """
-    Infer positive and negative ion residue names from a topology by
-    finding the most common monovalent ion of each charge type.
-    Falls back to NA/CL if none are found.
-
-    Parameters
-    ----------
-    topology : app.Topology
-        The topology to search for ions.
-
-    Returns
-    -------
-    pos_ion : str
-        The residue name of the most abundant positive monovalent ion (Na, K).
-    neg_ion : str
-        The residue name of the most abundant negative monovalent ion (Cl).
-    """
-    known_positive = {'NA', 'K'}
-    # This doesn't make much sense yet to check it, since it's only Cl, but
-    # leaving it here for now so we can add other neg ions.
-    known_negative = {'CL'}
-
-    pos_counts = Counter(
-        r.name for r in topology.residues() if r.name in known_positive
-    )
-    neg_counts = Counter(
-        r.name for r in topology.residues() if r.name in known_negative
-    )
-
-    if not pos_counts:
-        wmsg = (
-            "Could not find any known positive monovalent ions "
-            f"(searched for {known_positive}) in the topology. "
-            "Defaulting to NA for explicit charge correction."
-        )
-        warnings.warn(wmsg)
-        logger.warning(wmsg)
-        pos_ion = 'NA'
-    else:
-        pos_ion = max(pos_counts, key=pos_counts.get)
-
-    if not neg_counts:
-        wmsg = (
-            "Could not find any known negative monovalent ions "
-            f"(searched for {known_negative}) in the topology. "
-            "Defaulting to CL for explicit charge correction."
-        )
-        warnings.warn(wmsg)
-        logger.warning(wmsg)
-        neg_ion = 'CL'
-    else:
-        neg_ion = max(neg_counts, key=neg_counts.get)
-
-    return pos_ion, neg_ion

--- a/src/openfe/protocols/openmm_rfe/_rfe_utils/topologyhelpers.py
+++ b/src/openfe/protocols/openmm_rfe/_rfe_utils/topologyhelpers.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 def _get_ff_parameters(
     forcefield: app.ForceField,
     smiles: str,
-) -> dict[str, tuple]:
+) -> dict[str, tuple[float, float, float]]:
     """
     Get NonbondedForce parameters for all atoms in a molecule by creating
     a minimal dummy system from a SMILES string with the given forcefield.

--- a/src/openfe/protocols/openmm_rfe/_rfe_utils/topologyhelpers.py
+++ b/src/openfe/protocols/openmm_rfe/_rfe_utils/topologyhelpers.py
@@ -10,6 +10,7 @@
 import itertools
 import logging
 import warnings
+from collections import Counter
 from copy import deepcopy
 from typing import Optional, Union
 
@@ -123,10 +124,14 @@ def _fix_alchemical_water_atom_mapping(
 
 
 def handle_alchemical_waters(
-    water_resids: list[int], topology: app.Topology,
-    system: System, system_mapping: dict,
+    water_resids: list[int],
+    topology: app.Topology,
+    system: System,
+    system_mapping: dict,
     charge_difference: int,
-    solvent_component: SolventComponent,
+    positive_ion_resname: str,
+    negative_ion_resname: str,
+    water_resname: str,
 ):
     """
     Add alchemical waters from a pre-defined list.
@@ -150,7 +155,7 @@ def handle_alchemical_waters(
       The name of a negative ion to replace the water with if the absolute
       charge difference is negative.
     water_resname : str
-      The residue name of the water to get parameters for. Default 'HOH'.
+      The residue name of the water to get parameters for.
 
     Raises
     ------
@@ -172,16 +177,16 @@ def handle_alchemical_waters(
         raise ValueError(errmsg)
 
     if charge_difference > 0:
-        ion_resname = solvent_component.positive_ion.strip('-+').upper()
+        ion_resname = positive_ion_resname
     elif charge_difference < 0:
-        ion_resname = solvent_component.negative_ion.strip('-+').upper()
+        ion_resname = negative_ion_resname
     # if there's no charge difference then just skip altogether
     else:
         return None
 
     ion_charge, ion_sigma, ion_epsilon, o_charge, h_charge = _get_ion_and_water_parameters(
         topology, system, ion_resname,
-        'HOH',  # Modeller always adds HOH waters
+        water_resname,
     )
 
     # get the nonbonded forces
@@ -433,7 +438,6 @@ def _remove_constraints(old_to_new_atom_map, old_system, old_topology,
     * Very slow, needs refactoring
     * Can we drop having topologies as inputs here?
     """
-    from collections import Counter
 
     no_const_old_to_new_atom_map = deepcopy(old_to_new_atom_map)
 
@@ -720,3 +724,60 @@ def set_and_check_new_positions(mapping, old_topology, new_topology,
             logging.warning(wmsg)
 
     return new_pos_array * omm_unit.angstrom
+
+
+def _get_ion_resnames_from_topology(topology: app.Topology) -> tuple[str, str]:
+    """
+    Infer positive and negative ion residue names from a topology by
+    finding the most common monovalent ion of each charge type.
+    Falls back to NA/CL if none are found.
+
+    Parameters
+    ----------
+    topology : app.Topology
+        The topology to search for ions.
+
+    Returns
+    -------
+    pos_ion : str
+        The residue name of the most abundant positive monovalent ion (Na, K).
+    neg_ion : str
+        The residue name of the most abundant negative monovalent ion (Cl).
+    """
+    known_positive = {'NA', 'K'}
+    # This doesn't make much sense yet to check it, since it's only Cl, but
+    # leaving it here for now so we can add other neg ions.
+    known_negative = {'CL'}
+
+    pos_counts = Counter(
+        r.name for r in topology.residues() if r.name in known_positive
+    )
+    neg_counts = Counter(
+        r.name for r in topology.residues() if r.name in known_negative
+    )
+
+    if not pos_counts:
+        wmsg = (
+            "Could not find any known positive monovalent ions "
+            f"(searched for {known_positive}) in the topology. "
+            "Defaulting to NA for explicit charge correction."
+        )
+        warnings.warn(wmsg)
+        logger.warning(wmsg)
+        pos_ion = 'NA'
+    else:
+        pos_ion = max(pos_counts, key=pos_counts.get)
+
+    if not neg_counts:
+        wmsg = (
+            "Could not find any known negative monovalent ions "
+            f"(searched for {known_negative}) in the topology. "
+            "Defaulting to CL for explicit charge correction."
+        )
+        warnings.warn(wmsg)
+        logger.warning(wmsg)
+        neg_ion = 'CL'
+    else:
+        neg_ion = max(neg_counts, key=neg_counts.get)
+
+    return pos_ion, neg_ion

--- a/src/openfe/protocols/openmm_rfe/_rfe_utils/topologyhelpers.py
+++ b/src/openfe/protocols/openmm_rfe/_rfe_utils/topologyhelpers.py
@@ -77,17 +77,22 @@ def _get_ion_parameters(
     system : app.System
       The system associated with the input topology object.
     charge_difference : int
-      The charge difference between state A and state B. Determines
-      whether to look for a positive or negative ion.
+      The charge difference between state A and state B,
+      calculated as stateA_formal_charge - stateB_formal_charge.
+      Positive values indicate a positive ion is needed,
+      negative values a negative ion.
     forcefield : app.ForceField
       The force field to use for parameterization if no ion is found
       in the topology.
 
     Returns
     -------
-    ion_charge : openmm.unit.Quantity
-    ion_sigma : openmm.unit.Quantity
-    ion_epsilon : openmm.unit.Quantity
+    ion_charge : float
+      The partial charge of the ion atom
+    ion_sigma : float
+      The NonbondedForce sigma parameter of the ion atom
+    ion_epsilon : float
+      The NonbondedForce epsilon parameter of the ion atom
     """
     nbf = [i for i in system.getForces() if isinstance(i, NonbondedForce)][0]
 
@@ -182,7 +187,10 @@ def handle_alchemical_waters(
     system_mapping : dictionary
       A dictionary of system mappings between the stateA and stateB systems
     charge_difference : int
-      The charge difference between state A and state B.
+      The charge difference between state A and state B,
+      calculated as stateA_formal_charge - stateB_formal_charge.
+      Positive values indicate a positive ion is needed,
+      negative values a negative ion.
     forcefield : app.ForceField
       The forcefield to use for ion parameterization.
 

--- a/src/openfe/protocols/openmm_rfe/_rfe_utils/topologyhelpers.py
+++ b/src/openfe/protocols/openmm_rfe/_rfe_utils/topologyhelpers.py
@@ -25,101 +25,36 @@ from openmm import unit as omm_unit
 logger = logging.getLogger(__name__)
 
 
-def _get_ion_parameters_from_forcefield(
+def _get_ff_parameters(
     forcefield: app.ForceField,
-    ion_resname: str,
-    ion_element: app.Element,
-) -> tuple:
+    smiles: str,
+) -> list[tuple]:
     """
-    Get NonbondedForce parameters for a bare monovalent ion by creating a
-    minimal single-ion system via the ForceField. Used as a fallback when
-    no ion of the required type is present in the topology.
+    Get NonbondedForce parameters for all atoms in a molecule by creating
+    a minimal dummy system from a SMILES string with the given forcefield.
 
     Parameters
     ----------
     forcefield : app.ForceField
-        The ForceField to use to parameterize the ion.
-    ion_resname : str
-        The residue name of the ion to parameterize (e.g. 'NA', 'CL').
-    ion_element : app.Element
-        The element of the ion.
+      The force field to use for parameterisation.
+    smiles : str
+      The SMILES string of the molecule to parameterise
+      (e.g. '[Na+]', '[Cl-]', 'O').
 
     Returns
     -------
-    ion_charge : openmm.unit.Quantity
-        The partial charge of the ion.
-    ion_sigma : openmm.unit.Quantity
-        The NonbondedForce sigma parameter of the ion.
-    ion_epsilon : openmm.unit.Quantity
-        The NonbondedForce epsilon parameter of the ion.
+    list[tuple]
+      A list of (charge, sigma, epsilon) tuples for each atom in the
+      molecule, in the same order as the SMILES.
     """
-    dummy_top = app.Topology()
-    res = dummy_top.addResidue(ion_resname, dummy_top.addChain())
-    dummy_top.addAtom(ion_resname, ion_element, res)
+    from openff.toolkit import Molecule
+
+    offmol = Molecule.from_smiles(smiles)
+    dummy_top = offmol.to_topology().to_openmm()
     dummy_system = forcefield.createSystem(dummy_top)
+    nbf = [f for f in dummy_system.getForces() if isinstance(f, NonbondedForce)][0]
 
-    nbf = [i for i in dummy_system.getForces() if isinstance(i, NonbondedForce)][0]
-
-    return nbf.getParticleParameters(0)
-
-def _get_water_parameters(
-    topology: app.Topology,
-    system: System,
-    water_resname: str = 'HOH',
-) -> tuple:
-    """
-    Get water oxygen and hydrogen partial charges from the system.
-
-    Parameters
-    ----------
-    topology : app.Topology
-      The topology to search for water atoms.
-    system : app.System
-      The system associated with the input topology object.
-    water_resname : str
-      The residue name of the water. Default 'HOH'.
-
-    Returns
-    -------
-    o_charge : openmm.unit.Quantity
-      The partial charge of the water oxygen.
-    h_charge : openmm.unit.Quantity
-      The partial charge of the water hydrogen.
-
-    Raises
-    ------
-    ValueError
-      If no water residue named ``water_resname`` with O and H atoms
-      is found in the topology.
-    """
-    nbf = [i for i in system.getForces() if isinstance(i, NonbondedForce)][0]
-
-    o_charge = None
-    h_charge = None
-
-    for residue in topology.residues():
-        if residue.name != water_resname:
-            continue
-        for atom in residue.atoms():
-            if atom.element is None:
-                continue
-            charge, _, _ = nbf.getParticleParameters(atom.index)
-            if atom.element.symbol == 'O':
-                o_charge = charge
-            elif atom.element.symbol == 'H':
-                h_charge = charge
-        # Stop as soon as we have both charges
-        if o_charge is not None and h_charge is not None:
-            break
-
-    if o_charge is None or h_charge is None:
-        raise ValueError(
-            f"Could not find water residue '{water_resname}' with O and H "
-            "atoms in the topology. Water parameters are required for "
-            "alchemical charge correction."
-        )
-
-    return o_charge, h_charge
+    return [nbf.getParticleParameters(i) for i in range(dummy_top.getNumAtoms())]
 
 def _get_ion_parameters(
     topology: app.Topology,
@@ -178,23 +113,19 @@ def _get_ion_parameters(
 
     # No matching ion in topology: fall back to NA/CL from forcefield
     if charge_difference > 0:
-        fallback_resname = 'NA'
-        fallback_element = app.Element.getByAtomicNumber(11)  # Na
+        fallback_smiles = '[Na+]'
     else:
-        fallback_resname = 'CL'
-        fallback_element = app.Element.getByAtomicNumber(17)  # Cl
+        fallback_smiles = '[Cl-]'
 
     wmsg = (
         f"No monovalent ion with the appropriate charge sign found in "
-        f"the topology. Defaulting to '{fallback_resname}' and obtaining "
+        f"the topology. Defaulting to '{fallback_smiles}' and obtaining "
         f"parameters from the forcefield directly."
     )
     warnings.warn(wmsg)
     logger.warning(wmsg)
 
-    return _get_ion_parameters_from_forcefield(
-        forcefield, fallback_resname, fallback_element,
-    )
+    return _get_ff_parameters(forcefield, fallback_smiles)[0]
 
 def _fix_alchemical_water_atom_mapping(
     system_mapping: dict[str, Union[dict[int, int], list[int]]],
@@ -232,7 +163,6 @@ def handle_alchemical_waters(
     system_mapping: dict,
     charge_difference: int,
     forcefield: app.ForceField,
-    water_resname: str,
 ):
     """
     Add alchemical waters from a pre-defined list.
@@ -251,8 +181,6 @@ def handle_alchemical_waters(
       The charge difference between state A and state B.
     forcefield : app.ForceField
       The forcefield to use for ion parameterization.
-    water_resname : str
-      The residue name of the water to get parameters for.
 
     Raises
     ------
@@ -276,11 +204,6 @@ def handle_alchemical_waters(
     if charge_difference == 0:
         return None
 
-    ion_charge, ion_sigma, ion_epsilon = _get_ion_parameters(
-        topology, system, charge_difference, forcefield,
-    )
-    o_charge, h_charge = _get_water_parameters(topology, system, water_resname)
-
     # get the nonbonded forces
     nbfrcs = [i for i in system.getForces()
               if isinstance(i, NonbondedForce)]
@@ -290,8 +213,7 @@ def handle_alchemical_waters(
     # for convenience just grab the first & only entry
     nbf = nbfrcs[0]
 
-    # Loop through residues, check if they match the residue index
-    # mutate the atom as necessary
+    # Check for virtual site waters
     for res in topology.residues():
         if res.index in water_resids:
             # if the number of atoms > 3, then we have virtual sites which are
@@ -301,6 +223,18 @@ def handle_alchemical_waters(
                           "are not currently supported as alchemical waters")
                 raise ValueError(errmsg)
 
+    ion_charge, ion_sigma, ion_epsilon = _get_ion_parameters(
+        topology, system, charge_difference, forcefield,
+    )
+    # Get water parameters (O is index 0, H is index 1 and 2)
+    water_params = _get_ff_parameters(forcefield, '[H]O[H]')
+    o_charge, _, _ = water_params[0]
+    h_charge, _, _ = water_params[1]
+
+    # Loop through residues, check if they match the residue index
+    # mutate the atom as necessary
+    for res in topology.residues():
+        if res.index in water_resids:
             for at in res.atoms():
                 idx = at.index
                 charge, sigma, epsilon = nbf.getParticleParameters(idx)

--- a/src/openfe/protocols/openmm_rfe/_rfe_utils/topologyhelpers.py
+++ b/src/openfe/protocols/openmm_rfe/_rfe_utils/topologyhelpers.py
@@ -64,6 +64,7 @@ def _get_ff_parameters(
         for atom in dummy_top.atoms()
     }
 
+
 def _get_ion_parameters(
     topology: app.Topology,
     system: System,

--- a/src/openfe/protocols/openmm_rfe/_rfe_utils/topologyhelpers.py
+++ b/src/openfe/protocols/openmm_rfe/_rfe_utils/topologyhelpers.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 def _get_ff_parameters(
     forcefield: app.ForceField,
     smiles: str,
-) -> list[tuple]:
+) -> dict[str, tuple]:
     """
     Get NonbondedForce parameters for all atoms in a molecule by creating
     a minimal dummy system from a SMILES string with the given forcefield.
@@ -43,9 +43,9 @@ def _get_ff_parameters(
 
     Returns
     -------
-    list[tuple]
-      A list of (charge, sigma, epsilon) tuples for each atom in the
-      molecule, in the same order as the SMILES.
+    dict[str, tuple]
+      A dictionary keyed by element symbol, with (charge, sigma, epsilon)
+      tuples as values.
     """
     from openff.toolkit import Molecule
 
@@ -54,7 +54,10 @@ def _get_ff_parameters(
     dummy_system = forcefield.createSystem(dummy_top)
     nbf = [f for f in dummy_system.getForces() if isinstance(f, NonbondedForce)][0]
 
-    return [nbf.getParticleParameters(i) for i in range(dummy_top.getNumAtoms())]
+    return {
+        atom.element.symbol: nbf.getParticleParameters(atom.index)
+        for atom in dummy_top.atoms()
+    }
 
 def _get_ion_parameters(
     topology: app.Topology,
@@ -125,7 +128,8 @@ def _get_ion_parameters(
     warnings.warn(wmsg)
     logger.warning(wmsg)
 
-    return _get_ff_parameters(forcefield, fallback_smiles)[0]
+    ion_params = _get_ff_parameters(forcefield, fallback_smiles)
+    return next(iter(ion_params.values()))
 
 def _fix_alchemical_water_atom_mapping(
     system_mapping: dict[str, Union[dict[int, int], list[int]]],
@@ -226,10 +230,10 @@ def handle_alchemical_waters(
     ion_charge, ion_sigma, ion_epsilon = _get_ion_parameters(
         topology, system, charge_difference, forcefield,
     )
-    # Get water parameters (O is index 0, H is index 1 and 2)
+    # Get water parameters
     water_params = _get_ff_parameters(forcefield, '[H]O[H]')
-    o_charge, _, _ = water_params[0]
-    h_charge, _, _ = water_params[1]
+    o_charge = water_params['O'][0]
+    h_charge = water_params['H'][0]
 
     # Loop through residues, check if they match the residue index
     # mutate the atom as necessary

--- a/src/openfe/protocols/openmm_rfe/_rfe_utils/topologyhelpers.py
+++ b/src/openfe/protocols/openmm_rfe/_rfe_utils/topologyhelpers.py
@@ -70,7 +70,7 @@ def _get_ion_parameters(
     system: System,
     charge_difference: int,
     forcefield: app.ForceField,
-) -> tuple:
+) -> tuple[float, float, float]:
     """
     Get NonbondedForce parameters for the most abundant monovalent ion of
     the appropriate charge sign found in the topology. Falls back to

--- a/src/openfe/protocols/openmm_rfe/_rfe_utils/topologyhelpers.py
+++ b/src/openfe/protocols/openmm_rfe/_rfe_utils/topologyhelpers.py
@@ -43,9 +43,14 @@ def _get_ff_parameters(
 
     Returns
     -------
-    dict[str, tuple]
+    dict[str, tuple[float, float, float]]
       A dictionary keyed by element symbol, with (charge, sigma, epsilon)
       tuples as values.
+
+    Notes
+    -----
+    Parameters are keyed by element symbol. Only suitable for molecules
+    where all atoms of the same element are equivalent (e.g. ions, water).
     """
     from openff.toolkit import Molecule
 
@@ -105,8 +110,6 @@ def _get_ion_parameters(
         if len(atoms) != 1:
             continue
         atom = atoms[0]
-        if atom.element is None:
-            continue
         charge, _, _ = nbf.getParticleParameters(atom.index)
         charge_val = charge.value_in_unit(omm_unit.elementary_charge)
         if np.isclose(abs(charge_val), 1.0, atol=0.01) and np.sign(charge_val) == desired_sign:
@@ -130,7 +133,6 @@ def _get_ion_parameters(
         f"the topology. Defaulting to '{fallback_smiles}' and obtaining "
         f"parameters from the forcefield directly."
     )
-    warnings.warn(wmsg)
     logger.warning(wmsg)
 
     ion_params = _get_ff_parameters(forcefield, fallback_smiles)

--- a/src/openfe/protocols/openmm_rfe/hybridtop_protocols.py
+++ b/src/openfe/protocols/openmm_rfe/hybridtop_protocols.py
@@ -440,7 +440,7 @@ class RelativeHybridTopologyProtocol(gufe.Protocol):
         wmsg = (
             f"A charge difference of {difference} is observed "
             "between the end states. This will be addressed by "
-            "transforming a water into an ion of opposite charge."
+            "transforming a water into an ion of the same charge."
         )
         logger.info(wmsg)
 

--- a/src/openfe/protocols/openmm_rfe/hybridtop_protocols.py
+++ b/src/openfe/protocols/openmm_rfe/hybridtop_protocols.py
@@ -28,6 +28,7 @@ from gufe import (
     ProteinComponent,
     ProteinMembraneComponent,
     SmallMoleculeComponent,
+    SolvatedPDBComponent,
     SolventComponent,
     settings,
 )
@@ -50,6 +51,7 @@ from .equil_rfe_settings import (
     OpenMMSolvationSettings,
     RelativeHybridTopologyProtocolSettings,
 )
+from . import _rfe_utils
 from .hybridtop_protocol_results import RelativeHybridTopologyProtocolResult
 from .hybridtop_units import (
     HybridTopologyMultiStateAnalysisUnit,
@@ -435,7 +437,20 @@ class RelativeHybridTopologyProtocol(gufe.Protocol):
             )
             raise ValueError(errmsg)
 
-        ion = {-1: solvent_component.positive_ion, 1: solvent_component.negative_ion}[difference]
+        # resolve ion names from SolventComponent or topology
+        if isinstance(solvent_component, SolventComponent):
+            positive_ion = solvent_component.positive_ion.strip(
+                '-+').upper()
+            negative_ion = solvent_component.negative_ion.strip(
+                '-+').upper()
+        elif isinstance(solvent_component, SolvatedPDBComponent):
+            positive_ion, negative_ion = (
+                _rfe_utils.topologyhelpers._get_ion_resnames_from_topology(
+                    solvent_component.to_openmm_topology()
+                )
+            )
+
+        ion = {-1: positive_ion, 1: negative_ion}[difference]
 
         wmsg = (
             f"A charge difference of {difference} is observed "

--- a/src/openfe/protocols/openmm_rfe/hybridtop_protocols.py
+++ b/src/openfe/protocols/openmm_rfe/hybridtop_protocols.py
@@ -437,22 +437,11 @@ class RelativeHybridTopologyProtocol(gufe.Protocol):
             )
             raise ValueError(errmsg)
 
-        # resolve ion names from SolventComponent or topology
-        if isinstance(solvent_component, SolventComponent):
-            positive_ion = solvent_component.positive_ion.strip("-+").upper()
-            negative_ion = solvent_component.negative_ion.strip("-+").upper()
-            ion = {-1: positive_ion, 1: negative_ion}[difference]
-            wmsg = (
-                f"A charge difference of {difference} is observed "
-                "between the end states. This will be addressed by "
-                f"transforming a water into a {ion} ion"
-            )
-        elif isinstance(solvent_component, SolvatedPDBComponent):
-            wmsg = (
-                f"A charge difference of {difference} is observed "
-                "between the end states. This will be addressed by "
-                "transforming a water into an ion."
-            )
+        wmsg = (
+            f"A charge difference of {difference} is observed "
+            "between the end states. This will be addressed by "
+            "transforming a water into an ion of opposite charge."
+        )
         logger.info(wmsg)
 
     @staticmethod

--- a/src/openfe/protocols/openmm_rfe/hybridtop_protocols.py
+++ b/src/openfe/protocols/openmm_rfe/hybridtop_protocols.py
@@ -40,6 +40,7 @@ from ..openmm_utils import (
     settings_validation,
     system_validation,
 )
+from . import _rfe_utils
 from .equil_rfe_settings import (
     AlchemicalSettings,
     IntegratorSettings,
@@ -51,7 +52,6 @@ from .equil_rfe_settings import (
     OpenMMSolvationSettings,
     RelativeHybridTopologyProtocolSettings,
 )
-from . import _rfe_utils
 from .hybridtop_protocol_results import RelativeHybridTopologyProtocolResult
 from .hybridtop_units import (
     HybridTopologyMultiStateAnalysisUnit,
@@ -439,15 +439,11 @@ class RelativeHybridTopologyProtocol(gufe.Protocol):
 
         # resolve ion names from SolventComponent or topology
         if isinstance(solvent_component, SolventComponent):
-            positive_ion = solvent_component.positive_ion.strip(
-                '-+').upper()
-            negative_ion = solvent_component.negative_ion.strip(
-                '-+').upper()
+            positive_ion = solvent_component.positive_ion.strip("-+").upper()
+            negative_ion = solvent_component.negative_ion.strip("-+").upper()
         elif isinstance(solvent_component, SolvatedPDBComponent):
-            positive_ion, negative_ion = (
-                _rfe_utils.topologyhelpers._get_ion_resnames_from_topology(
-                    solvent_component.to_openmm_topology()
-                )
+            positive_ion, negative_ion = _rfe_utils.topologyhelpers._get_ion_resnames_from_topology(
+                solvent_component.to_openmm_topology()
             )
 
         ion = {-1: positive_ion, 1: negative_ion}[difference]

--- a/src/openfe/protocols/openmm_rfe/hybridtop_protocols.py
+++ b/src/openfe/protocols/openmm_rfe/hybridtop_protocols.py
@@ -374,7 +374,7 @@ class RelativeHybridTopologyProtocol(gufe.Protocol):
         mapping: LigandAtomMapping,
         nonbonded_method: str,
         explicit_charge_correction: bool,
-        solvent_component: SolventComponent | None,
+        solvent_component: SolventComponent | SolvatedPDBComponent | None,
     ):
         """
         Validates the net charge difference between the two states.
@@ -441,18 +441,18 @@ class RelativeHybridTopologyProtocol(gufe.Protocol):
         if isinstance(solvent_component, SolventComponent):
             positive_ion = solvent_component.positive_ion.strip("-+").upper()
             negative_ion = solvent_component.negative_ion.strip("-+").upper()
-        elif isinstance(solvent_component, SolvatedPDBComponent):
-            positive_ion, negative_ion = _rfe_utils.topologyhelpers._get_ion_resnames_from_topology(
-                solvent_component.to_openmm_topology()
+            ion = {-1: positive_ion, 1: negative_ion}[difference]
+            wmsg = (
+                f"A charge difference of {difference} is observed "
+                "between the end states. This will be addressed by "
+                f"transforming a water into a {ion} ion"
             )
-
-        ion = {-1: positive_ion, 1: negative_ion}[difference]
-
-        wmsg = (
-            f"A charge difference of {difference} is observed "
-            "between the end states. This will be addressed by "
-            f"transforming a water into a {ion} ion"
-        )
+        elif isinstance(solvent_component, SolvatedPDBComponent):
+            wmsg = (
+                f"A charge difference of {difference} is observed "
+                "between the end states. This will be addressed by "
+                "transforming a water into an ion."
+            )
         logger.info(wmsg)
 
     @staticmethod
@@ -571,6 +571,8 @@ class RelativeHybridTopologyProtocol(gufe.Protocol):
         # Note: validation depends on the mapping & solvent component checks
         if stateA.contains(SolventComponent):
             solv_comp = stateA.get_components_of_type(SolventComponent)[0]
+        elif stateA.contains(SolvatedPDBComponent):
+            solv_comp = stateA.get_components_of_type(SolvatedPDBComponent)[0]
         else:
             solv_comp = None
 

--- a/src/openfe/protocols/openmm_rfe/hybridtop_units.py
+++ b/src/openfe/protocols/openmm_rfe/hybridtop_units.py
@@ -410,6 +410,17 @@ class HybridTopologySetupUnit(gufe.ProtocolUnit, HybridTopologyUnitMixin):
         if charge_difference == 0:
             return
 
+        # Resolve ion names from the solvent component if available,
+        # otherwise infer from the topology (for explicitly solvated systems).
+        if isinstance(solvent_component, SolventComponent):
+            positive_ion = solvent_component.positive_ion.strip('-+').upper()
+            negative_ion = solvent_component.negative_ion.strip('-+').upper()
+        else:
+            positive_ion, negative_ion = (
+                _rfe_utils.topologyhelpers._get_ion_resnames_from_topology(
+                    stateA_topology)
+            )
+
         # Get the residue ids for waters to turn alchemical
         alchem_water_resids = _rfe_utils.topologyhelpers.get_alchemical_waters(
             topology=stateA_topology,
@@ -425,7 +436,9 @@ class HybridTopologySetupUnit(gufe.ProtocolUnit, HybridTopologyUnitMixin):
             system=stateB_system,
             system_mapping=system_mappings,
             charge_difference=charge_difference,
-            solvent_component=solvent_component,
+            positive_ion_resname=positive_ion,
+            negative_ion_resname=negative_ion,
+            water_resname='HOH'   # Need to check if this is also true for systems not prepped with addSolvent
         )
 
     def _get_omm_objects(

--- a/src/openfe/protocols/openmm_rfe/hybridtop_units.py
+++ b/src/openfe/protocols/openmm_rfe/hybridtop_units.py
@@ -390,7 +390,7 @@ class HybridTopologySetupUnit(gufe.ProtocolUnit, HybridTopologyUnitMixin):
         charge_difference: int,
         system_mappings: dict[str, dict[int, int]],
         distance_cutoff: Quantity,
-        solvent_component: SolventComponent | None,
+        forcefield: openmm.app.ForceField,
     ) -> None:
         """
         Handle system net charge by adding an alchemical water.
@@ -404,21 +404,11 @@ class HybridTopologySetupUnit(gufe.ProtocolUnit, HybridTopologyUnitMixin):
         charge_difference : int
         system_mappings : dict[str, dict[int, int]]
         distance_cutoff : Quantity
-        solvent_component : SolventComponent | None
+        forcefield: openmm.app.ForceField
         """
         # Base case, return if no net charge
         if charge_difference == 0:
             return
-
-        # Resolve ion names from the solvent component if available,
-        # otherwise infer from the topology (for explicitly solvated systems).
-        if isinstance(solvent_component, SolventComponent):
-            positive_ion = solvent_component.positive_ion.strip("-+").upper()
-            negative_ion = solvent_component.negative_ion.strip("-+").upper()
-        else:
-            positive_ion, negative_ion = _rfe_utils.topologyhelpers._get_ion_resnames_from_topology(
-                stateA_topology
-            )
 
         # Get the residue ids for waters to turn alchemical
         alchem_water_resids = _rfe_utils.topologyhelpers.get_alchemical_waters(
@@ -435,8 +425,7 @@ class HybridTopologySetupUnit(gufe.ProtocolUnit, HybridTopologyUnitMixin):
             system=stateB_system,
             system_mapping=system_mappings,
             charge_difference=charge_difference,
-            positive_ion_resname=positive_ion,
-            negative_ion_resname=negative_ion,
+            forcefield=forcefield,
             water_resname="HOH",  # Need to check if this is also true for systems not prepped with addSolvent
         )
 
@@ -557,6 +546,7 @@ class HybridTopologySetupUnit(gufe.ProtocolUnit, HybridTopologyUnitMixin):
         # Net charge: add alchemical water if needed
         # Must be done here as we in-place modify the particles of state B.
         if settings["alchemical_settings"].explicit_charge_correction:
+            forcefield = states_inputs["A"]["generator"].forcefield
             self._handle_net_charge(
                 stateA_topology=stateA_topology,
                 stateA_positions=stateA_positions,
@@ -565,7 +555,7 @@ class HybridTopologySetupUnit(gufe.ProtocolUnit, HybridTopologyUnitMixin):
                 charge_difference=mapping.get_alchemical_charge_difference(),
                 system_mappings=system_mappings,
                 distance_cutoff=settings["alchemical_settings"].explicit_charge_correction_cutoff,
-                solvent_component=solvent_component,
+                forcefield=forcefield,
             )
 
         # Finally get the state B positions

--- a/src/openfe/protocols/openmm_rfe/hybridtop_units.py
+++ b/src/openfe/protocols/openmm_rfe/hybridtop_units.py
@@ -413,12 +413,11 @@ class HybridTopologySetupUnit(gufe.ProtocolUnit, HybridTopologyUnitMixin):
         # Resolve ion names from the solvent component if available,
         # otherwise infer from the topology (for explicitly solvated systems).
         if isinstance(solvent_component, SolventComponent):
-            positive_ion = solvent_component.positive_ion.strip('-+').upper()
-            negative_ion = solvent_component.negative_ion.strip('-+').upper()
+            positive_ion = solvent_component.positive_ion.strip("-+").upper()
+            negative_ion = solvent_component.negative_ion.strip("-+").upper()
         else:
-            positive_ion, negative_ion = (
-                _rfe_utils.topologyhelpers._get_ion_resnames_from_topology(
-                    stateA_topology)
+            positive_ion, negative_ion = _rfe_utils.topologyhelpers._get_ion_resnames_from_topology(
+                stateA_topology
             )
 
         # Get the residue ids for waters to turn alchemical
@@ -438,7 +437,7 @@ class HybridTopologySetupUnit(gufe.ProtocolUnit, HybridTopologyUnitMixin):
             charge_difference=charge_difference,
             positive_ion_resname=positive_ion,
             negative_ion_resname=negative_ion,
-            water_resname='HOH'   # Need to check if this is also true for systems not prepped with addSolvent
+            water_resname="HOH",  # Need to check if this is also true for systems not prepped with addSolvent
         )
 
     def _get_omm_objects(

--- a/src/openfe/protocols/openmm_rfe/hybridtop_units.py
+++ b/src/openfe/protocols/openmm_rfe/hybridtop_units.py
@@ -426,7 +426,6 @@ class HybridTopologySetupUnit(gufe.ProtocolUnit, HybridTopologyUnitMixin):
             system_mapping=system_mappings,
             charge_difference=charge_difference,
             forcefield=forcefield,
-            water_resname="HOH",  # Need to check if this is also true for systems not prepped with addSolvent
         )
 
     def _get_omm_objects(

--- a/src/openfe/tests/protocols/openmm_rfe/test_hybrid_top_protocol.py
+++ b/src/openfe/tests/protocols/openmm_rfe/test_hybrid_top_protocol.py
@@ -2,6 +2,7 @@
 # For details, see https://github.com/OpenFreeEnergy/openfe
 import copy
 import json
+import logging
 import sys
 import xml.etree.ElementTree as ET
 from importlib import resources
@@ -1217,32 +1218,17 @@ def test_dry_run_membrane_complex(
 
 def test_validate_charge_difference_membrane_system(
     a2a_protein_membrane_component,
-    a2a_ligands,
+    benzene_to_aniline_mapping,
 ):
-    ligA = next(c for c in a2a_ligands if c.name == "4g")
-    ligB = next(c for c in a2a_ligands if c.name == "4h")
-
-    mapping = openfe.LigandAtomMapping(
-        componentA=ligA,
-        componentB=ligB,
-        componentA_to_componentB={i: i for i in range(36)},
-    )
-
     settings = openmm_rfe.RelativeHybridTopologyProtocol.default_settings()
 
-    # Mock get_alchemical_charge_difference to return non-zero
-    with mock.patch.object(
-        mapping,
-        "get_alchemical_charge_difference",
-        return_value=1,
-    ):
-        protocol = openmm_rfe.RelativeHybridTopologyProtocol(settings=settings)
-        protocol._validate_charge_difference(
-            mapping=mapping,
-            nonbonded_method=settings.forcefield_settings.nonbonded_method,
-            explicit_charge_correction=True,
-            solvent_component=a2a_protein_membrane_component,
-        )
+    protocol = openmm_rfe.RelativeHybridTopologyProtocol(settings=settings)
+    protocol._validate_charge_difference(
+        mapping=benzene_to_aniline_mapping,
+        nonbonded_method=settings.forcefield_settings.nonbonded_method,
+        explicit_charge_correction=True,
+        solvent_component=a2a_protein_membrane_component,
+    )
 
 
 def test_lambda_schedule_default():
@@ -1962,10 +1948,17 @@ def benzene_self_system_mapping(benzene_solvent_openmm_system):
     return system_mapping
 
 
-def test_get_ion_parameters_fallback_to_forcefield(benzene_modifications):
+@pytest.mark.parametrize("charge_difference,expected_charge", [
+    (1, 1.0),   # positive charge difference -> Na+ fallback
+    (-1, -1.0), # negative charge difference -> Cl- fallback
+])
+def test_get_ion_parameters_fallback_to_forcefield(
+    benzene_modifications, charge_difference, expected_charge, caplog,
+):
     """
     Check that when no matching ion is found in the topology,
-    parameters are obtained from the forcefield (NA fallback).
+    parameters are obtained from the forcefield. Tests both positive
+    (NA fallback) and negative (CL fallback) charge differences.
     """
     smc = benzene_modifications["benzene"]
     offmol = smc.to_openff()
@@ -1994,15 +1987,15 @@ def test_get_ion_parameters_fallback_to_forcefield(benzene_modifications):
     topology = modeller.getTopology()
     system = system_generator.create_system(topology, molecules=[offmol])
 
-    with pytest.warns(UserWarning, match="No monovalent ion"):
+    with caplog.at_level(logging.WARNING):
         ion_charge, ion_sigma, ion_epsilon = topologyhelpers._get_ion_parameters(
-            topology,
-            system,
-            charge_difference=1,
+            topology, system,
+            charge_difference=charge_difference,
             forcefield=system_generator.forcefield,
         )
 
-    assert ion_charge.value_in_unit(omm_unit.elementary_charge) == pytest.approx(1.0)
+    assert "No monovalent ion" in caplog.text
+    assert ion_charge.value_in_unit(omm_unit.elementary_charge) == pytest.approx(expected_charge)
 
 
 def test_get_alchemical_waters_no_waters(
@@ -2113,11 +2106,18 @@ def test_handle_alchemwats_incorrect_atom(
         )
 
 
+@pytest.mark.parametrize("charge_difference,expected_charge", [
+    (1, 1.0),   # positive charge difference -> water becomes Na+
+    (-1, -1.0), # negative charge difference -> water becomes Cl-
+])
 def test_handle_alchemical_wats(
     benzene_solvent_openmm_system,
     benzene_self_system_mapping,
+    charge_difference,
+    expected_charge,
 ):
     system, topology, positions, forcefield = benzene_solvent_openmm_system
+    system = copy.deepcopy(system)
 
     n_env = len(benzene_self_system_mapping["old_to_new_env_atom_map"])
     n_core = len(benzene_self_system_mapping["old_to_new_core_atom_map"])
@@ -2127,7 +2127,7 @@ def test_handle_alchemical_wats(
         topology=topology,
         system=system,
         system_mapping=benzene_self_system_mapping,
-        charge_difference=1,
+        charge_difference=charge_difference,
         forcefield=forcefield,
     )
 
@@ -2141,19 +2141,19 @@ def test_handle_alchemical_wats(
     expected_old_new_core = {i: i for i in range(12)} | {24: 24, 25: 25, 26: 26}
     assert old_new_core == expected_old_new_core
 
-    # system parameters checks
+    # check ion parameters were correctly applied
     nbf = [i for i in system.getForces() if isinstance(i, NonbondedForce)][0]
-    # check the oxygen parameters
     i_chg, i_sig, i_eps = topologyhelpers._get_ion_parameters(
-        topology, system, charge_difference=1, forcefield=forcefield
+        topology, system, charge_difference=charge_difference, forcefield=forcefield,
     )
 
     charge, sigma, epsilon = nbf.getParticleParameters(24)
-    assert charge == 1.0 * omm_unit.elementary_charge == i_chg
+    assert charge.value_in_unit(omm_unit.elementary_charge) == pytest.approx(expected_charge)
+    assert charge == i_chg
     assert sigma == i_sig
     assert epsilon == i_eps
 
-    # check the hydrogen parameters
+    # check hydrogen parameters were zeroed out
     for i in [25, 26]:
         charge, _, _ = nbf.getParticleParameters(i)
         assert charge == 0.0 * omm_unit.elementary_charge

--- a/src/openfe/tests/protocols/openmm_rfe/test_hybrid_top_protocol.py
+++ b/src/openfe/tests/protocols/openmm_rfe/test_hybrid_top_protocol.py
@@ -1948,12 +1948,18 @@ def benzene_self_system_mapping(benzene_solvent_openmm_system):
     return system_mapping
 
 
-@pytest.mark.parametrize("charge_difference,expected_charge", [
-    (1, 1.0),   # positive charge difference -> Na+ fallback
-    (-1, -1.0), # negative charge difference -> Cl- fallback
-])
+@pytest.mark.parametrize(
+    "charge_difference,expected_charge",
+    [
+        (1, 1.0),  # positive charge difference -> Na+ fallback
+        (-1, -1.0),  # negative charge difference -> Cl- fallback
+    ],
+)
 def test_get_ion_parameters_fallback_to_forcefield(
-    benzene_modifications, charge_difference, expected_charge, caplog,
+    benzene_modifications,
+    charge_difference,
+    expected_charge,
+    caplog,
 ):
     """
     Check that when no matching ion is found in the topology,
@@ -1989,7 +1995,8 @@ def test_get_ion_parameters_fallback_to_forcefield(
 
     with caplog.at_level(logging.WARNING):
         ion_charge, ion_sigma, ion_epsilon = topologyhelpers._get_ion_parameters(
-            topology, system,
+            topology,
+            system,
             charge_difference=charge_difference,
             forcefield=system_generator.forcefield,
         )
@@ -2106,10 +2113,13 @@ def test_handle_alchemwats_incorrect_atom(
         )
 
 
-@pytest.mark.parametrize("charge_difference,expected_charge", [
-    (1, 1.0),   # positive charge difference -> water becomes Na+
-    (-1, -1.0), # negative charge difference -> water becomes Cl-
-])
+@pytest.mark.parametrize(
+    "charge_difference,expected_charge",
+    [
+        (1, 1.0),  # positive charge difference -> water becomes Na+
+        (-1, -1.0),  # negative charge difference -> water becomes Cl-
+    ],
+)
 def test_handle_alchemical_wats(
     benzene_solvent_openmm_system,
     benzene_self_system_mapping,
@@ -2144,7 +2154,10 @@ def test_handle_alchemical_wats(
     # check ion parameters were correctly applied
     nbf = [i for i in system.getForces() if isinstance(i, NonbondedForce)][0]
     i_chg, i_sig, i_eps = topologyhelpers._get_ion_parameters(
-        topology, system, charge_difference=charge_difference, forcefield=forcefield,
+        topology,
+        system,
+        charge_difference=charge_difference,
+        forcefield=forcefield,
     )
 
     charge, sigma, epsilon = nbf.getParticleParameters(24)

--- a/src/openfe/tests/protocols/openmm_rfe/test_hybrid_top_protocol.py
+++ b/src/openfe/tests/protocols/openmm_rfe/test_hybrid_top_protocol.py
@@ -2010,9 +2010,9 @@ def test_handle_alchemwats_incorrect_count(
             system=system,
             system_mapping={},
             charge_difference=1,
-            positive_ion_resname='NA',
-            negative_ion_resname='CL',
-            water_resname='HOH',
+            positive_ion_resname="NA",
+            negative_ion_resname="CL",
+            water_resname="HOH",
         )
 
 
@@ -2036,9 +2036,9 @@ def test_handle_alchemwats_too_many_nbf(
             system=new_system,
             system_mapping={},
             charge_difference=1,
-            positive_ion_resname='NA',
-            negative_ion_resname='CL',
-            water_resname='HOH',
+            positive_ion_resname="NA",
+            negative_ion_resname="CL",
+            water_resname="HOH",
         )
 
 
@@ -2060,9 +2060,9 @@ def test_handle_alchemwats_vsite_water(
             system=system,
             system_mapping={},
             charge_difference=1,
-            positive_ion_resname='NA',
-            negative_ion_resname='CL',
-            water_resname='HOH',
+            positive_ion_resname="NA",
+            negative_ion_resname="CL",
+            water_resname="HOH",
         )
 
 
@@ -2090,9 +2090,9 @@ def test_handle_alchemwats_incorrect_atom(
             system=new_system,
             system_mapping=benzene_self_system_mapping,
             charge_difference=1,
-            positive_ion_resname='NA',
-            negative_ion_resname='CL',
-            water_resname='HOH',
+            positive_ion_resname="NA",
+            negative_ion_resname="CL",
+            water_resname="HOH",
         )
 
 
@@ -2111,9 +2111,9 @@ def test_handle_alchemical_wats(
         system=system,
         system_mapping=benzene_self_system_mapping,
         charge_difference=1,
-        positive_ion_resname='NA',
-        negative_ion_resname='CL',
-        water_resname='HOH',
+        positive_ion_resname="NA",
+        negative_ion_resname="CL",
+        water_resname="HOH",
     )
 
     # check the mappings

--- a/src/openfe/tests/protocols/openmm_rfe/test_hybrid_top_protocol.py
+++ b/src/openfe/tests/protocols/openmm_rfe/test_hybrid_top_protocol.py
@@ -1963,8 +1963,7 @@ def test_get_ion_parameters_fallback_to_forcefield(
 ):
     """
     Check that when no matching ion is found in the topology,
-    parameters are obtained from the forcefield. Tests both positive
-    (NA fallback) and negative (CL fallback) charge differences.
+    parameters are obtained from the forcefield.
     """
     smc = benzene_modifications["benzene"]
     offmol = smc.to_openff()
@@ -2166,7 +2165,7 @@ def test_handle_alchemical_wats(
     assert sigma == i_sig
     assert epsilon == i_eps
 
-    # check hydrogen parameters were zeroed out
+    # check the hydrogen parameters
     for i in [25, 26]:
         charge, _, _ = nbf.getParticleParameters(i)
         assert charge == 0.0 * omm_unit.elementary_charge

--- a/src/openfe/tests/protocols/openmm_rfe/test_hybrid_top_protocol.py
+++ b/src/openfe/tests/protocols/openmm_rfe/test_hybrid_top_protocol.py
@@ -1962,10 +1962,10 @@ def benzene_self_system_mapping(benzene_solvent_openmm_system):
     return system_mapping
 
 
-def test_get_ion_water_parameters_fallback_to_forcefield(benzene_modifications):
+def test_get_ion_parameters_fallback_to_forcefield(benzene_modifications):
     """
     Check that when no matching ion is found in the topology,
-    parameters are obtained from the forcefield (NA/CL fallback).
+    parameters are obtained from the forcefield (NA fallback).
     """
     smc = benzene_modifications["benzene"]
     offmol = smc.to_openff()
@@ -1995,17 +1995,15 @@ def test_get_ion_water_parameters_fallback_to_forcefield(benzene_modifications):
     system = system_generator.create_system(topology, molecules=[offmol])
 
     with pytest.warns(UserWarning, match="No monovalent ion"):
-        ion_charge, ion_sigma, ion_epsilon, o_charge, h_charge = (
-            topologyhelpers._get_ion_and_water_parameters(
-                topology, system, system_generator.forcefield,
-                charge_difference=1,
-            )
+        ion_charge, ion_sigma, ion_epsilon = topologyhelpers._get_ion_parameters(
+            topology, system, charge_difference=1,
+            forcefield=system_generator.forcefield,
         )
 
     assert ion_charge.value_in_unit(omm_unit.elementary_charge) == pytest.approx(1.0)
 
 
-def test_get_ion_water_parameters_bad_water(benzene_solvent_openmm_system):
+def test_get_water_parameters_bad_water(benzene_solvent_openmm_system):
     """
     Check that a ValueError is raised when the water residue name
     is not found in the topology.
@@ -2014,8 +2012,8 @@ def test_get_ion_water_parameters_bad_water(benzene_solvent_openmm_system):
 
     errmsg = "Could not find water residue"
     with pytest.raises(ValueError, match=errmsg):
-        topologyhelpers._get_ion_and_water_parameters(
-            topology, system, forcefield, charge_difference=1, water_resname="SOL"
+        topologyhelpers._get_water_parameters(
+            topology, system, water_resname="SOL"
         )
 
 
@@ -2163,8 +2161,8 @@ def test_handle_alchemical_wats(
     # system parameters checks
     nbf = [i for i in system.getForces() if isinstance(i, NonbondedForce)][0]
     # check the oxygen parameters
-    i_chg, i_sig, i_eps, o_chg, h_chg = (topologyhelpers._get_ion_and_water_parameters(
-        topology, system, forcefield, charge_difference=1)
+    i_chg, i_sig, i_eps = topologyhelpers._get_ion_parameters(
+        topology, system, charge_difference=1, forcefield=forcefield
     )
 
 

--- a/src/openfe/tests/protocols/openmm_rfe/test_hybrid_top_protocol.py
+++ b/src/openfe/tests/protocols/openmm_rfe/test_hybrid_top_protocol.py
@@ -2005,18 +2005,6 @@ def test_get_ion_parameters_fallback_to_forcefield(benzene_modifications):
     assert ion_charge.value_in_unit(omm_unit.elementary_charge) == pytest.approx(1.0)
 
 
-def test_get_water_parameters_bad_water(benzene_solvent_openmm_system):
-    """
-    Check that a ValueError is raised when the water residue name
-    is not found in the topology.
-    """
-    system, topology, positions, forcefield = benzene_solvent_openmm_system
-
-    errmsg = "Could not find water residue"
-    with pytest.raises(ValueError, match=errmsg):
-        topologyhelpers._get_water_parameters(topology, system, water_resname="SOL")
-
-
 def test_get_alchemical_waters_no_waters(
     benzene_solvent_openmm_system,
 ):
@@ -2048,7 +2036,6 @@ def test_handle_alchemwats_incorrect_count(
             system_mapping={},
             charge_difference=1,
             forcefield=forcefield,
-            water_resname="HOH",
         )
 
 
@@ -2073,7 +2060,6 @@ def test_handle_alchemwats_too_many_nbf(
             system_mapping={},
             charge_difference=1,
             forcefield=forcefield,
-            water_resname="HOH",
         )
 
 
@@ -2096,7 +2082,6 @@ def test_handle_alchemwats_vsite_water(
             system_mapping={},
             charge_difference=1,
             forcefield=app.ForceField(),
-            water_resname="HOH",
         )
 
 
@@ -2125,7 +2110,6 @@ def test_handle_alchemwats_incorrect_atom(
             system_mapping=benzene_self_system_mapping,
             charge_difference=1,
             forcefield=forcefield,
-            water_resname="HOH",
         )
 
 
@@ -2145,7 +2129,6 @@ def test_handle_alchemical_wats(
         system_mapping=benzene_self_system_mapping,
         charge_difference=1,
         forcefield=forcefield,
-        water_resname="HOH",
     )
 
     # check the mappings

--- a/src/openfe/tests/protocols/openmm_rfe/test_hybrid_top_protocol.py
+++ b/src/openfe/tests/protocols/openmm_rfe/test_hybrid_top_protocol.py
@@ -1215,6 +1215,36 @@ def test_dry_run_membrane_complex(
         )
 
 
+def test_validate_charge_difference_membrane_system(
+    a2a_protein_membrane_component,
+    a2a_ligands,
+):
+    ligA = next(c for c in a2a_ligands if c.name == "4g")
+    ligB = next(c for c in a2a_ligands if c.name == "4h")
+
+    mapping = openfe.LigandAtomMapping(
+        componentA=ligA,
+        componentB=ligB,
+        componentA_to_componentB={i: i for i in range(36)},
+    )
+
+    settings = openmm_rfe.RelativeHybridTopologyProtocol.default_settings()
+
+    # Mock get_alchemical_charge_difference to return non-zero
+    with mock.patch.object(
+        mapping,
+        "get_alchemical_charge_difference",
+        return_value=1,
+    ):
+        protocol = openmm_rfe.RelativeHybridTopologyProtocol(settings=settings)
+        protocol._validate_charge_difference(
+            mapping=mapping,
+            nonbonded_method=settings.forcefield_settings.nonbonded_method,
+            explicit_charge_correction=True,
+            solvent_component=a2a_protein_membrane_component,
+        )
+
+
 def test_lambda_schedule_default():
     lambdas = openmm_rfe._rfe_utils.lambdaprotocol.LambdaProtocol(functions="default")
     assert len(lambdas.lambda_schedule) == 10
@@ -1980,7 +2010,9 @@ def test_handle_alchemwats_incorrect_count(
             system=system,
             system_mapping={},
             charge_difference=1,
-            solvent_component=openfe.SolventComponent(),
+            positive_ion_resname='NA',
+            negative_ion_resname='CL',
+            water_resname='HOH',
         )
 
 
@@ -2004,7 +2036,9 @@ def test_handle_alchemwats_too_many_nbf(
             system=new_system,
             system_mapping={},
             charge_difference=1,
-            solvent_component=openfe.SolventComponent(),
+            positive_ion_resname='NA',
+            negative_ion_resname='CL',
+            water_resname='HOH',
         )
 
 
@@ -2026,7 +2060,9 @@ def test_handle_alchemwats_vsite_water(
             system=system,
             system_mapping={},
             charge_difference=1,
-            solvent_component=openfe.SolventComponent(),
+            positive_ion_resname='NA',
+            negative_ion_resname='CL',
+            water_resname='HOH',
         )
 
 
@@ -2054,7 +2090,9 @@ def test_handle_alchemwats_incorrect_atom(
             system=new_system,
             system_mapping=benzene_self_system_mapping,
             charge_difference=1,
-            solvent_component=openfe.SolventComponent(),
+            positive_ion_resname='NA',
+            negative_ion_resname='CL',
+            water_resname='HOH',
         )
 
 
@@ -2073,7 +2111,9 @@ def test_handle_alchemical_wats(
         system=system,
         system_mapping=benzene_self_system_mapping,
         charge_difference=1,
-        solvent_component=openfe.SolventComponent(),
+        positive_ion_resname='NA',
+        negative_ion_resname='CL',
+        water_resname='HOH',
     )
 
     # check the mappings

--- a/src/openfe/tests/protocols/openmm_rfe/test_hybrid_top_protocol.py
+++ b/src/openfe/tests/protocols/openmm_rfe/test_hybrid_top_protocol.py
@@ -1996,7 +1996,9 @@ def test_get_ion_parameters_fallback_to_forcefield(benzene_modifications):
 
     with pytest.warns(UserWarning, match="No monovalent ion"):
         ion_charge, ion_sigma, ion_epsilon = topologyhelpers._get_ion_parameters(
-            topology, system, charge_difference=1,
+            topology,
+            system,
+            charge_difference=1,
             forcefield=system_generator.forcefield,
         )
 
@@ -2012,9 +2014,7 @@ def test_get_water_parameters_bad_water(benzene_solvent_openmm_system):
 
     errmsg = "Could not find water residue"
     with pytest.raises(ValueError, match=errmsg):
-        topologyhelpers._get_water_parameters(
-            topology, system, water_resname="SOL"
-        )
+        topologyhelpers._get_water_parameters(topology, system, water_resname="SOL")
 
 
 def test_get_alchemical_waters_no_waters(
@@ -2164,7 +2164,6 @@ def test_handle_alchemical_wats(
     i_chg, i_sig, i_eps = topologyhelpers._get_ion_parameters(
         topology, system, charge_difference=1, forcefield=forcefield
     )
-
 
     charge, sigma, epsilon = nbf.getParticleParameters(24)
     assert charge == 1.0 * omm_unit.elementary_charge == i_chg

--- a/src/openfe/tests/protocols/openmm_rfe/test_hybrid_top_protocol.py
+++ b/src/openfe/tests/protocols/openmm_rfe/test_hybrid_top_protocol.py
@@ -1890,7 +1890,7 @@ def benzene_solvent_openmm_system(benzene_modifications):
     positions = to_openmm(from_openmm(modeller.getPositions()))
     system = system_generator.create_system(topology, molecules=[offmol])
 
-    return system, topology, positions
+    return system, topology, positions, system_generator.forcefield
 
 
 @pytest.fixture(scope="session")
@@ -1940,7 +1940,7 @@ def benzene_self_system_mapping(benzene_solvent_openmm_system):
     alchemical transformation (this technically doesn't work in practice
     because the RFE protocol expects an alchemical component).
     """
-    system, topology, positions = benzene_solvent_openmm_system
+    system, topology, positions, forcefield = benzene_solvent_openmm_system
 
     res = [r for r in topology.residues()]
     benzene_res = [r for r in res if r.name == "UNK"][0]
@@ -1962,28 +1962,67 @@ def benzene_self_system_mapping(benzene_solvent_openmm_system):
     return system_mapping
 
 
-@pytest.mark.parametrize(
-    "ion, water",
-    [
-        ["NA", "SOL"],
-        ["NX", "WAT"],
-    ],
-)
-def test_get_ion_water_parameters_unknownresname(ion, water, benzene_solvent_openmm_system):
-    system, topology, positions = benzene_solvent_openmm_system
+def test_get_ion_water_parameters_fallback_to_forcefield(benzene_modifications):
+    """
+    Check that when no matching ion is found in the topology,
+    parameters are obtained from the forcefield (NA/CL fallback).
+    """
+    smc = benzene_modifications["benzene"]
+    offmol = smc.to_openff()
+    settings = openmm_rfe.RelativeHybridTopologyProtocol.default_settings()
 
-    errmsg = "Error encountered when attempting to explicitly handle"
+    system_generator = system_creation.get_system_generator(
+        forcefield_settings=settings.forcefield_settings,
+        integrator_settings=settings.integrator_settings,
+        thermo_settings=settings.thermo_settings,
+        cache=None,
+        has_solvent=True,
+    )
+    system_generator.create_system(
+        offmol.to_topology().to_openmm(),
+        molecules=[offmol],
+    )
 
+    modeller, _ = system_creation.get_omm_modeller(
+        protein_comp=None,
+        solvent_comp=openfe.SolventComponent(ion_concentration=0 * unit.molar),
+        small_mols={smc: offmol},
+        omm_forcefield=system_generator.forcefield,
+        solvent_settings=settings.solvation_settings,
+    )
+
+    topology = modeller.getTopology()
+    system = system_generator.create_system(topology, molecules=[offmol])
+
+    with pytest.warns(UserWarning, match="No monovalent ion"):
+        ion_charge, ion_sigma, ion_epsilon, o_charge, h_charge = (
+            topologyhelpers._get_ion_and_water_parameters(
+                topology, system, system_generator.forcefield,
+                charge_difference=1,
+            )
+        )
+
+    assert ion_charge.value_in_unit(omm_unit.elementary_charge) == pytest.approx(1.0)
+
+
+def test_get_ion_water_parameters_bad_water(benzene_solvent_openmm_system):
+    """
+    Check that a ValueError is raised when the water residue name
+    is not found in the topology.
+    """
+    system, topology, positions, forcefield = benzene_solvent_openmm_system
+
+    errmsg = "Could not find water residue"
     with pytest.raises(ValueError, match=errmsg):
         topologyhelpers._get_ion_and_water_parameters(
-            topology, system, ion_resname=ion, water_resname=water
+            topology, system, forcefield, charge_difference=1, water_resname="SOL"
         )
 
 
 def test_get_alchemical_waters_no_waters(
     benzene_solvent_openmm_system,
 ):
-    system, topology, positions = benzene_solvent_openmm_system
+    system, topology, positions, forcefield = benzene_solvent_openmm_system
 
     errmsg = "There are no waters"
 
@@ -1999,7 +2038,7 @@ def test_handle_alchemwats_incorrect_count(
     """
     Check that an error is thrown when charge_difference != len(water_resids)
     """
-    system, topology, positions = benzene_solvent_openmm_system
+    system, topology, positions, forcefield = benzene_solvent_openmm_system
 
     errmsg = "There should be as many alchemical water residues:"
 
@@ -2010,8 +2049,7 @@ def test_handle_alchemwats_incorrect_count(
             system=system,
             system_mapping={},
             charge_difference=1,
-            positive_ion_resname="NA",
-            negative_ion_resname="CL",
+            forcefield=forcefield,
             water_resname="HOH",
         )
 
@@ -2022,7 +2060,7 @@ def test_handle_alchemwats_too_many_nbf(
     """
     Check that an error is thrown when there are multiple NonbondedForces
     """
-    system, topology, positions = benzene_solvent_openmm_system
+    system, topology, positions, forcefield = benzene_solvent_openmm_system
 
     new_system = copy.deepcopy(system)
     new_system.addForce(NonbondedForce())
@@ -2036,8 +2074,7 @@ def test_handle_alchemwats_too_many_nbf(
             system=new_system,
             system_mapping={},
             charge_difference=1,
-            positive_ion_resname="NA",
-            negative_ion_resname="CL",
+            forcefield=forcefield,
             water_resname="HOH",
         )
 
@@ -2060,8 +2097,7 @@ def test_handle_alchemwats_vsite_water(
             system=system,
             system_mapping={},
             charge_difference=1,
-            positive_ion_resname="NA",
-            negative_ion_resname="CL",
+            forcefield=app.ForceField(),
             water_resname="HOH",
         )
 
@@ -2073,7 +2109,7 @@ def test_handle_alchemwats_incorrect_atom(
     """
     Check that an error is thrown when charge_difference != len(water_resids)
     """
-    system, topology, positions = benzene_solvent_openmm_system
+    system, topology, positions, forcefield = benzene_solvent_openmm_system
 
     # modify the charge of hydrogen atom 25
     new_system = copy.deepcopy(system)  # protect the session scoped object
@@ -2090,8 +2126,7 @@ def test_handle_alchemwats_incorrect_atom(
             system=new_system,
             system_mapping=benzene_self_system_mapping,
             charge_difference=1,
-            positive_ion_resname="NA",
-            negative_ion_resname="CL",
+            forcefield=forcefield,
             water_resname="HOH",
         )
 
@@ -2100,7 +2135,7 @@ def test_handle_alchemical_wats(
     benzene_solvent_openmm_system,
     benzene_self_system_mapping,
 ):
-    system, topology, positions = benzene_solvent_openmm_system
+    system, topology, positions, forcefield = benzene_solvent_openmm_system
 
     n_env = len(benzene_self_system_mapping["old_to_new_env_atom_map"])
     n_core = len(benzene_self_system_mapping["old_to_new_core_atom_map"])
@@ -2111,8 +2146,7 @@ def test_handle_alchemical_wats(
         system=system,
         system_mapping=benzene_self_system_mapping,
         charge_difference=1,
-        positive_ion_resname="NA",
-        negative_ion_resname="CL",
+        forcefield=forcefield,
         water_resname="HOH",
     )
 
@@ -2129,9 +2163,10 @@ def test_handle_alchemical_wats(
     # system parameters checks
     nbf = [i for i in system.getForces() if isinstance(i, NonbondedForce)][0]
     # check the oxygen parameters
-    i_chg, i_sig, i_eps, o_chg, h_chg = topologyhelpers._get_ion_and_water_parameters(
-        topology, system, "NA", "HOH"
+    i_chg, i_sig, i_eps, o_chg, h_chg = (topologyhelpers._get_ion_and_water_parameters(
+        topology, system, forcefield, charge_difference=1)
     )
+
 
     charge, sigma, epsilon = nbf.getParticleParameters(24)
     assert charge == 1.0 * omm_unit.elementary_charge == i_chg

--- a/src/openfe/tests/protocols/openmm_rfe/test_hybrid_top_validation.py
+++ b/src/openfe/tests/protocols/openmm_rfe/test_hybrid_top_validation.py
@@ -444,7 +444,7 @@ def test_get_charge_difference(mapping_name, result, request, caplog):
     msg = (
         f"A charge difference of {result} is observed "
         "between the end states. This will be addressed by "
-        f"transforming a water into an ion of opposite charge"
+        f"transforming a water into an ion of the same charge"
     )
 
     openmm_rfe.RelativeHybridTopologyProtocol._validate_charge_difference(

--- a/src/openfe/tests/protocols/openmm_rfe/test_hybrid_top_validation.py
+++ b/src/openfe/tests/protocols/openmm_rfe/test_hybrid_top_validation.py
@@ -441,7 +441,7 @@ def test_get_charge_difference(mapping_name, result, request, caplog):
     mapping = request.getfixturevalue(mapping_name)
     caplog.set_level(logging.INFO)
 
-    ion = r"Na+" if result == -1 else r"Cl-"
+    ion = r"NA" if result == -1 else r"CL"
     msg = (
         f"A charge difference of {result} is observed "
         "between the end states. This will be addressed by "

--- a/src/openfe/tests/protocols/openmm_rfe/test_hybrid_top_validation.py
+++ b/src/openfe/tests/protocols/openmm_rfe/test_hybrid_top_validation.py
@@ -441,11 +441,10 @@ def test_get_charge_difference(mapping_name, result, request, caplog):
     mapping = request.getfixturevalue(mapping_name)
     caplog.set_level(logging.INFO)
 
-    ion = r"NA" if result == -1 else r"CL"
     msg = (
         f"A charge difference of {result} is observed "
         "between the end states. This will be addressed by "
-        f"transforming a water into a {ion} ion"
+        f"transforming a water into an ion of opposite charge"
     )
 
     openmm_rfe.RelativeHybridTopologyProtocol._validate_charge_difference(


### PR DESCRIPTION
This is just a first idea (and the `_get_ion_resnames_from_topology` was written together with Claude). This is mostly just to show the different things we have to consider, but I don't like the dictionary idea of known ions yet. Maybe it would also be ok to always use Cl and Na ions for explicitly solvated systems, no matter if other ion types were used as counterions?

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [x] All new code is appropriately documented (user-facing code _must_ have complete docstrings).
* [x] Added a ``news`` entry, or the changes are not user-facing.
* [x] Ran pre-commit: you can run [pre-commit](https://pre-commit.com) locally or comment on this PR with `pre-commit.ci autofix`.

Manual Tests: these are slow so don't need to be run every commit, only before merging and when relevant changes are made (generally at reviewer-discretion). 
* [ ] [GPU integration tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/aws-gpu-integration-tests.yaml)
* [ ] [example notebook testing](https://github.com/OpenFreeEnergy/openfe/actions/workflows/release-prep-examplenotebooks.yaml)
* [ ] [packaging tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/cron-package-test.yaml): run this for any large feature PRs or PRs that add test data.


## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
