### PR TITLE
ci: update docker build env

### DIFF
--- a/.github/workflows/release-docker-image.yaml
+++ b/.github/workflows/release-docker-image.yaml
@@ -71,7 +71,7 @@ jobs:
           df -h
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -119,7 +119,7 @@ jobs:
             ${{ steps.latest-version.outputs.VERSION }}
 
       - name: Build and export to Docker
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: production/Dockerfile

--- a/production/Dockerfile
+++ b/production/Dockerfile
@@ -1,4 +1,4 @@
-FROM mambaorg/micromamba:1.4.1
+FROM mambaorg/micromamba:2.4
 
 LABEL org.opencontainers.image.source=https://github.com/OpenFreeEnergy/openfe
 LABEL org.opencontainers.image.description="A Python package for executing alchemical free energy calculations."

--- a/production/environment.yml
+++ b/production/environment.yml
@@ -11,4 +11,4 @@ dependencies:
   - pytest
   - pytest-xdist
   - python==3.12.*
-  - rdkit==2025.09.*
+  - rdkit>=2025.09.1  # https://github.com/OpenFreeEnergy/gufe/pull/665

--- a/production/environment.yml
+++ b/production/environment.yml
@@ -10,5 +10,5 @@ dependencies:
   - py3dmol
   - pytest
   - pytest-xdist
-  - python==3.12.*
+  - python==3.13.*
   - rdkit>=2025.09.1  # https://github.com/OpenFreeEnergy/gufe/pull/665

--- a/production/environment.yml
+++ b/production/environment.yml
@@ -2,7 +2,7 @@ name: openfe_env
 channels:
   - conda-forge
 dependencies:
-  # - cudatoolkit >=11.8
+  - cudatoolkit >=11.8
   - jupyterlab
   - notebook
   - openfe

--- a/production/environment.yml
+++ b/production/environment.yml
@@ -2,7 +2,7 @@ name: openfe_env
 channels:
   - conda-forge
 dependencies:
-  - cudatoolkit >=11.8
+  - cudatoolkit==11.8
   - jupyterlab
   - notebook
   - openfe
@@ -10,5 +10,5 @@ dependencies:
   - py3dmol
   - pytest
   - pytest-xdist
-  - python >=3.12
-  - rdkit ~=2025.09.1  # https://github.com/OpenFreeEnergy/gufe/pull/665, https://github.com/OpenFreeEnergy/openfe/pull/2068
+  - python==3.12.*
+  - rdkit~=2025.09.1  # https://github.com/OpenFreeEnergy/gufe/pull/665, https://github.com/OpenFreeEnergy/openfe/pull/2068

--- a/production/environment.yml
+++ b/production/environment.yml
@@ -11,4 +11,4 @@ dependencies:
   - pytest
   - pytest-xdist
   - python==3.12.*
-  - rdkit==2025.09.1
+  - rdkit==2025.09.*

--- a/production/environment.yml
+++ b/production/environment.yml
@@ -11,4 +11,4 @@ dependencies:
   - pytest
   - pytest-xdist
   - python >=3.12
-  - rdkit >=2025.09.1  # https://github.com/OpenFreeEnergy/gufe/pull/665
+  - rdkit ~=2025.09.1  # https://github.com/OpenFreeEnergy/gufe/pull/665, https://github.com/OpenFreeEnergy/openfe/pull/2068

--- a/production/environment.yml
+++ b/production/environment.yml
@@ -2,7 +2,7 @@ name: openfe_env
 channels:
   - conda-forge
 dependencies:
-  - cudatoolkit
+  - cudatoolkit >=11.8
   - jupyterlab
   - notebook
   - openfe
@@ -10,5 +10,5 @@ dependencies:
   - py3dmol
   - pytest
   - pytest-xdist
-  - python
-  - rdkit>=2025.09.1  # https://github.com/OpenFreeEnergy/gufe/pull/665
+  - python >=3.12
+  - rdkit >=2025.09.1  # https://github.com/OpenFreeEnergy/gufe/pull/665

--- a/production/environment.yml
+++ b/production/environment.yml
@@ -2,7 +2,7 @@ name: openfe_env
 channels:
   - conda-forge
 dependencies:
-  - cudatoolkit==11.8
+  - cudatoolkit
   - jupyterlab
   - notebook
   - openfe
@@ -10,5 +10,5 @@ dependencies:
   - py3dmol
   - pytest
   - pytest-xdist
-  - python==3.13.*
+  - python
   - rdkit>=2025.09.1  # https://github.com/OpenFreeEnergy/gufe/pull/665

--- a/production/environment.yml
+++ b/production/environment.yml
@@ -2,7 +2,7 @@ name: openfe_env
 channels:
   - conda-forge
 dependencies:
-  - cudatoolkit >=11.8
+  # - cudatoolkit >=11.8
   - jupyterlab
   - notebook
   - openfe

--- a/production/environment.yml
+++ b/production/environment.yml
@@ -2,7 +2,7 @@ name: openfe_env
 channels:
   - conda-forge
 dependencies:
-  - cudatoolkit==13.*
+  - cudatoolkit==11.8
   - jupyterlab
   - notebook
   - openfe

--- a/production/environment.yml
+++ b/production/environment.yml
@@ -2,7 +2,7 @@ name: openfe_env
 channels:
   - conda-forge
 dependencies:
-  - cudatoolkit==11.8
+  - cudatoolkit==13.*
   - jupyterlab
   - notebook
   - openfe


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

## LLM / AI generated code disclosure
<!-- Please update this disclosure to reflect if you did or did not use LLMs / AI to generate code -->
LLMs or other AI-powered tools (beyond simple IDE use cases) were used in this contribution: no

addressing environment solving issues seen at: https://github.com/OpenFreeEnergy/openfe/actions/runs/28526960381/job/84565896358

Checklist
* [x] All new code is appropriately documented (user-facing code _must_ have complete docstrings).
* [x] Added a ``news`` entry, or the changes are not user-facing.
* [x] Ran pre-commit: you can run [pre-commit](https://pre-commit.com) locally or comment on this PR with `pre-commit.ci autofix`.
* [x] Filled in the AI generated code disclosure.

Manual Tests: these are slow so don't need to be run every commit, only before merging and when relevant changes are made (generally at reviewer-discretion). 
* [ ] [GPU integration tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/aws-gpu-integration-tests.yaml)
* [ ] [example notebook testing](https://github.com/OpenFreeEnergy/openfe/actions/workflows/release-prep-examplenotebooks.yaml)
* [ ] [packaging tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/cron-package-test.yaml): run this for any large feature PRs or PRs that add test data.

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
