### PR TITLE
testing: catch konnektor warnings 

### DIFF
--- a/src/openfe/tests/setup/test_network_planning.py
+++ b/src/openfe/tests/setup/test_network_planning.py
@@ -280,11 +280,15 @@ class TestRadialNetworkGenerator:
         toluene, others = toluene_vs_others
         mappers = [BadMapper(), lomap_old_mapper]
 
-        network = openfe.setup.ligand_network_planning.generate_radial_network(
-            ligands=others,
-            central_ligand=toluene,
-            mappers=mappers,
-        )
+        with pytest.warns(
+            UserWarning,
+            match="Multiple mappers were provided, but no scorer. Only the first valid mapper will be used",
+        ):
+            network = openfe.setup.ligand_network_planning.generate_radial_network(
+                ligands=others,
+                central_ligand=toluene,
+                mappers=mappers,
+            )
 
         expected_names = set([c.name for c in others] + ["toluene"])
 
@@ -327,6 +331,7 @@ def test_generate_maximal_network(
     extra_mapper,
     lomap_old_mapper,
     simple_scorer,
+    recwarn,
 ):
     toluene, others = toluene_vs_others
 
@@ -343,6 +348,14 @@ def test_generate_maximal_network(
         scorer=scorer,
         progress=with_progress,
     )
+
+    if extra_mapper and scorer is None:
+        assert len(recwarn) == 1
+        w = recwarn.pop(UserWarning)
+        assert issubclass(w.category, UserWarning)
+        assert "Only the first valid mapper will be used: <LomapAtomMapper" in str(w.message)
+    else:
+        assert len(recwarn) == 0
 
     expected_names = set([c.name for c in others] + ["toluene"])
 
@@ -576,12 +589,13 @@ class TestGenerateNetworkFromNames:
             ("toluene", "2-naftanol"),
             ("2-methylnaphthalene", "2-naftanol"),
         ]
-
-        network = openfe.setup.ligand_network_planning.generate_network_from_names(
-            ligands=ligands,
-            names=requested_names,
-            mapper=lomap_old_mapper,
-        )
+        # we're only adding two edges, so there will be lone nodes
+        with pytest.warns(UserWarning, match="is not connected as a single network"):
+            network = openfe.setup.ligand_network_planning.generate_network_from_names(
+                ligands=ligands,
+                names=requested_names,
+                mapper=lomap_old_mapper,
+            )
 
         assert len(network.nodes) == len(ligands)
         assert len(network.edges) == 2
@@ -636,11 +650,13 @@ class TestNetworkFromIndices:
 
         requested = [(0, 1), (2, 3)]
 
-        network = openfe.setup.ligand_network_planning.generate_network_from_indices(
-            ligands=ligands,
-            indices=requested,
-            mapper=lomap_old_mapper,
-        )
+        # we're only adding two edges, so there will be lone nodes
+        with pytest.warns(UserWarning, match="is not connected as a single network"):
+            network = openfe.setup.ligand_network_planning.generate_network_from_indices(
+                ligands=ligands,
+                indices=requested,
+                mapper=lomap_old_mapper,
+            )
 
         assert len(network.nodes) == len(ligands)
         assert len(network.edges) == 2

--- a/src/openfecli/tests/commands/test_plan_rhfe_network.py
+++ b/src/openfecli/tests/commands/test_plan_rhfe_network.py
@@ -208,9 +208,10 @@ def test_custom_yaml_plan_rhfe_smoke_test(custom_yaml_settings, mol_dir_args, tm
     runner = CliRunner()
 
     with runner.isolated_filesystem():
-        result = runner.invoke(plan_rhfe_network, args)
+        with pytest.warns(UserWarning, match="for redundancy iteration 2"):
+            result = runner.invoke(plan_rhfe_network, args)
 
-        assert result.exit_code == 0
+            assert result.exit_code == 0
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
before we bump to the latest version of konnektor, I'd like to make sure we're catching warnings.
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

Checklist
* [x] All new code is appropriately documented (user-facing code _must_ have complete docstrings).
* [ ] Added a ``news`` entry, or the changes are not user-facing.
* [x] Ran pre-commit: you can run [pre-commit](https://pre-commit.com) locally or comment on this PR with `pre-commit.ci autofix`.

Manual Tests: these are slow so don't need to be run every commit, only before merging and when relevant changes are made (generally at reviewer-discretion). 
* [ ] [GPU integration tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/aws-gpu-integration-tests.yaml)
* [ ] [example notebook testing](https://github.com/OpenFreeEnergy/openfe/actions/workflows/release-prep-examplenotebooks.yaml)
* [ ] [packaging tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/cron-package-test.yaml): run this for any large feature PRs or PRs that add test data.


## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
