### PR TITLE
Net charge abfe -fix alchemical ion selection heuristic

### DIFF
--- a/openfe/protocols/openmm_afe/equil_binding_afe_method.py
+++ b/openfe/protocols/openmm_afe/equil_binding_afe_method.py
@@ -1057,6 +1057,9 @@ class AbsoluteBindingUnitMixin:
         if abs(total_charge) > 1:
             errmsg = "Cannot handle net charge correction on charges greater than one"
             raise ValueError(errmsg)
+        
+         # Declare resname to only select counterions (exclude ligand)
+        ion_resnames = [e.upper() for e in IONS[total_charge]]  
 
         univ = _get_mda_universe(
             omm_topology,
@@ -1067,7 +1070,7 @@ class AbsoluteBindingUnitMixin:
         counter_ions_idxs = [
             at.ix
             for at in univ.atoms
-            if at.element in IONS[total_charge]
+            if at.resname in ion_resnames
         ]
         counter_ions = univ.atoms[counter_ions_idxs]
 

--- a/openfe/protocols/openmm_afe/equil_binding_afe_method.py
+++ b/openfe/protocols/openmm_afe/equil_binding_afe_method.py
@@ -36,6 +36,7 @@ from typing import Any, Iterable, Optional, Union
 import gufe
 import MDAnalysis as mda
 from MDAnalysis.lib.distances import calc_bonds
+from MDAnalysis.lib.mdamath import triclinic_vectors
 import numpy as np
 import numpy.typing as npt
 from gufe import (
@@ -1079,6 +1080,25 @@ class AbsoluteBindingUnitMixin:
         alchem_idxs = _get_idxs_from_residxs(topology=omm_topology, residxs=residxs)
         alchem_atoms = univ.atoms[alchem_idxs]
 
+        # Cap the search at the periodic minimum-image limit
+        univ.trajectory[-1]  # read the box from the final frame
+        box = univ.dimensions
+        if box is None or not np.all(np.isfinite(box)) or np.any(box[:3] <= 0.0):
+            errmsg = (
+                "Could not identify a periodic box for the co-alchemical ion "
+                "search. The search distance is bounded by the periodic "
+                "minimum-image convention, which requires a valid (non-zero) "
+                f"box in the equilibrated frame; got dimensions: {box}."
+            )
+            raise ValueError(errmsg)
+        bvecs = triclinic_vectors(box)  # box vectors, Angstrom
+        vol = abs(np.dot(bvecs[0], np.cross(bvecs[1], bvecs[2])))
+        perp_widths = [
+            vol / np.linalg.norm(np.cross(bvecs[(i + 1) % 3], bvecs[(i + 2) % 3]))
+            for i in range(3)
+        ]
+        max_dist = (0.5 * min(perp_widths) / 10.0 - 0.1) * offunit.nanometer  # Å -> nm
+
         # Re-using a utility from the restraints utilities
         # TODO: rename this class!
         atom_finder = FindHostAtoms(
@@ -1087,7 +1107,7 @@ class AbsoluteBindingUnitMixin:
             min_search_distance=settings['alchemical_settings'].alchemical_ion_min_distance,
             # set max distance to just above solvent padding to avoid picking
             # an ion more than half a box distance away
-            max_search_distance=settings['solvation_settings'].solvent_padding + 0.1 * offunit.nanometer,
+            max_search_distance=max_dist,
         )
 
         # only run on the final frame


### PR DESCRIPTION
Fixed some problems with the alchemical ion selection in the `net_charge_abfe` feature branch for an experimental implementation of ABFE calculations for charged ligands.

Issue 1: the previous implementation searches for ions by element name: https://github.com/OpenFreeEnergy/openfe/blob/d55d90cd8b9d19eff320c6796c23fb7060f67876/openfe/protocols/openmm_afe/equil_binding_afe_method.py#L1070 For larger ligands, this can end up selecting Cl atoms that have a distance >10 Angstrom to another atom in the ligand

Fix 1: select alchemical ions based on residue name ('NA', 'CL', 'K', et.c) - this excludes the ligand atoms as these have the residue name 'UNK'

Issue 2: the previous search volume for candidate ions uses a search shell with 1.0-1.1 nm distance radius. For a large protein, the closest ion can often be >1.1 nm away from the ligand - this returns no candidate ions. 

Fix 2: we can keep the 1.0 nm minimum distance but expand the maximum limit to a PBC safe distance. The safe limit is obtained by reading in the unit cell vectors and computing the cell inradius. The inradius minus a small buffer should ensure that we only select ions within the unit cell. The implementation should work for any triclinic cell. 

Testing: 
The new `_get_alchemical_ion` method was tested using 
[test_ion_selection.py](https://github.com/user-attachments/files/28830780/test_ion_selection.py) . Ion selection was performed for the ejm_52charg and jmc_32charg ligands from the [OpenFE Benchmark](https://github.com/OpenFreeEnergy/IndustryBenchmarks2024/tree/main/industry_benchmarks/input_structures/prepared_structures/charge_annihilation_set/tyk2) (equilibration performed using the default `AbsoluteBindingProtocol`. The test verified the following: 

- A suitable counterion is chosen (NA for a negative ligand, CL for a positive ligand)
- The selected alchemical ion is not a ligand atom
- The selected ion is within the distance cutoff, i.e. within the unit cell inradius

```
### ejm_52charg
  ligand total_charge = +1  ->  expecting counter-ion 'CL'
  unit cell [A,B,C,α,β,γ] : [78.31, 78.31, 78.31, 60.0, 60.0, 90.0]  (Å, deg)
  box vectors (Å):
      a = [  78.310    0.000    0.000]
      b = [   0.000   78.310    0.000]
      c = [  39.155   39.155   55.373]
  centre->edge (inradius) : 27.69 Å = 2.769 nm  (min-image radius; ion-search max = this - 0.1 nm)
  selected atom index : 34084
  resname / resid     : CL 10119
  distance to ligand  : 1.81 nm
  CHECK is expected counter-ion (CL): True
  CHECK not a ligand atom (UNK)               : True

### jmc_32charg
  ligand total_charge = -1  ->  expecting counter-ion 'NA'
  unit cell [A,B,C,α,β,γ] : [78.12, 78.12, 78.12, 60.0, 60.0, 90.0]  (Å, deg)
  box vectors (Å):
      a = [  78.124    0.000    0.000]
      b = [   0.000   78.124    0.000]
      c = [  39.062   39.062   55.242]
  centre->edge (inradius) : 27.62 Å = 2.762 nm  (min-image radius; ion-search max = this - 0.1 nm)
  selected atom index : 34049
  resname / resid     : NA 10089
  distance to ligand  : 0.87 nm
  CHECK is expected counter-ion (NA): True
  CHECK not a ligand atom (UNK)               : True

```

Note: the current 1.0 nm minimum distance applies to the pairwise ligand-counterion distances over *all ligand atoms* scanned using `FindHostAtoms`. This means that ions with a distance of <1.0 nm can be selected, as is the case for jmc_32charg (0.87 nm). This may be confusing for the user. We could easily fix this by filtering the atoms pairs explicitly with a minimum distance cutoff.

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
