### PR TITLE
Validate the vacuum and solvent force field settings in ASFE

### DIFF
--- a/news/asfe_ff_validation.rst
+++ b/news/asfe_ff_validation.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* The ``AbsoluteSolvationProtocol`` will now raise a ``ValueError`` during validation if the solvent and vaccum force field settings do not match exactally after excluding the ``nonbonded_method`` field.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/asfe_ff_validation.rst
+++ b/news/asfe_ff_validation.rst
@@ -4,6 +4,8 @@
 
 **Changed:**
 
+* The ``AbsoluteSolvationSettings`` class will now raise a ``ValueError`` if initialized with nonidentical solvent and vaccum force field settings after excluding the ``nonbonded_method`` field.
+
 * The ``AbsoluteSolvationProtocol`` will now raise a ``ValueError`` during validation if the solvent and vaccum force field settings do not match exactally after excluding the ``nonbonded_method`` field.
 
 **Deprecated:**

--- a/src/openfe/protocols/openmm_afe/equil_afe_settings.py
+++ b/src/openfe/protocols/openmm_afe/equil_afe_settings.py
@@ -246,6 +246,31 @@ class AbsoluteSolvationSettings(SettingsBaseModel):
     solvent_forcefield_settings: OpenMMSystemGeneratorFFSettings
     vacuum_forcefield_settings: OpenMMSystemGeneratorFFSettings
     """Parameters to set up the force field with OpenMM Force Fields"""
+
+    @model_validator(mode="after")
+    def vacuum_and_solvent_forcefield_settings_must_match(self):
+        vac_settings = self.vacuum_forcefield_settings.model_dump(
+            exclude={"nonbonded_method"}
+        )
+        solvent_settings = self.solvent_forcefield_settings.model_dump(
+            exclude={"nonbonded_method"}
+        )
+
+        if vac_settings != solvent_settings:
+            errmsg = (
+                "The vacuum and solvent force field settings must match "
+                "except for the nonbonded_method. The following settings differ:\n"
+            )
+            for k in vac_settings.keys():
+                if vac_settings[k] != solvent_settings[k]:
+                    errmsg += (
+                        f"  {k}: vacuum={vac_settings[k]}, "
+                        f"solvent={solvent_settings[k]}\n"
+                    )
+            raise ValueError(errmsg)
+
+        return self
+
     thermo_settings: ThermoSettings
     """Settings for thermodynamic parameters"""
 

--- a/src/openfe/protocols/openmm_afe/equil_afe_settings.py
+++ b/src/openfe/protocols/openmm_afe/equil_afe_settings.py
@@ -249,12 +249,8 @@ class AbsoluteSolvationSettings(SettingsBaseModel):
 
     @model_validator(mode="after")
     def vacuum_and_solvent_forcefield_settings_must_match(self):
-        vac_settings = self.vacuum_forcefield_settings.model_dump(
-            exclude={"nonbonded_method"}
-        )
-        solvent_settings = self.solvent_forcefield_settings.model_dump(
-            exclude={"nonbonded_method"}
-        )
+        vac_settings = self.vacuum_forcefield_settings.model_dump(exclude={"nonbonded_method"})
+        solvent_settings = self.solvent_forcefield_settings.model_dump(exclude={"nonbonded_method"})
 
         if vac_settings != solvent_settings:
             errmsg = (
@@ -263,10 +259,7 @@ class AbsoluteSolvationSettings(SettingsBaseModel):
             )
             for k in vac_settings.keys():
                 if vac_settings[k] != solvent_settings[k]:
-                    errmsg += (
-                        f"  {k}: vacuum={vac_settings[k]}, "
-                        f"solvent={solvent_settings[k]}\n"
-                    )
+                    errmsg += f"  {k}: vacuum={vac_settings[k]}, solvent={solvent_settings[k]}\n"
             raise ValueError(errmsg)
 
         return self

--- a/src/openfe/protocols/openmm_afe/equil_solvation_afe_method.py
+++ b/src/openfe/protocols/openmm_afe/equil_solvation_afe_method.py
@@ -433,8 +433,12 @@ class AbsoluteSolvationProtocol(gufe.Protocol):
         )
 
         # make sure the solvent and vacuum force field settings match
