### PR TITLE
ci: update condalock ci

### DIFF
--- a/.github/workflows/release-make-condalock.yaml
+++ b/.github/workflows/release-make-condalock.yaml
@@ -15,7 +15,6 @@ jobs:
     - name: Install conda-lock with Micromamba
       uses: mamba-org/setup-micromamba@v3
       with:
-        micromamba-version: '2.6.0-0'
         environment-name: conda-lock
         create-args: >-
           conda-lock

--- a/.github/workflows/release-make-condalock.yaml
+++ b/.github/workflows/release-make-condalock.yaml
@@ -18,7 +18,7 @@ jobs:
         micromamba-version: '2.6.0-0'
         environment-name: conda-lock
         create-args: >-
-          conda-lock==4.0.0
+          conda-lock
 
     # This saves me some time since we only need the latest tag
     - name: Get latest tag

--- a/.github/workflows/release-make-condalock.yaml
+++ b/.github/workflows/release-make-condalock.yaml
@@ -18,7 +18,7 @@ jobs:
         micromamba-version: '2.6.0-0'
         environment-name: conda-lock
         create-args: >-
-          conda-lock
+          conda-lock==4.0.0
 
     # This saves me some time since we only need the latest tag
     - name: Get latest tag

--- a/.github/workflows/release-make-condalock.yaml
+++ b/.github/workflows/release-make-condalock.yaml
@@ -15,6 +15,7 @@ jobs:
     - name: Install conda-lock with Micromamba
       uses: mamba-org/setup-micromamba@v3
       with:
+        micromamba-version: '2.6.0-0'
         environment-name: conda-lock
         create-args: >-
           conda-lock

--- a/.github/workflows/release-make-condalock.yaml
+++ b/.github/workflows/release-make-condalock.yaml
@@ -68,7 +68,7 @@ jobs:
     runs-on: macos-latest
     steps:
     - name: Download artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: conda-lock-files
 

--- a/.github/workflows/release-make-condalock.yaml
+++ b/.github/workflows/release-make-condalock.yaml
@@ -58,7 +58,7 @@ jobs:
         openfe test
 
     - name: Upload file as artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: conda-lock-files
         path: "*conda-lock.yml"

--- a/.github/workflows/release-make-condalock.yaml
+++ b/.github/workflows/release-make-condalock.yaml
@@ -13,7 +13,7 @@ jobs:
     
     steps:  
     - name: Install conda-lock with Micromamba
-      uses: mamba-org/setup-micromamba@v2
+      uses: mamba-org/setup-micromamba@v3
       with:
         environment-name: conda-lock
         create-args: >-

--- a/.github/workflows/release-make-condalock.yaml
+++ b/.github/workflows/release-make-condalock.yaml
@@ -49,7 +49,7 @@ jobs:
 
     - name: Generate lock files
       run: | 
-        conda lock --with-cuda 11.8 -f environment-to-lock.yaml --lockfile openfe-conda-lock.yml 
+        conda-lock --with-cuda 11.8 -f environment-to-lock.yaml --lockfile openfe-conda-lock.yml
         cp openfe-conda-lock.yml openfe-${{ steps.latest-version.outputs.VERSION }}-conda-lock.yml
 
     - name: Test lock file (linux)


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
we're seeing the following error message in our runners:

https://github.com/OpenFreeEnergy/openfe/actions/runs/28533414925/job/84588529819

```
conda lock --with-cuda 11.8 -f environment-to-lock.yaml --lockfile openfe-conda-lock.yml 
usage: conda [-h] [-v] [--no-plugins] [-V] COMMAND ...
conda: error: argument COMMAND: invalid choice: 'lock' (choose from activate, check, clean, commands, compare, config, content-trust, create, deactivate, doctor, env, export, info, init, install, list, menuinst, notices, package, remove, rename, repoquery, run, search, token, tos, uninstall, update, upgrade)


```
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

## LLM / AI generated code disclosure
<!-- Please update this disclosure to reflect if you did or did not use LLMs / AI to generate code -->
LLMs or other AI-powered tools (beyond simple IDE use cases) were used in this contribution: no
If yes, please provide details here:

Checklist
* [x] All new code is appropriately documented (user-facing code _must_ have complete docstrings).
* [x] Added a ``news`` entry, or the changes are not user-facing.
* [x] Ran pre-commit: you can run [pre-commit](https://pre-commit.com) locally or comment on this PR with `pre-commit.ci autofix`.
* [x] Filled in the AI generated code disclosure.

Manual Tests: these are slow so don't need to be run every commit, only before merging and when relevant changes are made (generally at reviewer-discretion). 
* [ ] [GPU integration tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/aws-gpu-integration-tests.yaml)
* [ ] [example notebook testing](https://github.com/OpenFreeEnergy/openfe/actions/workflows/release-prep-examplenotebooks.yaml)
* [ ] [packaging tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/cron-package-test.yaml): run this for any large feature PRs or PRs that add test data.

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
