### PR TITLE
Update docstrings and warnings with updated convergence analysis

### DIFF
--- a/src/openfe/protocols/openmm_afe/afe_protocol_results.py
+++ b/src/openfe/protocols/openmm_afe/afe_protocol_results.py
@@ -64,15 +64,19 @@ class AbsoluteProtocolResultMixin:
               - `fractions`: npt.NDArray
                   The fractions of data used for the estimates
               - `forward_DGs`, `reverse_DGs`: openff.units.Quantity
-                  The forward and reverse estimates for each fraction of data
+                  The forward and reverse estimates for each fraction of data.
+                  A fraction at which MBAR failed to converge is recorded as
+                  ``NaN`` in both directions.
               - `forward_dDGs`, `reverse_dDGs`: openff.units.Quantity
                   The forward and reverse estimate uncertainty for each
-                  fraction of data.
+                  fraction of data (``NaN`` wherever the estimate is ``NaN``).
 
-            If one of the cycle leg list entries is ``None``, this indicates
-            that the analysis could not be carried out for that repeat. This
-            is most likely caused by MBAR convergence issues when attempting to
-            calculate free energies from too few samples.
+            A cycle leg list entry is ``None`` only when MBAR could not obtain
+            an estimate from the *full* set of uncorrelated samples (the
+            fraction 1.0 estimate, i.e. the reported free energy). If MBAR
+            fails only at a lower fraction, that fraction is recorded as ``NaN``
+            (see ``forward_DGs`` above) and the remaining fractions are
+            retained, so the entry is still a dictionary.
 
         Raises
         ------
@@ -93,9 +97,9 @@ class AbsoluteProtocolResultMixin:
                 wmsg = (
                     "One or more ``None`` entries were found in the forward "
                     f"and reverse dictionaries of the repeats of the {key} "
-                    "calculations. This is likely caused by an MBAR convergence "
-                    "failure caused by too few independent samples when "
-                    "calculating the free energies of the 10% timeseries slice."
+                    "calculations. This indicates that MBAR could not obtain a "
+                    "free energy estimate from the full set of uncorrelated "
+                    "samples for that repeat."
                 )
                 warnings.warn(wmsg)
 

--- a/src/openfe/protocols/openmm_rfe/hybridtop_protocol_results.py
+++ b/src/openfe/protocols/openmm_rfe/hybridtop_protocol_results.py
@@ -104,12 +104,14 @@ class RelativeHybridTopologyProtocolResult(gufe.ProtocolResult):
         'forward_dDGs', 'reverse_dDGs' - for each estimate, the uncertainty
 
         The 'fractions' values are a numpy array, while the other arrays are
-        Quantity arrays, with units attached.
+        Quantity arrays, with units attached. A fraction at which MBAR failed
+        to converge is recorded as ``NaN`` in both directions.
 
-        If the list entry is ``None`` instead of a dictionary, this indicates
-        that the analysis could not be carried out for that repeat. This
-        is most likely caused by MBAR convergence issues when attempting to
-        calculate free energies from too few samples.
+        A list entry is ``None`` only when MBAR could not obtain an estimate
+        from the full set of uncorrelated samples (the fraction 1.0 estimate,
+        i.e. the reported free energy) for that repeat. If MBAR fails only at a
+        lower fraction, that fraction is recorded as ``NaN`` and the remaining
+        fractions are retained, so the entry is still a dictionary.
 
 
         Returns
@@ -129,10 +131,9 @@ class RelativeHybridTopologyProtocolResult(gufe.ProtocolResult):
         if None in forward_reverse:
             wmsg = (
                 "One or more ``None`` entries were found in the list of "
-                "forward and reverse analyses. This is likely caused by "
-                "an MBAR convergence failure caused by too few independent "
-                "samples when calculating the free energies of the 10% "
-                "timeseries slice."
+                "forward and reverse analyses. This indicates that MBAR could "
+                "not obtain a free energy estimate from the full set of "
+                "uncorrelated samples for that repeat."
             )
             warnings.warn(wmsg)
 

--- a/src/openfe/protocols/openmm_septop/septop_protocol_results.py
+++ b/src/openfe/protocols/openmm_septop/septop_protocol_results.py
@@ -274,15 +274,19 @@ class SepTopProtocolResult(gufe.ProtocolResult):
               - `fractions`: npt.NDArray
                   The fractions of data used for the estimates
               - `forward_DDGs`, `reverse_DDGs`: unit.Quantity
-                  The forward and reverse estimates for each fraction of data
+                  The forward and reverse estimates for each fraction of data.
+                  A fraction at which MBAR failed to converge is recorded as
+                  ``NaN`` in both directions.
               - `forward_dDDGs`, `reverse_dDDGs`: unit.Quantity
                   The forward and reverse estimate uncertainty for each
-                  fraction of data.
+                  fraction of data (``NaN`` wherever the estimate is ``NaN``).
 
-            If one of the cycle leg list entries is ``None``, this indicates
-            that the analysis could not be carried out for that repeat. This
-            is most likely caused by MBAR convergence issues when attempting to
-            calculate free energies from too few samples.
+            A cycle leg list entry is ``None`` only when MBAR could not obtain
+            an estimate from the *full* set of uncorrelated samples (the
+            fraction 1.0 estimate, i.e. the reported free energy). If MBAR
+            fails only at a lower fraction, that fraction is recorded as ``NaN``
+            (see ``forward_DDGs`` above) and the remaining fractions are
+            retained, so the entry is still a dictionary.
 
         Raises
         ------
@@ -302,9 +306,9 @@ class SepTopProtocolResult(gufe.ProtocolResult):
                 wmsg = (
                     "One or more ``None`` entries were found in the forward "
                     f"and reverse dictionaries of the repeats of the {key} "
-                    "calculations. This is likely caused by an MBAR convergence "
-                    "failure caused by too few independent samples when "
-                    "calculating the free energies of the 10% timeseries slice."
+                    "calculations. This indicates that MBAR could not obtain a "
+                    "free energy estimate from the full set of uncorrelated "
+                    "samples for that repeat."
                 )
                 warnings.warn(wmsg)
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

This PR (no logic change) updates the docstrings and warning messages left stale by the recently merged #1984. #1984 changed the forward/reverse analysis so a partial result is returned when MBAR fails at a fraction below 100% of the uncorrelated samples — that fraction is recorded as `NaN` (both directions) and the rest are retained; `None` is returned only when MBAR fails on the full sample set. Here we bring the `ProtocolResult.get_forward_and_reverse_energy_analysis` docstrings (AFE, RFE, SepTop) and their None-entry warnings in line with that behaviour.

## LLM / AI generated code disclosure
<!-- Please update this disclosure to reflect if you did or did not use LLMs / AI to generate code -->
LLMs or other AI-powered tools (beyond simple IDE use cases) were used in this contribution: no

Checklist
* [x] All new code is appropriately documented (user-facing code _must_ have complete docstrings).
* [x]  ``news`` entry added in #1984 
* [x] Ran pre-commit: you can run [pre-commit](https://pre-commit.com) locally or comment on this PR with `pre-commit.ci autofix`.
* [x] Filled in the AI generated code disclosure.

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
