### PR TITLE
[MAINT] Try adding linux arm runner to openfe ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,8 +45,11 @@ jobs:
           - os: "ubuntu-latest"
             python-version: "3.13"
             openeye: "yes"
+          - os: "ubuntu-24.04-arm"
+            python-version: "3.13"
+            openeye: "no"
           - os: "macos-latest"
-            python-version: "3.12"
+            python-version: "3.13"
             openeye: "no"
 
     env:


### PR DESCRIPTION
Mostly out of curiosity, feel free to reject.

I added this running in MDAnalylsis' CI a few weeks back and it seems to perform really well. It might be worth testing here since arm linux + GPU is becoming the new normal (see DGX spark etc..).

Checklist
* [ ] All new code is appropriately documented (user-facing code _must_ have complete docstrings).
* [ ] Added a ``news`` entry, or the changes are not user-facing.
* [ ] Ran pre-commit: you can run [pre-commit](https://pre-commit.com) locally or comment on this PR with `pre-commit.ci autofix`.

Manual Tests: these are slow so don't need to be run every commit, only before merging and when relevant changes are made (generally at reviewer-discretion). 
* [ ] [GPU integration tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/aws-gpu-integration-tests.yaml)
* [ ] [example notebook testing](https://github.com/OpenFreeEnergy/openfe/actions/workflows/release-prep-examplenotebooks.yaml)
* [ ] [packaging tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/cron-package-test.yaml): run this for any large feature PRs or PRs that add test data.


## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
