### PR TITLE
Raise an error for empty HybridTopology atom mappings

### DIFF
--- a/news/empty_mapping_validation.rst
+++ b/news/empty_mapping_validation.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* The RelativeHybridTopologyProtocol will now raise a ValueError during validation if the atom mapping is empty preventing execution of the simulation.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/openfe/protocols/openmm_rfe/hybridtop_protocols.py
+++ b/src/openfe/protocols/openmm_rfe/hybridtop_protocols.py
@@ -299,7 +299,6 @@ class RelativeHybridTopologyProtocol(gufe.Protocol):
             if not m.componentA_to_componentB:
                 raise ValueError("No atoms are mapped between the two alchemical components.")
 
-
     @staticmethod
     def _validate_smcs(
         stateA: ChemicalSystem,

--- a/src/openfe/protocols/openmm_rfe/hybridtop_protocols.py
+++ b/src/openfe/protocols/openmm_rfe/hybridtop_protocols.py
@@ -274,6 +274,7 @@ class RelativeHybridTopologyProtocol(gufe.Protocol):
         ValueError
           * If there are more than one mapping or mapping is None
           * If the mapping components are not in the alchemical components.
+          * If the atom mapping is empty.
         """
         # if a single mapping is provided, convert to list
         if isinstance(mapping, ComponentMapping):
@@ -293,6 +294,11 @@ class RelativeHybridTopologyProtocol(gufe.Protocol):
                         f"Mapping component{state} {comp} not "
                         f"in alchemical components of state{state}"
                     )
+
+            # make sure the mapping is not empty
+            if not m.componentA_to_componentB:
+                raise ValueError("No atoms are mapped between the two alchemical components.")
+
 
     @staticmethod
     def _validate_smcs(

--- a/src/openfe/tests/protocols/openmm_rfe/test_hybrid_top_protocol.py
+++ b/src/openfe/tests/protocols/openmm_rfe/test_hybrid_top_protocol.py
@@ -2556,12 +2556,12 @@ def test_empty_atom_mapping(tmp_path, benzene_vacuum_system, toluene_vacuum_syst
         componentA_to_componentB={},
     )
 
-    with pytest.raises(ValueError, match="No atoms are mapped between the two alchemical components."):
+    with pytest.raises(
+        ValueError, match="No atoms are mapped between the two alchemical components."
+    ):
         # create the DAG and run validation
         _ = protocol.create(
             stateA=benzene_vacuum_system,
             stateB=toluene_vacuum_system,
             mapping=blank_mapping,
         )
-
-

--- a/src/openfe/tests/protocols/openmm_rfe/test_hybrid_top_protocol.py
+++ b/src/openfe/tests/protocols/openmm_rfe/test_hybrid_top_protocol.py
@@ -2541,3 +2541,27 @@ def test_structural_analysis_uses_ligand_resnames(tmp_path):
         )
 
     assert captured["ligand_selection"] == "resname LIG"
+
+
+def test_empty_atom_mapping(tmp_path, benzene_vacuum_system, toluene_vacuum_system, vac_settings):
+    """Make sure an informative error is raised if the user supplies an empty atom mapping which is not supported."""
+
+    protocol = openmm_rfe.RelativeHybridTopologyProtocol(
+        settings=vac_settings,
+    )
+
+    blank_mapping = gufe.LigandAtomMapping(
+        componentA=benzene_vacuum_system["ligand"],
+        componentB=toluene_vacuum_system["ligand"],
+        componentA_to_componentB={},
+    )
+
+    with pytest.raises(ValueError, match="No atoms are mapped between the two alchemical components."):
+        # create the DAG and run validation
+        _ = protocol.create(
+            stateA=benzene_vacuum_system,
+            stateB=toluene_vacuum_system,
+            mapping=blank_mapping,
+        )
+
+


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
The protocol currently allows atom mappings to be empty, resulting in an uninformative indexing error in validation, this PR adds validation specifically for this case.
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

## LLM / AI generated code disclosure
<!-- Please update this disclosure to reflect if you did or did not use LLMs / AI to generate code -->
LLMs or other AI-powered tools (beyond simple IDE use cases) were used in this contribution: yes / no
If yes, please provide details here: No

Checklist
* [ ] All new code is appropriately documented (user-facing code _must_ have complete docstrings).
* [x] Added a ``news`` entry, or the changes are not user-facing.
* [x] Ran pre-commit: you can run [pre-commit](https://pre-commit.com) locally or comment on this PR with `pre-commit.ci autofix`.
* [x] Filled in the AI generated code disclosure.

Manual Tests: these are slow so don't need to be run every commit, only before merging and when relevant changes are made (generally at reviewer-discretion). 
* [ ] [GPU integration tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/aws-gpu-integration-tests.yaml)
* [ ] [example notebook testing](https://github.com/OpenFreeEnergy/openfe/actions/workflows/release-prep-examplenotebooks.yaml)
* [ ] [packaging tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/cron-package-test.yaml): run this for any large feature PRs or PRs that add test data.

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
