### PR TITLE
Test Ambertools 26

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,9 @@
 name: openfe_env
 channels:
+  - mmh/label/amber26
   - conda-forge
 dependencies:
+  - ambertools >= 26
   - cinnabar >=0.6.0  # min pin for some API breaks and behavior changes in 0.6.0
   - click >=8.2.0
   - coverage

--- a/environment.yml
+++ b/environment.yml
@@ -21,7 +21,6 @@ dependencies:
   - openff-toolkit-base >=0.16.2
   - openff-units==0.3.1  # https://github.com/OpenFreeEnergy/openfe/pull/1374
   - openmm ~=8.4.0  # omit 8.3.0 and 8.3.1 due to https://github.com/openmm/openmm/pull/5069
-  - openmmforcefields >=0.15.1  # min needed for https://github.com/openmm/openmmforcefields/pull/414
   - openmmtools >=0.26  # fix to support membrane barostat: https://github.com/choderalab/openmmtools/pull/798
   - packaging
   - pandas
@@ -55,6 +54,7 @@ dependencies:
   - threadpoolctl
   - pip:
     - git+https://github.com/OpenFreeEnergy/gufe@main
+    - git+https://github.com/openmm/openmmforcefields.git@0.16.0
   - run_constrained:
     # drop this pin when handled upstream in espaloma-feedstock
     - smirnoff99frosst>=1.1.0.1  #https://github.com/openforcefield/smirnoff99Frosst/issues/109

--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,7 @@ channels:
   - mmh/label/amber26
   - conda-forge
 dependencies:
+  - openff-packmol
   - ambertools >= 26
   - cinnabar >=0.6.0  # min pin for some API breaks and behavior changes in 0.6.0
   - click >=8.2.0


### PR DESCRIPTION
I've tested ambertools 26 in openmmforcefields + the openff-toolkit ecosystem, but wanted to make sure we didn't up with any surprises here. I might need to skip the espaloma tests since it might not work with esplaoma b/c of ABI/env issues with things like pytorch or dgl.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

## LLM / AI generated code disclosure
<!-- Please update this disclosure to reflect if you did or did not use LLMs / AI to generate code -->
LLMs or other AI-powered tools (beyond simple IDE use cases) were used in this contribution: no
If yes, please provide details here:

Checklist
* [ ] All new code is appropriately documented (user-facing code _must_ have complete docstrings).
* [ ] Added a ``news`` entry, or the changes are not user-facing.
* [ ] Ran pre-commit: you can run [pre-commit](https://pre-commit.com) locally or comment on this PR with `pre-commit.ci autofix`.
* [ ] Filled in the AI generated code disclosure.

Manual Tests: these are slow so don't need to be run every commit, only before merging and when relevant changes are made (generally at reviewer-discretion). 
* [ ] [GPU integration tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/aws-gpu-integration-tests.yaml)
* [ ] [example notebook testing](https://github.com/OpenFreeEnergy/openfe/actions/workflows/release-prep-examplenotebooks.yaml)
* [ ] [packaging tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/cron-package-test.yaml): run this for any large feature PRs or PRs that add test data.

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
