### PR TITLE
Security: Unsafe Tarfile Extraction without Validation

### DIFF
--- a/devtools/data/fix_rbfe_results.py
+++ b/devtools/data/fix_rbfe_results.py
@@ -18,6 +18,9 @@ from openfe.protocols import openmm_rfe
 def untar(fn):
     """extract tarfile called *fn*"""
     with tarfile.open(fn) as f:
+        for member in f.getmembers():
+            if os.path.isabs(member.name) or '..' in member.name:
+                raise ValueError(f"Invalid tar member: {member.name}")
         f.extractall()
 
 


### PR DESCRIPTION
## Summary

Security: Unsafe Tarfile Extraction without Validation

## Problem

**Severity**: `High` | **File**: `devtools/data/fix_rbfe_results.py:L16`

The `untar` function in `fix_rbfe_results.py` uses `tarfile.extractall()` without any path validation or member checking. This is a well-known vulnerability (CVE-2007-4559) where malicious tar files can contain members with absolute paths or `..` path components, leading to arbitrary file overwrite outside the intended directory.

## Solution

Use `tarfile.extractall()` with a `filter` parameter (Python 3.12+) or manually validate each member's path before extraction. Implement a helper that checks `os.path.commonpath()` to ensure extracted files stay within the target directory. Example: `for member in f.getmembers(): if os.path.isabs(member.name) or '..' in member.name: raise ValueError('Invalid tar member')`

## Changes

- `devtools/data/fix_rbfe_results.py` (modified)