### PR TITLE
CLI: add command for gathering results from a warehouse

### DIFF
--- a/src/openfecli/commands/gather_warehouse.py
+++ b/src/openfecli/commands/gather_warehouse.py
@@ -1,0 +1,52 @@
+import os
+import pathlib
+import sys
+from typing import List, Literal
+
+import click
+import numpy as np
+import pandas as pd
+
+from openfecli import OFECommandPlugin
+
+# from openfecli.utils import rich_print_to_stdout
+
+
+@click.command(
+    "gather-warehouse",
+    short_help="Gather results from a Warehouse and return the raw values",
+)
+@click.argument(
+    "warehouse_path",
+    nargs=1,  # accept any number of results
+    type=click.Path(dir_okay=True, file_okay=False, path_type=pathlib.Path),
+    required=True,
+)
+def gather_warehouse(
+    warehouse_path: os.PathLike | str,
+):
+    """
+    .. warning::
+
+        Gathering of results with ``openfe gather-warehouse`` is an experimental feature
+        and is subject to change in a future release of openfe!
+
+    Gather simulation results from the `results` store of a Warehouse and output the raw results.
+
+    """
+    from openfe.storage.warehouse import FileSystemWarehouse
+
+    msg = "WARNING! Warehouse and Workers are experimental features and subject to change in a future release of openfe."
+    click.secho(msg, err=True, fg="yellow")  # fmt: skip
+
+    warehouse = FileSystemWarehouse.from_dir(warehouse_path)
+    raw_results = warehouse.gather_all_results()
+
+    # rich_print_to_stdout(df)
+
+
+PLUGIN = OFECommandPlugin(
+    command=gather_warehouse,
+    section="Quickrun Executor",
+    requires_ofe=(0, 6),
+)


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

## LLM / AI generated code disclosure
<!-- Please update this disclosure to reflect if you did or did not use LLMs / AI to generate code -->
LLMs or other AI-powered tools (beyond simple IDE use cases) were used in this contribution: no


Checklist
* [ ] All new code is appropriately documented (user-facing code _must_ have complete docstrings).
* [ ] Added a ``news`` entry, or the changes are not user-facing.
* [ ] Ran pre-commit: you can run [pre-commit](https://pre-commit.com) locally or comment on this PR with `pre-commit.ci autofix`.
* [ ] Filled in the AI generated code disclosure.

Manual Tests: these are slow so don't need to be run every commit, only before merging and when relevant changes are made (generally at reviewer-discretion). 
* [ ] [GPU integration tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/aws-gpu-integration-tests.yaml)
* [ ] [example notebook testing](https://github.com/OpenFreeEnergy/openfe/actions/workflows/release-prep-examplenotebooks.yaml)
* [ ] [packaging tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/cron-package-test.yaml): run this for any large feature PRs or PRs that add test data.

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
