### PR TITLE
update cli sections

### DIFF
--- a/news/cli_headers.rst
+++ b/news/cli_headers.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Changed CLI sections from "Network Planning", "Quickrun Exectutor" and "Miscellaneous" to "Planning & Setup", "Execution", "Results Gathering", and "Miscellaneous".
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/openfecli/cli.py
+++ b/src/openfecli/cli.py
@@ -14,7 +14,7 @@ from openfecli.plugins import OFECommandPlugin
 
 class OpenFECLI(CLI):
     # COMMAND_SECTIONS = ["Setup", "Simulation", "Orchestration", "Analysis"]
-    COMMAND_SECTIONS = ["Network Planning", "Quickrun Executor", "Miscellaneous"]
+    COMMAND_SECTIONS = ["Planning & Setup", "Execution", "Results Gathering", "Miscellaneous"]
 
     def get_loaders(self):
         commands = str(pathlib.Path(__file__).parent.resolve() / "commands")

--- a/src/openfecli/commands/gather.py
+++ b/src/openfecli/commands/gather.py
@@ -803,11 +803,7 @@ def gather(
         rich_print_to_stdout(df)
 
 
-PLUGIN = OFECommandPlugin(
-    command=gather,
-    section="Quickrun Executor",
-    requires_ofe=(0, 6),
-)
+PLUGIN = OFECommandPlugin(command=gather, section="Results Gathering", requires_ofe=(0, 6))
 
 if __name__ == "__main__":
     gather()

--- a/src/openfecli/commands/gather_abfe.py
+++ b/src/openfecli/commands/gather_abfe.py
@@ -360,8 +360,4 @@ def gather_abfe(
         rich_print_to_stdout(df)
 
 
-PLUGIN = OFECommandPlugin(
-    command=gather_abfe,
-    section="Quickrun Executor",
-    requires_ofe=(0, 6),
-)
+PLUGIN = OFECommandPlugin(command=gather_abfe, section="Results Gathering", requires_ofe=(0, 6))

--- a/src/openfecli/commands/gather_septop.py
+++ b/src/openfecli/commands/gather_septop.py
@@ -451,8 +451,4 @@ def gather_septop(
         rich_print_to_stdout(df)
 
 
-PLUGIN = OFECommandPlugin(
-    command=gather_septop,
-    section="Quickrun Executor",
-    requires_ofe=(0, 6),
-)
+PLUGIN = OFECommandPlugin(command=gather_septop, section="Results Gathering", requires_ofe=(0, 6))

--- a/src/openfecli/commands/generate_partial_charges.py
+++ b/src/openfecli/commands/generate_partial_charges.py
@@ -94,4 +94,4 @@ def charge_molecules(molecules, yaml_settings, output, n_cores, overwrite_charge
             output.write(mol.to_sdf())
 
 
-PLUGIN = OFECommandPlugin(command=charge_molecules, section="Miscellaneous", requires_ofe=(0, 3))
+PLUGIN = OFECommandPlugin(command=charge_molecules, section="Planning & Setup", requires_ofe=(1, 3))

--- a/src/openfecli/commands/plan_rbfe_network.py
+++ b/src/openfecli/commands/plan_rbfe_network.py
@@ -263,5 +263,5 @@ def plan_rbfe_network(
 
 
 PLUGIN = OFECommandPlugin(
-    command=plan_rbfe_network, section="Network Planning", requires_ofe=(0, 3)
+    command=plan_rbfe_network, section="Planning & Setup", requires_ofe=(0, 3)
 )

--- a/src/openfecli/commands/plan_rhfe_network.py
+++ b/src/openfecli/commands/plan_rhfe_network.py
@@ -216,5 +216,5 @@ def plan_rhfe_network(
 
 
 PLUGIN = OFECommandPlugin(
-    command=plan_rhfe_network, section="Network Planning", requires_ofe=(0, 3)
+    command=plan_rhfe_network, section="Planning & Setup", requires_ofe=(0, 3)
 )

--- a/src/openfecli/commands/quickrun.py
+++ b/src/openfecli/commands/quickrun.py
@@ -203,7 +203,7 @@ def quickrun(transformation, work_dir, output, resume):
         )
 
 
-PLUGIN = OFECommandPlugin(command=quickrun, section="Quickrun Executor", requires_ofe=(0, 3))
+PLUGIN = OFECommandPlugin(command=quickrun, section="Execution", requires_ofe=(0, 3))
 
 if __name__ == "__main__":
     quickrun()

--- a/src/openfecli/commands/status.py
+++ b/src/openfecli/commands/status.py
@@ -73,4 +73,4 @@ def status(task_db_path: pathlib.Path):
     status_main(task_db_path=task_db_path)
 
 
-PLUGIN = OFECommandPlugin(command=status, section="Execution", requires_ofe=(1, 12))
+PLUGIN = OFECommandPlugin(command=status, section="Execution", requires_ofe=(1, 13))

--- a/src/openfecli/commands/status.py
+++ b/src/openfecli/commands/status.py
@@ -73,4 +73,4 @@ def status(task_db_path: pathlib.Path):
     status_main(task_db_path=task_db_path)
 
 
-PLUGIN = OFECommandPlugin(command=status, section="Quickrun Executor", requires_ofe=(0, 3))
+PLUGIN = OFECommandPlugin(command=status, section="Execution", requires_ofe=(1, 12))

--- a/src/openfecli/commands/view_ligand_network.py
+++ b/src/openfecli/commands/view_ligand_network.py
@@ -33,6 +33,6 @@ def view_ligand_network(ligand_network: os.PathLike):
 
 PLUGIN = OFECommandPlugin(
     command=view_ligand_network,
-    section="Network Planning",
+    section="Planning & Setup",
     requires_ofe=(0, 7, 0),
 )

--- a/src/openfecli/commands/worker.py
+++ b/src/openfecli/commands/worker.py
@@ -130,4 +130,4 @@ def worker(warehouse_path: pathlib.Path, scratch: pathlib.Path | None):
     worker_main(warehouse_path=warehouse_path, scratch=scratch)
 
 
-PLUGIN = OFECommandPlugin(command=worker, section="Quickrun Executor", requires_ofe=(0, 3))
+PLUGIN = OFECommandPlugin(command=worker, section="Execution", requires_ofe=(1, 12))

--- a/src/openfecli/commands/worker.py
+++ b/src/openfecli/commands/worker.py
@@ -130,4 +130,4 @@ def worker(warehouse_path: pathlib.Path, scratch: pathlib.Path | None):
     worker_main(warehouse_path=warehouse_path, scratch=scratch)
 
 
-PLUGIN = OFECommandPlugin(command=worker, section="Execution", requires_ofe=(1, 12))
+PLUGIN = OFECommandPlugin(command=worker, section="Execution", requires_ofe=(1, 13))

--- a/src/openfecli/tests/test_cli.py
+++ b/src/openfecli/tests/test_cli.py
@@ -50,7 +50,7 @@ class TestCLI:
         # This test does not ensure the order of the sections, and does not
         # prevent other sections from being added later. It only ensures
         # that the main 4 sections continue to exist.
-        included = ["Network Planning", "Quickrun Executor", "Miscellaneous"]
+        included = ["Planning & Setup", "Execution", "Results Gathering", "Miscellaneous"]
         for sec in included:
             assert sec in cli.COMMAND_SECTIONS
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.

now looks like:

<img width="795" height="666" alt="Screenshot 2026-08-21 at 1 10 19 PM" src="https://github.com/user-attachments/assets/60b28fcb-c7cd-4c3b-8f77-e33b230d9579" />

-->
ahead of adding more CLI commands, we should split these into Plan/Run/Gather so they have homes that make sense.
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

## LLM / AI generated code disclosure
<!-- Please update this disclosure to reflect if you did or did not use LLMs / AI to generate code -->
LLMs or other AI-powered tools (beyond simple IDE use cases) were used in this contribution: no


Checklist
* [x] All new code is appropriately documented (user-facing code _must_ have complete docstrings).
* [x] Added a ``news`` entry, or the changes are not user-facing.
* [x] Ran pre-commit: you can run [pre-commit](https://pre-commit.com) locally or comment on this PR with `pre-commit.ci autofix`.
* [x] Filled in the AI generated code disclosure.

Manual Tests: these are slow so don't need to be run every commit, only before merging and when relevant changes are made (generally at reviewer-discretion). 
* [ ] [GPU integration tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/aws-gpu-integration-tests.yaml)
* [ ] [example notebook testing](https://github.com/OpenFreeEnergy/openfe/actions/workflows/release-prep-examplenotebooks.yaml)
* [ ] [packaging tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/cron-package-test.yaml): run this for any large feature PRs or PRs that add test data.

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
