### PR TITLE
Updated the CLI to use unbiased std for errors 

### DIFF
--- a/src/openfecli/commands/gather_abfe.py
+++ b/src/openfecli/commands/gather_abfe.py
@@ -150,9 +150,12 @@ def _get_legs_from_result_jsons(
 
 def _error_std(r):
     """
-    Calculate the error of the estimate as the std of the repeats
+    Calculate the error of the estimate as the unbiased std of the repeats
     """
-    return np.std([v[0].m for v in r["overall"]])
+    std = np.std([v[0].m for v in r["overall"]], ddof=1)
+    if np.isnan(std):
+        std = 0.0
+    return std
 
 
 def _error_mbar(r):

--- a/src/openfecli/commands/gather_septop.py
+++ b/src/openfecli/commands/gather_septop.py
@@ -163,9 +163,12 @@ def _get_names(result: dict) -> tuple[str, str]:
 
 def _error_std(r):
     """
-    Calculate the error of the estimate as the std of the repeats
+    Calculate the error of the estimate as the unbiased std of the repeats
     """
-    return np.std([v[0].m for v in r["overall"]])
+    std = np.std([v[0].m for v in r["overall"]], ddof=1)
+    if np.isnan(std):
+        std = 0.0
+    return std
 
 
 def _error_mbar(r):

--- a/src/openfecli/tests/commands/test_gather/test_abfe_full_results_multiple_units_dg_.tsv
+++ b/src/openfecli/tests/commands/test_gather/test_abfe_full_results_multiple_units_dg_.tsv
@@ -1,2 +1,2 @@
 ligand	DG (kcal/mol)	std dev uncertainty (kcal/mol)
-1	-20.87	0.47
+1	-20.87	0.58

--- a/src/openfecli/tests/commands/test_gather/test_abfe_full_results_single_unit_dg_.tsv
+++ b/src/openfecli/tests/commands/test_gather/test_abfe_full_results_single_unit_dg_.tsv
@@ -1,2 +1,2 @@
 ligand	DG (kcal/mol)	std dev uncertainty (kcal/mol)
-1	-18.36	0.98
+1	-18.4	1.2


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Follow on from #2000 updates the CLI error functions to report the unbiased std as the error.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

# Questions
- [ ] Do we want to update the gather CLIs to use the `get_estimate` and `get_uncertainty` protocol result functions to keep them in sync now or is this a 2.0 issue?
- [ ] If not can we have a single util function which calculates the error and is used in the protocols and the CLI, isolating the behaviour to a single place? 


Checklist
* [x] All new code is appropriately documented (user-facing code _must_ have complete docstrings).
* [ ] Added a ``news`` entry, or the changes are not user-facing.
* [ ] Ran pre-commit: you can run [pre-commit](https://pre-commit.com) locally or comment on this PR with `pre-commit.ci autofix`.

Manual Tests: these are slow so don't need to be run every commit, only before merging and when relevant changes are made (generally at reviewer-discretion). 
* [ ] [GPU integration tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/aws-gpu-integration-tests.yaml)
* [ ] [example notebook testing](https://github.com/OpenFreeEnergy/openfe/actions/workflows/release-prep-examplenotebooks.yaml)
* [ ] [packaging tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/cron-package-test.yaml): run this for any large feature PRs or PRs that add test data.


## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