-        vac_settings = self.settings.vacuum_forcefield_settings.model_dump(exclude={"nonbonded_method"})
-        solvent_settings = self.settings.solvent_forcefield_settings.model_dump(exclude={"nonbonded_method"})
+        vac_settings = self.settings.vacuum_forcefield_settings.model_dump(
+            exclude={"nonbonded_method"}
+        )
+        solvent_settings = self.settings.solvent_forcefield_settings.model_dump(
+            exclude={"nonbonded_method"}
+        )
         if vac_settings != solvent_settings:
             errmsg = (
                 "The vacuum and solvent force field settings must match "
@@ -444,7 +448,6 @@ class AbsoluteSolvationProtocol(gufe.Protocol):
                 if vac_settings[k] != solvent_settings[k]:
                     errmsg += f"  {k}: vacuum={vac_settings[k]}, solvent={solvent_settings[k]}\n"
             raise ValueError(errmsg)
-
 
     def _create(
         self,

--- a/src/openfe/protocols/openmm_afe/equil_solvation_afe_method.py
+++ b/src/openfe/protocols/openmm_afe/equil_solvation_afe_method.py
@@ -433,21 +433,7 @@ class AbsoluteSolvationProtocol(gufe.Protocol):
         )
 
         # make sure the solvent and vacuum force field settings match
-        vac_settings = self.settings.vacuum_forcefield_settings.model_dump(
-            exclude={"nonbonded_method"}
-        )
-        solvent_settings = self.settings.solvent_forcefield_settings.model_dump(
-            exclude={"nonbonded_method"}
-        )
-        if vac_settings != solvent_settings:
-            errmsg = (
-                "The vacuum and solvent force field settings must match "
-                "except for the nonbonded_method. The following settings differ:\n"
-            )
-            for k in vac_settings.keys():
-                if vac_settings[k] != solvent_settings[k]:
-                    errmsg += f"  {k}: vacuum={vac_settings[k]}, solvent={solvent_settings[k]}\n"
-            raise ValueError(errmsg)
+        self.settings.model_validate(self.settings)
 
     def _create(
         self,

--- a/src/openfe/protocols/openmm_afe/equil_solvation_afe_method.py
+++ b/src/openfe/protocols/openmm_afe/equil_solvation_afe_method.py
@@ -432,6 +432,20 @@ class AbsoluteSolvationProtocol(gufe.Protocol):
             self.settings.integrator_settings.timestep,
         )
 
+        # make sure the solvent and vacuum force field settings match
+        vac_settings = self.settings.vacuum_forcefield_settings.model_dump(exclude={"nonbonded_method"})
+        solvent_settings = self.settings.solvent_forcefield_settings.model_dump(exclude={"nonbonded_method"})
+        if vac_settings != solvent_settings:
+            errmsg = (
+                "The vacuum and solvent force field settings must match "
+                "except for the nonbonded_method. The following settings differ:\n"
+            )
+            for k in vac_settings.keys():
+                if vac_settings[k] != solvent_settings[k]:
+                    errmsg += f"  {k}: vacuum={vac_settings[k]}, solvent={solvent_settings[k]}\n"
+            raise ValueError(errmsg)
+
+
     def _create(
         self,
         stateA: ChemicalSystem,

--- a/src/openfe/tests/protocols/openmm_ahfe/test_ahfe_validation.py
+++ b/src/openfe/tests/protocols/openmm_ahfe/test_ahfe_validation.py
@@ -324,13 +324,15 @@ def test_validate_forcefield_settings(stateA, stateB):
     # make sure the default settings with a different nonbonded method still works
     settings = AbsoluteSolvationProtocol.default_settings()
     assert settings.vacuum_forcefield_settings.nonbonded_method == "nocutoff"
-    
+
     protocol = AbsoluteSolvationProtocol(settings=settings)
     protocol.validate(stateA=stateA, stateB=stateB, mapping=None)
 
     # change some other forcefield settings and make sure an error is raised
     settings.solvent_forcefield_settings.small_molecule_forcefield = "gaff-2.11"
     protocol = AbsoluteSolvationProtocol(settings=settings)
-    with pytest.raises(ValueError, match="The following settings differ:\n  small_molecule_forcefield: vacuum=openff-2.2.1, solvent=gaff-2.11"):
+    with pytest.raises(
+        ValueError,
+        match="The following settings differ:\n  small_molecule_forcefield: vacuum=openff-2.2.1, solvent=gaff-2.11",
+    ):
         protocol.validate(stateA=stateA, stateB=stateB, mapping=None)
-    

--- a/src/openfe/tests/protocols/openmm_ahfe/test_ahfe_validation.py
+++ b/src/openfe/tests/protocols/openmm_ahfe/test_ahfe_validation.py
@@ -7,11 +7,7 @@ from openff.units import unit as offunit
 
 from openfe import ChemicalSystem, SolventComponent
 from openfe.protocols import openmm_afe
-from openfe.protocols.openmm_afe import (
-    AbsoluteSolvationProtocol,
-    AbsoluteSolvationSettings
-)
-from openfe.protocols.openmm_utils import system_validation
+from openfe.protocols.openmm_afe import AbsoluteSolvationProtocol, AbsoluteSolvationSettings
 from openfe.protocols.openmm_afe.equil_afe_settings import (
     AbsoluteSolvationSettings,
     AlchemicalSettings,
@@ -25,6 +21,7 @@ from openfe.protocols.openmm_afe.equil_afe_settings import (
     OpenMMEngineSettings,
     OpenMMSolvationSettings,
 )
+from openfe.protocols.openmm_utils import system_validation
 
 
 @pytest.fixture()
@@ -356,8 +353,8 @@ def test_validate_forcefield_settings(stateA, stateB):
 def test_settings_validation():
     # make sure an error is raised if invalid settings are initialized
     with pytest.raises(
-            ValueError,
-            match="The following settings differ:\n  small_molecule_forcefield: vacuum=openff-2.2.1, solvent=gaff-2.11"
+        ValueError,
+        match="The following settings differ:\n  small_molecule_forcefield: vacuum=openff-2.2.1, solvent=gaff-2.11",
     ):
         _ = AbsoluteSolvationSettings(
             protocol_repeats=3,
@@ -374,14 +371,53 @@ def test_settings_validation():
             alchemical_settings=AlchemicalSettings(),
             lambda_settings=LambdaSettings(
                 lambda_elec=[
-                    0.0, 0.25, 0.5, 0.75, 1.0, 1.0, 1.0,
-                    1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                    0.0,
+                    0.25,
+                    0.5,
+                    0.75,
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0,
+                ],
                 lambda_vdw=[
-                    0.0, 0.0, 0.0, 0.0, 0.0, 0.12, 0.24,
-                    0.36, 0.48, 0.6, 0.7, 0.77, 0.85, 1.0],
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.12,
+                    0.24,
+                    0.36,
+                    0.48,
+                    0.6,
+                    0.7,
+                    0.77,
+                    0.85,
+                    1.0,
+                ],
                 lambda_restraints=[
-                    0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-                    0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                ],
             ),
             partial_charge_settings=OpenFFPartialChargeSettings(),
             solvation_settings=OpenMMSolvationSettings(),

--- a/src/openfe/tests/protocols/openmm_ahfe/test_ahfe_validation.py
+++ b/src/openfe/tests/protocols/openmm_ahfe/test_ahfe_validation.py
@@ -318,3 +318,19 @@ def test_high_timestep(phase, stateA, stateB):
 
     with pytest.raises(ValueError, match="too large for hydrogen"):
         protocol.validate(stateA=stateA, stateB=stateB, mapping=None)
+
+
+def test_validate_forcefield_settings(stateA, stateB):
+    # make sure the default settings with a different nonbonded method still works
+    settings = AbsoluteSolvationProtocol.default_settings()
+    assert settings.vacuum_forcefield_settings.nonbonded_method == "nocutoff"
+    
+    protocol = AbsoluteSolvationProtocol(settings=settings)
+    protocol.validate(stateA=stateA, stateB=stateB, mapping=None)
+
+    # change some other forcefield settings and make sure an error is raised
+    settings.solvent_forcefield_settings.small_molecule_forcefield = "gaff-2.11"
+    protocol = AbsoluteSolvationProtocol(settings=settings)
+    with pytest.raises(ValueError, match="The following settings differ:\n  small_molecule_forcefield: vacuum=openff-2.2.1, solvent=gaff-2.11"):
+        protocol.validate(stateA=stateA, stateB=stateB, mapping=None)
+    

--- a/src/openfe/tests/protocols/openmm_ahfe/test_ahfe_validation.py
+++ b/src/openfe/tests/protocols/openmm_ahfe/test_ahfe_validation.py
@@ -2,14 +2,29 @@
 # For details, see https://github.com/OpenFreeEnergy/openfe
 import pytest
 from gufe import LigandAtomMapping, ProtocolDAGResult
+from gufe.settings import OpenMMSystemGeneratorFFSettings, ThermoSettings
 from openff.units import unit as offunit
 
 from openfe import ChemicalSystem, SolventComponent
 from openfe.protocols import openmm_afe
 from openfe.protocols.openmm_afe import (
     AbsoluteSolvationProtocol,
+    AbsoluteSolvationSettings
 )
 from openfe.protocols.openmm_utils import system_validation
+from openfe.protocols.openmm_afe.equil_afe_settings import (
+    AbsoluteSolvationSettings,
+    AlchemicalSettings,
+    IntegratorSettings,
+    LambdaSettings,
+    MDOutputSettings,
+    MDSimulationSettings,
+    MultiStateOutputSettings,
+    MultiStateSimulationSettings,
+    OpenFFPartialChargeSettings,
+    OpenMMEngineSettings,
+    OpenMMSolvationSettings,
+)
 
 
 @pytest.fixture()
@@ -336,3 +351,81 @@ def test_validate_forcefield_settings(stateA, stateB):
         match="The following settings differ:\n  small_molecule_forcefield: vacuum=openff-2.2.1, solvent=gaff-2.11",
     ):
         protocol.validate(stateA=stateA, stateB=stateB, mapping=None)
+
+
+def test_settings_validation():
+    # make sure an error is raised if invalid settings are initialized
+    with pytest.raises(
+            ValueError,
+            match="The following settings differ:\n  small_molecule_forcefield: vacuum=openff-2.2.1, solvent=gaff-2.11"
+    ):
+        _ = AbsoluteSolvationSettings(
+            protocol_repeats=3,
+            solvent_forcefield_settings=OpenMMSystemGeneratorFFSettings(
+                small_molecule_forcefield="gaff-2.11",
+            ),
+            vacuum_forcefield_settings=OpenMMSystemGeneratorFFSettings(
+                nonbonded_method="nocutoff",
+            ),
+            thermo_settings=ThermoSettings(
+                temperature=298.15 * offunit.kelvin,
+                pressure=1 * offunit.bar,
+            ),
+            alchemical_settings=AlchemicalSettings(),
+            lambda_settings=LambdaSettings(
+                lambda_elec=[
+                    0.0, 0.25, 0.5, 0.75, 1.0, 1.0, 1.0,
+                    1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                lambda_vdw=[
+                    0.0, 0.0, 0.0, 0.0, 0.0, 0.12, 0.24,
+                    0.36, 0.48, 0.6, 0.7, 0.77, 0.85, 1.0],
+                lambda_restraints=[
+                    0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                    0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            ),
+            partial_charge_settings=OpenFFPartialChargeSettings(),
+            solvation_settings=OpenMMSolvationSettings(),
+            vacuum_engine_settings=OpenMMEngineSettings(),
+            solvent_engine_settings=OpenMMEngineSettings(),
+            integrator_settings=IntegratorSettings(),
+            solvent_equil_simulation_settings=MDSimulationSettings(
+                equilibration_length_nvt=0.1 * offunit.nanosecond,
+                equilibration_length=0.2 * offunit.nanosecond,
+                production_length=0.5 * offunit.nanosecond,
+            ),
+            solvent_equil_output_settings=MDOutputSettings(
+                equil_nvt_structure="equil_nvt_structure.pdb",
+                equil_npt_structure="equil_npt_structure.pdb",
+                production_trajectory_filename="production_equil.xtc",
+                log_output="equil_simulation.log",
+            ),
+            solvent_simulation_settings=MultiStateSimulationSettings(
+                n_replicas=14,
+                equilibration_length=1.0 * offunit.nanosecond,
+                production_length=10.0 * offunit.nanosecond,
+            ),
+            solvent_output_settings=MultiStateOutputSettings(
+                output_filename="solvent.nc",
+                checkpoint_storage_filename="solvent_checkpoint.nc",
+            ),
+            vacuum_equil_simulation_settings=MDSimulationSettings(
+                equilibration_length_nvt=None,
+                equilibration_length=0.2 * offunit.nanosecond,
+                production_length=0.5 * offunit.nanosecond,
+            ),
+            vacuum_equil_output_settings=MDOutputSettings(
+                equil_nvt_structure=None,
+                equil_npt_structure="equil_structure.pdb",
+                production_trajectory_filename="production_equil.xtc",
+                log_output="equil_simulation.log",
+            ),
+            vacuum_simulation_settings=MultiStateSimulationSettings(
+                n_replicas=14,
+                equilibration_length=0.5 * offunit.nanosecond,
+                production_length=2.0 * offunit.nanosecond,
+            ),
+            vacuum_output_settings=MultiStateOutputSettings(
+                output_filename="vacuum.nc",
+                checkpoint_storage_filename="vacuum_checkpoint.nc",
+            ),
+        )


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Fixes #702 

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command)
-->

## LLM / AI generated code disclosure
<!-- Please update this disclosure to reflect if you did or did not use LLMs / AI to generate code -->
LLMs or other AI-powered tools (beyond simple IDE use cases) were used in this contribution: yes / no
If yes, please provide details here: No

Checklist
* [ ] All new code is appropriately documented (user-facing code _must_ have complete docstrings).
* [x] Added a ``news`` entry, or the changes are not user-facing.
* [x] Ran pre-commit: you can run [pre-commit](https://pre-commit.com) locally or comment on this PR with `pre-commit.ci autofix`.
* [x] Filled in the AI generated code disclosure.

Manual Tests: these are slow so don't need to be run every commit, only before merging and when relevant changes are made (generally at reviewer-discretion). 
* [ ] [GPU integration tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/aws-gpu-integration-tests.yaml)
* [ ] [example notebook testing](https://github.com/OpenFreeEnergy/openfe/actions/workflows/release-prep-examplenotebooks.yaml)
* [ ] [packaging tests](https://github.com/OpenFreeEnergy/openfe/actions/workflows/cron-package-test.yaml): run this for any large feature PRs or PRs that add test data.

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
